### PR TITLE
new character vector argument functionality for setData method

### DIFF
--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -284,26 +284,51 @@ Resets the \'data\' property of ALL model nodes to FALSE.  Subsequent to this ca
                                       return(invisible(NULL))
                                   },
                                   
-                                  setData = function(data, warnAboutMissingNames = TRUE) {
+                                  setData = function(..., warnAboutMissingNames = TRUE) {
 '
 Sets the \'data\' flag for specified nodes to TRUE, and also sets the value of these nodes to the value provided.  This is the exclusive method for specifying \'data\' nodes in a model object.  When a \'data\' argument is provided to \'nimbleModel()\', it uses this method to set the data nodes.
 
 Arguments:
 
-data: There are two possible types for the data argument.  The first is a named list of numeric elements.  The names of list elements must correspond to model variable names.  The elements of the list must be of class numeric, with size and dimension each matching the corresponding model variable.  These numeric scalars, vectors, arrays, etc, may only contain numeric data, or NAs.  Providing data as a named list in this manner sets the values of model variables according to the numeric list elements, and also designates these variables (non-NA values only) as being data.  The second possibility is a character vector of model variable names.  Specifying data in this manner does not change the values of any variables in the model, but only designates the specified model variables (those which already contain non-NA values) as being data.
+...:  Arguments may be provided as named elements with numeric values or as character names of model variables.  These may be provided in a single list, a single character vector, or as multiple arguments.  When a named element with a numeric value is provided, the size and dimension must match the corresponding model variable.  This value will be copied to the model variable and any non-NA elements will be marked as data.  When a character name is provided, the value of that variable in the model is not changed but any currently non-NA values are marked as data.  Examples: setData(\'x\', y = 1:10) will mark both x and y as data and will set the value of y to 1:10.  setData(list(\'x\', y = 1:10)) is equivalent.  setData(c(\'x\',\'y\')) or setData(\'x\',\'y\') will mark both x and y as data.  
 
-Details: If a list element contains some number of NA values, then the model nodes corresponding to these NAs will not have their value set, and will not be designated as \'data\'.  Only model nodes corresponding to numeric values in the argument list elements will be designated as data.  Designating a deterministic model node as \'data\' will result in an error.  Designating part of a multivariate node as \'data\' and part as non-data (NA) will resilt in an error; multivariate nodes must be entirely data, or entirely non-data.
+Details: If a provided value (or the current value in the model when only a name is specified) contains some NA values, then the model nodes corresponding to these NAs will not have their value set, and will not be designated as \'data\'.  Only model nodes corresponding to numeric values in the argument list elements will be designated as data.  Designating a deterministic model node as \'data\' will result in an error.  Designating part of a multivariate node as \'data\' and part as non-data (NA) will result in an error; multivariate nodes must be entirely data, or entirely non-data.
 '
-                                      ## new functionality for setData():
-                                      ## 'data' argument can be a character vector of variable names.
-                                      ## intention is to flag these variables as 'data', and not change any model values.
-                                      ## some inefficiency here (accesses model values, then re-sets the same model values),
-                                      ## but this simplifies the addition without changing exisiting code.
-                                      if(is.character(data)) {
-                                          dataNames <- data
-                                          data <- lapply(data, function(x) get(x))
-                                          names(data) <- dataNames
-                                      }
+                                          ## new functionality for setData():
+                                          ## ... can be a list, a character vector of variable names, or a mix of both
+                                          ## intention is to flag these variables as 'data', and not change any model values.
+                                          ## some inefficiency here (accesses model values, then re-sets the same model values),
+                                          ## but this simplifies the addition without changing exisiting code.
+
+                                           data = list(...)
+                                           ## Check if a single list or character vector was provided
+                                           if(length(data)==1)
+                                               if(is.character(data[[1]])) {
+                                                   data <- as.list(data[[1]])
+                                               } else {
+                                                   if(is.list(data[[1]])) {
+                                                       data <- data[[1]]
+                                                   }
+                                               }
+
+                                           ## When a variable name was provided, make it the list name and put the model's value for that variable as the list element
+                                           dataNames <- names(data)
+                                           if(is.null(dataNames)) dataNames <- rep("", length(data))
+                                           for(i in seq_along(data)) {
+                                               if(dataNames[i]=="") {
+                                                   dataNames[i] <- data[[i]]
+                                                   data[[i]] <- get(dataNames[i])
+                                               }
+                                           }
+                                           names(data) <- dataNames
+                                           data
+
+
+                                      ##  if(is.character(data)) {
+                                      ##     dataNames <- data
+                                      ##     data <- lapply(data, function(x) get(x))
+                                      ##     names(data) <- dataNames
+                                      ## }
                                       origData <<- data
                                       ## argument is a named list of data values.
                                       ## all nodes specified (except with NA) are set to that value, and have isDataEnv$VAR set to TRUE

--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -290,10 +290,20 @@ Sets the \'data\' flag for specified nodes to TRUE, and also sets the value of t
 
 Arguments:
 
-data: A named list.  The names of list elements must correspond to model variable names.  The elements of the list must be of class numeric, with size and dimension each matching the corresponding model variable.  These numeric scalars, vectors, arrays, etc, may only contain numeric data, or NAs.
+data: There are two possible types for the data argument.  The first is a named list of numeric elements.  The names of list elements must correspond to model variable names.  The elements of the list must be of class numeric, with size and dimension each matching the corresponding model variable.  These numeric scalars, vectors, arrays, etc, may only contain numeric data, or NAs.  Providing data as a named list in this manner sets the values of model variables according to the numeric list elements, and also designates these variables (non-NA values only) as being data.  The second possibility is a character vector of model variable names.  Specifying data in this manner does not change the values of any variables in the model, but only designates the specified model variables (those which already contain non-NA values) as being data.
 
 Details: If a list element contains some number of NA values, then the model nodes corresponding to these NAs will not have their value set, and will not be designated as \'data\'.  Only model nodes corresponding to numeric values in the argument list elements will be designated as data.  Designating a deterministic model node as \'data\' will result in an error.  Designating part of a multivariate node as \'data\' and part as non-data (NA) will resilt in an error; multivariate nodes must be entirely data, or entirely non-data.
 '
+                                      ## new functionality for setData():
+                                      ## 'data' argument can be a character vector of variable names.
+                                      ## intention is to flag these variables as 'data', and not change any model values.
+                                      ## some inefficiency here (accesses model values, then re-sets the same model values),
+                                      ## but this simplifies the addition without changing exisiting code.
+                                      if(is.character(data)) {
+                                          dataNames <- data
+                                          data <- lapply(data, function(x) get(x))
+                                          names(data) <- dataNames
+                                      }
                                       origData <<- data
                                       ## argument is a named list of data values.
                                       ## all nodes specified (except with NA) are set to that value, and have isDataEnv$VAR set to TRUE


### PR DESCRIPTION
Added functionality to `model$setData(data)` method.  `data` argument can now be a character vector of model variable names.  In this case, the values of these model variables are not changed, and only the designation of these variables as being 'data' occurs.

This addition was done in a very simplistic way, where the values of the model variables are accessed, to create a named list `data` argument, which then goes through all of the original processing (including re-setting the model variable values).  It wasn't done this way to be a quick fix, but instead to leave the original core of `setData()` unchanged, and have this addition to be a simple and well-defined advance step.

That being said, it's not the most efficient implementation possible, so certainly open to revision (but bear in mind exactly when and how often this inefficiency will be imposed).

roxygen documentation for `setData()` is also updated.