### PR TITLE
Filling out the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,28 @@
-nimble
+NIMBLE
 ======
 
-repository for the base nimble package
+This is the repository for the base NIMBLE package, 
+An R package for programming with BUGS models.
+
+For more information:
+
+* [website](http://r-nimble.org/)
+* [user manual](http://r-nimble.org/manuals/NimbleUserManual.pdf)
+
+
+## Citation: 
+
+NIMBLE Development Team. 2014. NIMBLE: An R Package for Programming with BUGS models, Version 0.1.   http://r-nimble.org.
+
+## Installation
+
+```r
+ # Windows or Linux
+install.packages("nimble", repos = "http://r-nimble.org")
+# Mac OSX 
+install.packages("nimble", repos = "http://r-nimble.org", type = "source")
+```
+
+## Acknowledgements
+
+The development of NIMBLE has been funded by an NSF Advances in Biological Informatics grant (DBI-1147230) to P. de Valpine, C. Paciorek, and D. Temple Lang, with additional support provided by postdoctoral funding for D. Turek from the Berkeley Institute for Data Science.


### PR DESCRIPTION
copy/pasted from r-nimble.org information that I thought would be useful to have in the README, since in a GitHub repo the README becomes a de-facto secondary home page (since it may be a first point of entry for some users).
