### PR TITLE
CalcIndexedNodeVector

### DIFF
--- a/packages/nimble/R/genCpp_eigenization.R
+++ b/packages/nimble/R/genCpp_eigenization.R
@@ -101,6 +101,7 @@ eigenizeCalls <- c( ## component-wise unarys valid for either Eigen array or mat
     makeCallList(coreRmanipulationCalls, 'eigenize_nimbleNullaryClass'),
     makeCallList(c('nimCd','nimCi','nimCb'), 'eigenize_alwaysMatrix'),
     list(##'t' = 'eigenize_cWiseUnaryEither',
+        ':' = 'eigenize_nimbleNullaryClass', ## at this point ':' is like a coreRmanipulationCall
          eigenBlock = 'eigenize_eigenBlock',
          diagonal  = 'eigenize_cWiseUnaryMatrix',
          'inverse' = 'eigenize_cWiseUnaryMatrix',
@@ -558,8 +559,8 @@ eigenize_cWiseBinaryArrayLogical <- function(code, symTab, typeEnv, workEnv) {
     if(is.null(newName)) stop(exprClassProcessingErrorMsg(code, 'Missing eigenizeTranslate entry.'), call. = FALSE)
     code$name <- newName
     code$eigMatrix <- TRUE
-    if(inherits(code$args[[1]], 'exprClass')) if(code$args[[1]]$eigMatrix) eigenizeArrayize(code$args[[1]])
-    if(inherits(code$args[[2]], 'exprClass')) if(code$args[[2]]$eigMatrix) eigenizeArrayize(code$args[[2]])
+    if(inherits(code$args[[1]], 'exprClass')) if(!isEigScalar(code$args[[1]])) if(code$args[[1]]$eigMatrix) eigenizeArrayize(code$args[[1]])
+    if(inherits(code$args[[2]], 'exprClass')) if(!isEigScalar(code$args[[2]])) if(code$args[[2]]$eigMatrix) eigenizeArrayize(code$args[[2]])
     promoteArgTypes(code) ## key difference for logical case: promote args to match each other, not logical return type
     invisible(NULL)
 }

--- a/packages/nimble/inst/CppCode/accessorClasses.cpp
+++ b/packages/nimble/inst/CppCode/accessorClasses.cpp
@@ -41,7 +41,7 @@ NimArr<2, double> getBound_2D_double(int boundID, const oneNodeUseInfo &useInfo,
   return(useInfo.nodeFunPtr->getBound_2D_double_block(boundID, useInfo.useInfo));
 }
 
-
+// see include/nimble/nimbleEigenNimArr.h for some templated versions of calculate, simulate, calculateDiff and getLogProb used for arbitrary index vectors
 double calculate(NodeVectorClassNew &nodes) {
   double ans(0);
   const vector<oneNodeUseInfo> &useInfoVec = nodes.getUseInfoVec();

--- a/packages/nimble/inst/include/nimble/nimbleEigenNimArr.h
+++ b/packages/nimble/inst/include/nimble/nimbleEigenNimArr.h
@@ -8,21 +8,90 @@
 #include "nimble/accessorClasses.h"
 
 template<typename Derived>
-double calculate(NodeVectorClassNew &nodes, const Derived &indices) {
+double calculate(NodeVectorClassNew &nodes, const Derived &indices, bool logical=false) {
   double ans(0);
   const vector<oneNodeUseInfo> &useInfoVec = nodes.getUseInfoVec();
   int len = indices.size();
-  //  vector<oneNodeUseInfo>::const_iterator iNode(useInfoVec.begin());
-  //  vector<oneNodeUseInfo>::const_iterator iNodeEnd(useInfoVec.end());
-  int thisIndex;
-  for(int i = 0; i < len; ++i) {
-    thisIndex = indices(i)-1; // indices is R-based
-    ans += useInfoVec[ thisIndex ].nodeFunPtr->calculateBlock(useInfoVec[ thisIndex ].useInfo );
+  if(!logical) {
+    int thisIndex;
+    for(int i = 0; i < len; ++i) {
+      thisIndex = indices(i)-1; // indices is R-based
+      ans += useInfoVec[ thisIndex ].nodeFunPtr->calculateBlock(useInfoVec[ thisIndex ].useInfo );
+    }
+    return(ans);
   }
-    //    ans += iNode->nodeFunPtr->calculateBlock(iNode->useInfo);
+  // logical = true. treat indices as a logical vector
+  for(int i = 0; i < len; ++i) {
+    if(indices(i)) {
+      ans += useInfoVec[ i ].nodeFunPtr->calculateBlock(useInfoVec[ i ].useInfo );
+    }
+  }
+  return(ans);
+}
+  
+template<typename Derived>  
+  double calculateDiff(NodeVectorClassNew &nodes, const Derived &indices, bool logical=false) {
+  double ans(0);
+  const vector<oneNodeUseInfo> &useInfoVec = nodes.getUseInfoVec();
+  int len = indices.size();
+  if(!logical) {
+    int thisIndex;
+    for(int i = 0; i < len; ++i) {
+      thisIndex = indices(i)-1; // indices is R-based
+      ans += useInfoVec[ thisIndex ].nodeFunPtr->calculateDiffBlock(useInfoVec[ thisIndex ].useInfo );
+    }
+    return(ans);
+  }
+  // logical = true. treat indices as a logical vector
+  for(int i = 0; i < len; ++i) {
+    if(indices(i)) {
+      ans += useInfoVec[ i ].nodeFunPtr->calculateDiffBlock(useInfoVec[ i ].useInfo );
+    }
+  }
   return(ans);
 }
 
+template<typename Derived>  
+  double getLogProb(NodeVectorClassNew &nodes, const Derived &indices, bool logical=false) {
+  double ans(0);
+  const vector<oneNodeUseInfo> &useInfoVec = nodes.getUseInfoVec();
+  int len = indices.size();
+  if(!logical) {
+    int thisIndex;
+    for(int i = 0; i < len; ++i) {
+      thisIndex = indices(i)-1; // indices is R-based
+      ans += useInfoVec[ thisIndex ].nodeFunPtr->getLogProbBlock(useInfoVec[ thisIndex ].useInfo );
+    }
+    return(ans);
+  }
+  // logical = true. treat indices as a logical vector
+  for(int i = 0; i < len; ++i) {
+    if(indices(i)) {
+      ans += useInfoVec[ i ].nodeFunPtr->getLogProbBlock(useInfoVec[ i ].useInfo );
+    }
+  }
+  return(ans);
+}
+
+template<typename Derived>  
+  void simulate(NodeVectorClassNew &nodes, const Derived &indices, bool logical=false) {
+  const vector<oneNodeUseInfo> &useInfoVec = nodes.getUseInfoVec();
+  int len = indices.size();
+  if(!logical) {
+   int thisIndex;
+   for(int i = 0; i < len; ++i) {
+    thisIndex = indices(i)-1; // indices is R-based
+    useInfoVec[ thisIndex ].nodeFunPtr->simulateBlock(useInfoVec[ thisIndex ].useInfo );
+   }
+  } else {
+  // logical = true. treat indices as a logical vector
+   for(int i = 0; i < len; ++i) {
+    if(indices(i)) {
+      useInfoVec[ i ].nodeFunPtr->simulateBlock(useInfoVec[ i ].useInfo );
+    }
+   }
+  }
+}
 
 template<typename NimArrOutput, typename VectorInput>
 void assignVectorToNimArr(NimArrOutput &output, const VectorInput &input) {

--- a/packages/nimble/inst/include/nimble/nimbleEigenNimArr.h
+++ b/packages/nimble/inst/include/nimble/nimbleEigenNimArr.h
@@ -5,6 +5,24 @@
 #include <vector>
 #include <cstdlib>
 #include<Rmath.h>
+#include "nimble/accessorClasses.h"
+
+template<typename Derived>
+double calculate(NodeVectorClassNew &nodes, const Derived &indices) {
+  double ans(0);
+  const vector<oneNodeUseInfo> &useInfoVec = nodes.getUseInfoVec();
+  int len = indices.size();
+  //  vector<oneNodeUseInfo>::const_iterator iNode(useInfoVec.begin());
+  //  vector<oneNodeUseInfo>::const_iterator iNodeEnd(useInfoVec.end());
+  int thisIndex;
+  for(int i = 0; i < len; ++i) {
+    thisIndex = indices(i)-1; // indices is R-based
+    ans += useInfoVec[ thisIndex ].nodeFunPtr->calculateBlock(useInfoVec[ thisIndex ].useInfo );
+  }
+    //    ans += iNode->nodeFunPtr->calculateBlock(iNode->useInfo);
+  return(ans);
+}
+
 
 template<typename NimArrOutput, typename VectorInput>
 void assignVectorToNimArr(NimArrOutput &output, const VectorInput &input) {


### PR DESCRIPTION
Makes general numeric or logical index vectors work for model$calculate, calculateDiff, getLogProb and simulate.  e.g. 

mode$simulate(nodes[ values(model, nodes)+0.1 < x ], includeData = TRUE)

or

test <- model$getLogProb(nodes[1:i])
