### PR TITLE
changed conjugate wishart case to only handle link=identity

### DIFF
--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -73,13 +73,19 @@ conjugacyRelationshipsInputList <- list(
 
     ## wishart
     list(prior = 'dwish',
-         link = 'linear',
+         ## changing to only use link='identity' case, since the link='linear' case was not correct.
+         ## -DT March 2017
+         ## link = 'linear',
+         link = 'identity',
          dependents = list(
              ## parentheses added to the contribution_R calculation:
              ## colVec * (rowVec * matrix)
              ## Chris is checking to see whether this makes a difference for Eigen
              ## -DT April 2016
-             dmnorm = list(param = 'prec', contribution_R = 'asCol(value-mean) %*% (asRow(value-mean) %*% coeff)', contribution_df = '1')),
+             ## changing to only use link='identity' case, since the link='linear' case was not correct
+             ## -DT March 2017
+             ## dmnorm = list(param = 'prec', contribution_R = 'asCol(value-mean) %*% (asRow(value-mean) %*% coeff)', contribution_df = '1')),
+             dmnorm = list(param = 'prec', contribution_R = 'asCol(value-mean) %*% asRow(value-mean)', contribution_df = '1')),
          posterior = 'dwish_chol(cholesky    = chol(prior_R + contribution_R),
                                  df          = prior_df + contribution_df,
                                  scale_param = 0)')


### PR DESCRIPTION
Conjugate Wishart case was not handling multiplicative link correctly.

One point to note, @paciorek, the multiplicative case isn't restricted to scalar multiples, (c*W), but is generally built for a matrix multiplication (A*W).  So, the incorrectness was probably more extreme than we realized.  I'm curious about this, though, since I thought we had worked through these cases previously.

