### PR TITLE
fixing conjugacy bug

### DIFF
--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -161,7 +161,10 @@ conjugacyRelationshipsClass <- setRefClass(
                                 control <- lapply(uniqueDepTypes,
                                                   function(oneType) {
                                                       boolMatch <- depTypes == oneType
-                                                      depEnds[boolMatch]
+                                                      ## prevent multiple instances of same dependent node name
+                                                      ## (via different graph dependency paths   -DT Oct 2016
+                                                      ##depEnds[boolMatch]
+                                                      unique(depEnds[boolMatch])
                                                   })
                                 names(control) <- uniqueDepTypes
                                 list(prior = conjugacyObj$prior, type = conjugacyObj$samplerType, target = targetNode, control = control)


### PR DESCRIPTION
Fixing uniqueness bug in conjugacy system.

@perrydv I have to point out this bug was introduced with the checkConjugacy2() system, where you added tracing dependency paths through graph.  It arose from overlooking that different paths through the graph could terminate at the same dependent node, with both paths satisfying conjugacy requirements, and duplicating those terminal nodes in the final list of dependent nodes.  This didn't occur in the original checkConjugacy() system.

Anyway, fixed with a simple addition of unique().

@paciorek would be great if this can make the submission & release, but perhaps it's too late?