### PR TITLE
Windows uninitialized warning

### DIFF
--- a/packages/nimble/inst/include/nimble/NimArrBase.h
+++ b/packages/nimble/inst/include/nimble/NimArrBase.h
@@ -7,7 +7,17 @@
 #include <typeinfo>
 #include <iostream>
 
+#ifdef _WIN32
+#define _WIN3264
+#endif
+
+#ifdef _WIN64
+#define _WIN3264
+#endif
+
+#ifdef _WIN3264
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 
 using std::vector;
 

--- a/packages/nimble/inst/include/nimble/NimArrBase.h
+++ b/packages/nimble/inst/include/nimble/NimArrBase.h
@@ -7,6 +7,8 @@
 #include <typeinfo>
 #include <iostream>
 
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
 using std::vector;
 
 enum nimType {INT = 1, DOUBLE = 2, UNDEFINED = -1};
@@ -23,7 +25,7 @@ enum nimType {INT = 1, DOUBLE = 2, UNDEFINED = -1};
 	public:
 	nimType myType;
 	virtual nimType getNimType() const {return(myType);};
-	virtual NimArrType* getRowTypePtr(int row)=0; 
+	virtual NimArrType* getRowTypePtr(int row)=0;
 	virtual int size() =0;
 	virtual void setRowDims(int row, vector<int> dims) = 0;
 	virtual vector<int> getRowDims(int row) = 0;
@@ -37,7 +39,7 @@ class NimArrBase: public NimArrType {
   T *v;
   //vector<T> *vPtr;
   T **vPtr;
-  void setVptr() {vPtr = &v;} 
+  void setVptr() {vPtr = &v;}
   //  vector<T> *getVptr() const {return(vPtr);}
   T **getVptr() const{return(vPtr);}
   bool own_v;
@@ -45,11 +47,11 @@ class NimArrBase: public NimArrType {
   //  int *NAdims;
   int NAdims[4];
   //  const vector<int> &dim() const {return(NAdims);}
-  const int* dim() const {return(NAdims);}    
+  const int* dim() const {return(NAdims);}
     //vector<int> NAstrides;
   //  int *NAstrides;
   int NAstrides[4];
-  int stride1, offset; // everyone has a stride1, and the flat [] operator needs it, so it is here. 
+  int stride1, offset; // everyone has a stride1, and the flat [] operator needs it, so it is here.
   int getOffset() {return(offset);}
   bool boolMap;
   bool isMap() const {return(boolMap);}
@@ -66,7 +68,7 @@ class NimArrBase: public NimArrType {
   virtual void setSize(vector<int> sizeVec)=0;
   void setLength(int l, bool copyValues = true, bool fillZeros = true) {
     if(NAlength==l) {
-      if((!copyValues) & fillZeros) fillAllValues(static_cast<T>(0)); 
+      if((!copyValues) & fillZeros) fillAllValues(static_cast<T>(0));
       return;
     }
     T *new_v = new T[l];
@@ -86,7 +88,7 @@ class NimArrBase: public NimArrType {
     //v.resize(l);
     v = new_v;
     own_v = true;
-  } // Warning, this does not make sense if vPtr is pointing to someone else's vMemory. 
+  } // Warning, this does not make sense if vPtr is pointing to someone else's vMemory.
   void fillAllValues(T value) { std::fill(v, v + NAlength, value); }
   void setMyType() {
     myType = UNDEFINED;
@@ -130,7 +132,7 @@ class VecNimArrBase : public NimVecType {
   virtual void resize(int i)=0;
   virtual NimArrBase<T>* getBasePtr(int i)=0;
   NimArrType* getRowTypePtr(int row){
-   	return(static_cast<NimArrType *> (getBasePtr(row) )  );	
+   	return(static_cast<NimArrType *> (getBasePtr(row) )  );
    }
 
   VecNimArrBase() {
@@ -140,7 +142,7 @@ class VecNimArrBase : public NimVecType {
     if(typeid(T) == typeid(double) )
       myType = DOUBLE;
   }
-  
+
   ~VecNimArrBase(){};
 };
 


### PR DESCRIPTION
This puts compiler directives in NimArrBase.h to avoid -Wmaybe-uninitialized from a case that occur in generated getParam code.