### PR TITLE
Better error trapping for parseEvalNumericMany, getParam, and unknown names in size processing

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -2249,11 +2249,41 @@ parseEvalNumeric <- function(x, env){
     as.numeric(ans)
 }
 
+parseEvalNumericManyFindErrors <- function(x, env) {
+    problems <- list()
+    for(thisx in x) {
+        oneResult <- try(parseEvalNumeric(thisx, env), silent = TRUE)
+        if(inherits(oneResult, 'try-error')) {
+            problems[[ length(problems) + 1]] <- oneResult[1]
+            if(length(problems) >= 10)
+                return(problems)
+        }
+    }
+    return(problems)
+}
+
+parseEvalNumericManyHandleError <- function(cond, x, env) {
+    problems <- parseEvalNumericManyFindErrors(x, env)
+    if(length(problems)==0) message(paste0('There an unknown problem looking for variables ', paste0(x, collapse=','), ' in the model.\n'))
+    else {
+        message(paste0('One or more errors occurred looking for variables in a model (first 10 shown below).\n',
+                       'These messages may be cryptic, but generally the variable or expression somewhere in each message was not valid in a model:\n',
+                       paste0(unlist(problems), collapse = ''))) 
+    }
+    invokeRestart('abort')
+}
+
 parseEvalNumericMany <- function(x, env) {
-    if(length(x) > 1) {
-        return(as.numeric(eval(parse(text = paste0('c(', paste0(x, collapse=','),')'), keep.source = FALSE)[[1]], envir = env)))
-    } else 
-        as.numeric(eval(parse(text = x, keep.source = FALSE)[[1]], envir = env))
+    withCallingHandlers(
+        if(length(x) > 1) {
+            as.numeric(eval(parse(text = paste0('c(', paste0(x, collapse=','),')'), keep.source = FALSE)[[1]], envir = env))
+        } else 
+            as.numeric(eval(parse(text = x, keep.source = FALSE)[[1]], envir = env))
+       ,
+        error = function(cond) {
+           parseEvalNumericManyHandleError(cond, x, env)
+        }
+    )
 }
 
 parseEvalCharacter <- function(x, env){

--- a/packages/nimble/R/RCfunction_compile.R
+++ b/packages/nimble/R/RCfunction_compile.R
@@ -47,6 +47,15 @@ RCvirtualFunProcessing <- setRefClass('RCvirtualFunProcessing',
                                           setupSymbolTables = function(parentST = NULL) {
                                               argInfoWithMangledNames <- RCfun$argInfo
                                               numArgs <- length(argInfoWithMangledNames)
+                                              if(numArgs > 0) {
+                                                  argIsBlank <- unlist(lapply(RCfun$argInfo, identical, formals(function(a) {})[[1]]))
+                                                  ## it seems to be impossible to store the value of a blank argument, formals(function(a) {})[[1]], in a variable
+                                                  if(any(argIsBlank)) {
+                                                      stop(paste0("Type declaration missing for argument(s) ", paste(names(RCfun$argInfo)[argIsBlank], collapse = ", ")), call. = FALSE)
+                                                  }
+                                              }
+                                              argInfoWithMangledNames <- RCfun$argInfo
+                                              numArgs <- length(argInfoWithMangledNames)
                                               if(numArgs>0) names(argInfoWithMangledNames) <- paste0("ARG", 1:numArgs, "_", Rname2CppName(names(argInfoWithMangledNames)),"_")
                                               nameSubList <<- lapply(names(argInfoWithMangledNames), as.name)
                                               names(nameSubList) <<- names(RCfun$argInfo)
@@ -193,6 +202,7 @@ RCfunProcessing <- setRefClass('RCfunProcessing',
                                        }
 
                                        compileInfo$typeEnv[['neededRCfuns']] <<- list()
+                                       compileInfo$typeEnv[['.AllowUnknowns']] <<- TRUE ## will be FALSE for RHS recursion in setSizes
 
                                        passedArgNames <- as.list(compileInfo$origLocalSymTab$getSymbolNames()) 
                                        names(passedArgNames) <- compileInfo$origLocalSymTab$getSymbolNames() 

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -89,6 +89,9 @@ exprClasses_setSizes <- function(code, symTab, typeEnv) { ## input code is exprC
                     code$type <- class(symTab$getSymbolObject(code$name, TRUE))[1]
                 } else {
                     code$type <- 'unknown'
+                    ##if(exists('.AllowUnknowns', envir = typeEnv)) 
+                        if(!typeEnv$.AllowUnknowns)
+                            warning(paste0("variable '",code$name,"' has not been created yet."), call.=FALSE) 
                 }
             } else {
                 ## otherwise fill in type fields from typeEnv object
@@ -605,7 +608,12 @@ sizeInsertIntermediate <- function(code, argID, symTab, typeEnv, forceAssign = F
 }
 
 sizeAssign <- function(code, symTab, typeEnv) {
-    asserts <- recurseSetSizes(code, symTab, typeEnv)
+    ##asserts <- recurseSetSizes(code, symTab, typeEnv)
+    typeEnv$.AllowUnknowns <- FALSE
+    asserts <- recurseSetSizes(code, symTab, typeEnv, useArgs = c(FALSE, TRUE))
+    typeEnv$.AllowUnknowns <- TRUE
+    asserts <- c(asserts, recurseSetSizes(code, symTab, typeEnv, useArgs = c(TRUE, FALSE)))
+    
     asserts <- c(asserts, sizeAssignAfterRecursing(code, symTab, typeEnv))
     if(length(asserts) == 0) NULL else asserts
 }

--- a/packages/nimble/R/nimbleFunction_Rexecution.R
+++ b/packages/nimble/R/nimbleFunction_Rexecution.R
@@ -81,28 +81,29 @@ asCol <- function(x) {
 #'
 #' @param model A model such as returned by \code{\link{nimbleModel}}.
 #'
-#' @param nodes A character string naming one stochastic node, such as "mu", "beta[2]", or "eta[1:3, 2]"
+#' @param nodes A character string naming one one or more stochastic nodes, such as "mu", "c('mu', 'beta[2]')", or "eta[1:3, 2]".  getParam only works for one node at a time, but if it is indexed (nodes[i]), then makeParamInfo sets up the information for the entire vector nodes.  The processing pathway is used by the NIMBLE compiler.
 #'
 #' @param param A character string naming a parameter of the distribution followed by node, such as "mean", "rate", "lambda", or whatever parameter names are relevant for the distribution of the node.
 #'
 #' @export
 #' @details This is used internally by \code{\link{getParam}}.  It is not intended for direct use by a user or even a nimbleFunction programmer.
 makeParamInfo <- function(model, nodes, param) {
-    if(length(nodes) != 1) stop(paste0("Problem with nodes argument while setting up getParam.  Should be length 1 but was: ", paste0(nodes, collapse = ",")))
-    distInfo <- getDistributionList(model$getNodeDistribution(nodes))[[1]]
-    ## If nodes is invalid, an error from the above line will be trapped in parseEvalNumericMany
+    ## updating to allow nodes to be a vector. getParam only works for a scalar but in a case like nodes[i] the param info is set up for the entire vector.
+    distInfo <- getDistributionList(model$getNodeDistribution(nodes))
+
+    ## if(length(nodes) != 1) stop(paste0("Problem with nodes argument while setting up getParam.  Should be length 1 but was: ", paste0(nodes, collapse = ",")))
+    ## distInfo <- getDistributionList(model$getNodeDistribution(nodes))[[1]]
+    ## ## If nodes is invalid, an error from the above line will be trapped in parseEvalNumericMany
     if(length(param) != 1) stop(paste0(paste0('Problem with param(s) ', paste0(param, collapse = ','), ' while setting up getParam for node ', nodes,
-                                       '\nOnly one parameter is allowed.')))
-    paramID <- distInfo$paramIDs[param]
-    if(length(paramID)!=1 | any(is.na(paramID))) stop(paste0('Problem with param ', paste0(param, collapse = ','), ' while setting up getParam for node ', nodes,
-                                       '\nThe parameter name is not valid.'))
-    ##paramIDvec <- unlist(lapply(distInfo, function(x) x$paramIDs[param]))
-    ##typeVec <- unlist(lapply(distInfo, function(x) x$types[[param]]$type))
-    ##nDimVec <- unlist(lapply(distInfo, function(x) x$types[[param]]$nDim))
-    ##if(length(unique(typeVec)) != 1 | length(unique(nDimVec)) != 1) stop('cannot have multiple nodes accessed by the same getParam if they have different types or dimensions for the same parameter.') 
-##    ans <- c(list(paramID = distInfo$paramIDs[param]), distInfo$types[[param]])
-    ##    ans <- c(list(paramID = paramIDvec), distInfo[[1]]$types[[param]])
-    ans <- c(list(paramID = paramID), distInfo$types[[param]])
+                 '\nOnly one parameter is allowed.')))
+    ## paramID <- distInfo$paramIDs[param]
+    ## if(length(paramID)!=1 | any(is.na(paramID))) stop(paste0('Problem with param ', paste0(param, collapse = ','), ' while setting up getParam for node ', nodes,
+    ##                                    '\nThe parameter name is not valid.'))
+    paramIDvec <- unlist(lapply(distInfo, function(x) x$paramIDs[param]))
+    typeVec <- unlist(lapply(distInfo, function(x) x$types[[param]]$type))
+    nDimVec <- unlist(lapply(distInfo, function(x) x$types[[param]]$nDim))
+    if(length(unique(typeVec)) != 1 | length(unique(nDimVec)) != 1) stop('cannot have an indexed vector of nodes used in getParam if they have different types or dimensions for the same parameter.') 
+    ans <- c(list(paramID = paramIDvec), distInfo[[1]]$types[[param]])
     class(ans) <- 'getParam_info'
     ans
 }
@@ -132,10 +133,14 @@ makeParamInfo <- function(model, nodes, param) {
 getParam <- function(model, node, param, nodeFunctionIndex) {
     if(missing(param)) { ## already converted by keyword conversion
         stop('This case of getParam (after keyword replacement) has not been updated for R execution with newNodeFunction system')
+        ## nodeFunctionIndex would only be used here, when we make this part work
         nodeFunction <- model
         paramInfo <- node
     } else {
-        ## not already converted
+        ## not already converted; this is regular execution
+        if(length(node) != 1) stop(paste0("getParam only works for one node at a time, but", length(node), "were provided."))
+        ## makeParamInfo, called by nodeFunctionVector, will check on length of param
+        ## nodeFunctionIndex should never be used.
         nfv <- nodeFunctionVector(model, node)
         indexingInfo <- nfv$indexingInfo
         declID <- indexingInfo$declIDs[1] ## should only be one


### PR DESCRIPTION
Better error trapping for:
- parseEvalNumericMany, which is the place of looking up graphIDs used eventually by many model query functions including getDependencies.
- getParam for multiple or invalid variables or params
- unknown names during nimbleFunction compilation during size processing.