### PR TITLE
RW_dirichlet sampler

### DIFF
--- a/packages/nimble/NEWS
+++ b/packages/nimble/NEWS
@@ -6,6 +6,7 @@ USER LEVEL CHANGES
 
 -- Updates to MCMC configuration API.  Member methods conf$addMonitors() and conf$addMonitors2() now accept argument ..., allowing multiple monitors to be added using the syntax conf$addMonitors('x', 'y', 'z').  Introduced a new member method, conf$printMonitors(), which nicely prints the current MCMC monitors.  This takes the place of the former method conf$getMonitors().  Now, conf$getMonitors() returns a character vector of the MCMC monitors, and the new method conf$getMonitors2() returns a character vector of the MCMC monitors2 field.
 
+-- New sampling algorithm (RW_dirichlet) added to MCMC engine, for sampling non-conjugate Dirichlet distributions.
 
 
 

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -193,10 +193,10 @@ print: A logical argument, specifying whether to print the ordered list of defau
                             addConjugateSampler(conjugacyResult = conjugacyResult);     next }
                     }
                     if(nodeDist == 'dmulti')   { addSampler(target = node, type = 'RW_multinomial');     next }
+                    if(nodeDist == 'ddirch')   { addSampler(target = node, type = 'RW_dirichlet');       next }
                     if(multivariateNodesAsScalars) {
                         for(scalarNode in nodeScalarComponents) {
                             addSampler(target = scalarNode, type = 'RW') };     next }
-                    if(nodeDist == 'ddirch')   warning(paste0('RW_block sampler was applied to Dirichlet node \'', node, '\', which will not result in proper sampling behaviour. Try reparameterizing this node in terms of constituent gamma distributions.'))
                     addSampler(target = node, type = 'RW_block');     next }
 
                 ## node is scalar, non-end node

--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -1089,6 +1089,81 @@ sampler_RW_multinomial <- nimbleFunction(
 
 
 
+#####################################################################################
+### RW_dirichlet sampler for multinomial distributions ##############################
+#####################################################################################
+
+#' @rdname samplers
+#' @export
+sampler_RW_dirichlet <- nimbleFunction(
+    contains = sampler_BASE,
+    setup = function(model, mvSaved, target, control) {
+        ## control list extraction
+        adaptive      <- control$adaptive
+        adaptInterval <- control$adaptInterval
+        scaleOriginal <- control$scale
+        ## node list generation
+        calcNodes <- model$getDependencies(target)
+        depNodes  <- model$getDependencies(target, self = FALSE)
+        targetScalarNodes <- model$expandNodeNames(target, returnScalarComponents = TRUE)
+        ## numeric value generation
+        d <- length(targetScalarNodes)
+        thetaVec         <- rep(0, d)
+        scaleVec         <- rep(scaleOriginal, d)
+        timesRan         <- 0
+        timesAcceptedVec <- rep(0, d)
+        timesAdapted     <- 0
+        gamma1           <- 0
+        ## checks
+        if(length(model$expandNodeNames(target)) > 1)    stop('RW_dirichlet sampler only applies to one target node')
+        if(model$getDistribution(target) != 'ddirch')    stop('can only use RW_dirichlet sampler for dirichlet distributions')
+    },
+    run = function() {
+        if(thetaVec[1] == 0)   thetaVec <<- values(model, target)   ## initialization
+        alphaVec <- model$getParam(target, 'alpha')
+        for(i in 1:d) {
+            currentValue <- thetaVec[i]
+            propLogScale <- rnorm(1, mean = 0, sd = scaleVec[i])
+            propValue <- currentValue * exp(propLogScale)
+            thetaVecProp <- thetaVec
+            thetaVecProp[i] <- propValue
+            values(model, target) <<- thetaVecProp / sum(thetaVecProp)
+            logMHR <- alphaVec[i]*propLogScale + currentValue - propValue + calculateDiff(model, depNodes)
+            jump <- decide(logMHR)
+            if(adaptive & jump)   timesAcceptedVec[i] <<- timesAcceptedVec[i] + 1
+            if(jump) { thetaVec <<- thetaVecProp
+                       nimCopy(from = model, to = mvSaved, row = 1, nodes = calcNodes, logProb = TRUE)
+            } else   { nimCopy(from = mvSaved, to = model, row = 1, nodes = calcNodes, logProb = TRUE) }
+            model$calculate(target)                                                         ## update target logProb
+            nimCopy(from = model, to = mvSaved, row = 1, nodes = target, logProb = TRUE)    ##
+        }
+        if(adaptive) {
+            timesRan <<- timesRan + 1
+            if(timesRan %% adaptInterval == 0) {
+                acceptanceRateVec <- timesAcceptedVec / timesRan
+                timesAdapted <<- timesAdapted + 1
+                gamma1 <<- 1/((timesAdapted + 3)^0.8)
+                adaptFactorVec <- exp(10 * gamma1 * (acceptanceRateVec - 0.44))   ## optimalAR = 0.44
+                scaleVec <<- scaleVec * adaptFactorVec
+                timesRan <<- 0
+                timesAcceptedVec <<- numeric(d, 0)
+            }
+        }
+    },
+    methods = list(
+        reset = function() {
+            thetaVec         <<- numeric(d, 0)
+            scaleVec         <<- numeric(d, scaleOriginal)
+            timesRan         <<- 0
+            timesAcceptedVec <<- numeric(d, 0)
+            timesAdapted     <<- 0
+            gamma1           <<- 0
+        }
+    ), where = getLoadingNamespace()
+)
+
+
+
 #' MCMC Sampling Algorithms
 #'
 #' Details of the MCMC sampling algorithms provided with the NIMBLE MCMC engine
@@ -1243,6 +1318,17 @@ sampler_RW_multinomial <- nimbleFunction(
 #' \itemize{
 #' \item adaptive.  A logical argument, specifying whether the sampler should adapt the binomial proposal probabilities throughout the course of MCMC execution. (default = TRUE)
 #' \item adaptInterval.  The interval on which to perform adaptation.  A minimum value of 100 is required. (default = 200)
+#' }
+#'
+#' @section RW_dirichlet sampler:
+#'
+#' This sampler is designed for sampling non-conjugate Dirichlet distributions.  The sampler performs a series of Metropolis-Hastings updates (on the log scale) to each component of a gamma-reparameterization of the target Dirichlet distribution.  The acceptance or rejection of these proposals follows a standard Metropolis-Hastings procedure.
+#'
+#' The \code{RW_dirichlet} sampler accepts the following control list elements:
+#' \itemize{
+#' \item adaptive. A logical argument, specifying whether the sampler should independently adapt the scale (proposal standard deviation, on the log scale) for each componentwise Metropolis-Hasting update, to achieve a theoretically desirable acceptance rate for each. (default = TRUE)
+#' \item adaptInterval. The interval on which to perform adaptation.  Every adaptInterval MCMC iterations (prior to thinning), the sampler will perform its adaptation procedure.  (default = 200)
+#' \item scale. The initial value of the proposal standard deviation (on the log scale) for each component of the reparameterized Dirichlet distribution.  If adaptive = FALSE, the proposal standard deviations will never change. (default = 1)
 #' }
 #'
 #' @section posterior_predictive sampler:

--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -294,7 +294,7 @@ sampler_RW_llFunction <- nimbleFunction(
         calcNodes <- model$getDependencies(target)
         ## nested function and function list definitions
         mvInternal <- modelValues(model)
-        RWControl <- list(adaptive = adaptive, adaptInterval = adaptInterval, scale = scale)
+        RWControl <- list(adaptive=adaptive, adaptInterval=adaptInterval, scale=scale, log=FALSE, reflective=FALSE)
         targetRWSamplerFunction <- sampler_RW(model, mvInternal, target, RWControl)
         my_setAndCalculateOne <- setAndCalculateOne(model, target)
         my_decideAndJump <- decideAndJump(model, mvSaved, calcNodes)


### PR DESCRIPTION
Addition of `RW_dirichlet` sampler, for sampling non-conjugate Dirichlet distributions using the component univariate gamma reparameterization.

`configureMCMC()` will now assign `RW_dirichlet` sampler for non-conjugate Dirichlet nodes.

Added Rd documentation for `RW_dirichlet` sampler, and updated NEWS .

Added tests to `test-mcmc.R` for `RW_dirichlet` sampler, to demonstrate agreement between conjugate sampling, and rewriting the model using gamma distributions in the non-conjugate case.

User Manual already updated.
