### PR TITLE
Ignore .Rproj files in repo

### DIFF
--- a/packages/.gitignore
+++ b/packages/.gitignore
@@ -12,3 +12,4 @@ MyMakevars
 Eigen_local*
 
 config.*
+*.Rproj

--- a/packages/nimble/.Rbuildignore
+++ b/packages/nimble/.Rbuildignore
@@ -7,3 +7,5 @@
 src/Makevars$
 inst/Makevars$
 NOT_IN_TARBALL$
+^.*\.Rproj$
+^\.Rproj\.user$


### PR DESCRIPTION
Why?
RStudio does a better job indexing .R files when I create an R project in the nimble repo. Creating a project in the repo adds a .Rproj file. We don't want this .Rproj file in git.