### PR TITLE
fix to dependent path separation in new conjugacy checking

### DIFF
--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -127,7 +127,7 @@ conjugacyRelationshipsClass <- setRefClass(
                 if(is.null(conjugacyObj)) next
                 
                 depPathsByNode <- lapply(nodeIDsFromOneDecl, getDependencyPaths, maps = maps)  ## make list (by nodeID) of lists of paths through graph
-                depPathsByNode <- depPathsByNode[!unlist(lapply(depPathsByNode, is.null))]
+                depPathsByNode <- depPathsByNode[!unlist(lapply(depPathsByNode, function(x) is.null(x) || (length(x)==0)))]
                 depPathsByNodeLabels <- lapply(depPathsByNode, function(z)                     ## make character labels that match for same path through graph
                     unlist(lapply(z,
                                   function(x)


### PR DESCRIPTION
Fix to new conjugacy "dependent paths" processing, that was added by @perrydv .

Removed dependentNodePaths that have length = 0.

@perrydv please take a look at this one-line change, and merge into newNodeFxns if you approve.  It seems to work just fine, but I suggest you take a look at the email I sent with subject "Error in conjugacy checking", and the attached model and data file (which triggered the previous error), since I'm not sure why this error never showed up before.

@perrydv I leave it to you to merge this change in.
