### PR TITLE
Add NIM_ASSERT macro and use it in RcppNimbleUtils.h

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ script:
   - Rscript packages/nimble/inst/tests/test-declare.R
   - Rscript packages/nimble/inst/tests/test-distributions.R
   - Rscript packages/nimble/inst/tests/test-dsl_dists.R
+  - Rscript packages/nimble/inst/tests/test-errors.R
   - Rscript packages/nimble/inst/tests/test-filtering.R
   - Rscript packages/nimble/inst/tests/test-getBound.R
   - Rscript packages/nimble/inst/tests/test-getDependencies.R

--- a/packages/nimble/inst/CppCode/eigenUsingClasses.cpp
+++ b/packages/nimble/inst/CppCode/eigenUsingClasses.cpp
@@ -7,20 +7,21 @@
 
 template<>
 void SEXP_2_NimArr<1>(SEXP Sn, NimArr<1, double> &ans) {
-  if(!(isNumeric(Sn) || isLogical(Sn))) PRINTF("Error: SEXP_2_NimArr<1> called for SEXP that is not a numeric or logical!\n");
+  NIM_ASSERT(isNumeric(Sn) || isLogical(Sn),
+    "SEXP_2_NimArr<1, double> called for SEXP that is not a numeric or logical: actual type %s\n",
+    type2str(TYPEOF(Sn)));
   int nn = LENGTH(Sn);
-  if(ans.size() != 0) PRINTF("Error: trying to reset a NimArr that was already sized\n");
+  NIM_ASSERT(ans.size() == 0, "trying to reset a NimArr that was already sized\n");
   ans.setSize(nn);
   if(isReal(Sn)) {
-     std::copy(REAL(Sn), REAL(Sn) + nn, ans.getPtr());	
+     std::copy(REAL(Sn), REAL(Sn) + nn, ans.getPtr());
   } else {
-    if(isInteger(Sn) || isLogical(Sn)) {
-      int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
-      for(int i = 0; i < nn; ++i) {
-	ans(i) = static_cast<double>(iSn[i]);
-      }
-    } else {
-      PRINTF("Error: We could not handle the R input type to SEXP_2_NimArr<1>\n");
+    NIM_ASSERT(isInteger(Sn) || isLogical(Sn),
+      "could not handle input of type %s to SEXP_2_NimArr<1, double>\n",
+      type2str(TYPEOF(Sn)));
+    int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
+    for(int i = 0; i < nn; ++i) {
+      ans(i) = static_cast<double>(iSn[i]);
     }
   }
 }
@@ -28,23 +29,24 @@ void SEXP_2_NimArr<1>(SEXP Sn, NimArr<1, double> &ans) {
 // Actually this is identical to above so could be done without specialization
 template<>
 void SEXP_2_NimArr<1>(SEXP Sn, NimArr<1, int> &ans) {
-  if(!(isNumeric(Sn) || isLogical(Sn))) PRINTF("Error: SEXP_2_NimArr<1> called for SEXP that is not a numeric or logical!\n");
+  NIM_ASSERT(isNumeric(Sn) || isLogical(Sn),
+    "SEXP_2_NimArr<1, int> called for SEXP that is not a numeric or logical: actual type %s\n",
+    type2str(TYPEOF(Sn)));
   int nn = LENGTH(Sn);
-  if(ans.size() != 0) PRINTF("Error: trying to reset a NimArr that was already sized\n");
+  NIM_ASSERT(ans.size() == 0, "trying to reset a NimArr that was already sized\n");
   ans.setSize(nn);
   if(isReal(Sn)) {
-     std::copy(REAL(Sn), REAL(Sn) + nn, ans.getPtr());	
+     std::copy(REAL(Sn), REAL(Sn) + nn, ans.getPtr());
   } else {
-    if(isInteger(Sn) || isLogical(Sn)) {
-      int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
-      for(int i = 0; i < nn; ++i) {
-	ans(i) = static_cast<double>(iSn[i]);
-      }
-    } else {
-      PRINTF("Error: We could not handle the R input type to SEXP_2_NimArr<1>\n");
+    NIM_ASSERT(isInteger(Sn) || isLogical(Sn),
+      "could not handle input of type %s to SEXP_2_NimArr<1, int>\n",
+      type2str(TYPEOF(Sn)));
+    int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
+    for(int i = 0; i < nn; ++i) {
+      ans(i) = static_cast<double>(iSn[i]);
     }
   }
-} 
+}
 
 /*EIGEN_EIGEN class functions below */
 SEXP  EIGEN_EIGENCLASS_R::copyToSEXP (  )  {

--- a/packages/nimble/inst/include/nimble/RcppNimbleUtils.h
+++ b/packages/nimble/inst/include/nimble/RcppNimbleUtils.h
@@ -156,62 +156,53 @@ void SEXP_2_NimArr<1>(SEXP Sn, NimArr<1, int> &ans);
 
 template<int ndim>
 void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, double> &ans) {
-  if(!(isNumeric(Sn) || isLogical(Sn))) PRINTF("Error: SEXP_2_NimArr<ndim> called for SEXP that is not a numeric or logica!\n");
+  NIM_ASSERT(isNumeric(Sn) || isLogical(Sn), "Error: SEXP_2_NimArr<ndim> called for SEXP that is not a numeric or logica!\n");
   vector<int> inputDims(getSEXPdims(Sn));
-  if(inputDims.size() != ndim) PRINTF("Error: Wrong number of input dimensions in SEXP_2_NimArr<ndim, double> called for SEXP that is not a numeric!\n");
+  NIM_ASSERT(inputDims.size() == ndim, "Error: Wrong number of input dimensions in SEXP_2_NimArr<ndim, double> called for SEXP that is not a numeric!\n");
   // if(ans.size() != 0) PRINTF("Error: trying to reset a NimArr that was already sized\n");
   ans.setSize(inputDims);
   int nn = LENGTH(Sn);
   if(isReal(Sn)) {
     std::copy(REAL(Sn), REAL(Sn) + nn, ans.getPtr() );
   } else {
-    if(isInteger(Sn) || isLogical(Sn)) {
-      int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
-      std::copy(iSn, iSn + nn, ans.getPtr()); //v);
-    } else {
-      PRINTF("Error: could not handle input type to SEXP_2_NimArr\n");
-    }
+    NIM_ASSERT(isInteger(Sn) || isLogical(Sn), "Error: could not handle input type to SEXP_2_NimArr\n");
+    int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
+    std::copy(iSn, iSn + nn, ans.getPtr()); //v);
   }
 }
 
 // ACTUALLY THIS IS IDENTICAL CODE TO ABOVE, SO THEY COULD BE COMBINED WITHOUT TEMPLATE SPECIALIZATION
 template<int ndim>
 void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, int> &ans) {
-  if(!(isNumeric(Sn) || isLogical(Sn))) PRINTF("Error: SEXP_2_NimArr<ndim> called for SEXP that is not a numeric or logica!\n");
+  NIM_ASSERT(isNumeric(Sn) || isLogical(Sn), "Error: SEXP_2_NimArr<ndim> called for SEXP that is not a numeric or logica!\n");
   vector<int> inputDims(getSEXPdims(Sn));
-  if(inputDims.size() != ndim) PRINTF("Error: Wrong number of input dimensions in SEXP_2_NimArr<ndim, double> called for SEXP that is not a numeric!\n");
+  NIM_ASSERT(inputDims.size() == ndim, "Error: Wrong number of input dimensions in SEXP_2_NimArr<ndim, double> called for SEXP that is not a numeric!\n");
   // if(ans.size() != 0) PRINTF("Error: trying to reset a NimArr that was already sized\n");
   ans.setSize(inputDims);
   int nn = LENGTH(Sn);
   if(isReal(Sn)) {
     std::copy(REAL(Sn), REAL(Sn) + nn, ans.getPtr() );
   } else {
-    if(isInteger(Sn) || isLogical(Sn)) {
-      int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
-      std::copy(iSn, iSn + nn, ans.getPtr()); //v);
-    } else {
-      PRINTF("Error: could not handle input type to SEXP_2_NimArr\n");
-    }
+    NIM_ASSERT(isInteger(Sn) || isLogical(Sn), "Error: could not handle input type to SEXP_2_NimArr\n");
+    int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
+    std::copy(iSn, iSn + nn, ans.getPtr()); //v);
   }
 }
 
 template<int ndim>
 void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, bool> &ans) {
-  if(!(isNumeric(Sn) || isLogical(Sn))) PRINTF("Error: SEXP_2_NimArr<ndim> called for SEXP that is not a numeric or logica!\n");
+  NIM_ASSERT(isNumeric(Sn) || isLogical(Sn), "Error: SEXP_2_NimArr<ndim> called for SEXP that is not a numeric or logica!\n");
   vector<int> inputDims(getSEXPdims(Sn));
-  if(inputDims.size() != ndim) PRINTF("Error: Wrong number of input dimensions in SEXP_2_NimArr<ndim, double> called for SEXP that is not a numeric!\n");
+  NIM_ASSERT(inputDims.size() == ndim, "Error: Wrong number of input dimensions in SEXP_2_NimArr<ndim, double> called for SEXP that is not a numeric!\n");
   // if(ans.size() != 0) PRINTF("Error: trying to reset a NimArr that was already sized\n");
   ans.setSize(inputDims);
   int nn = LENGTH(Sn);
   if(isReal(Sn)) {
     std::copy(REAL(Sn), REAL(Sn) + nn, ans.getPtr() );
   } else {
-    if(isInteger(Sn) || isLogical(Sn)) {
-      int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
-      std::copy(iSn, iSn + nn, ans.getPtr()); //v);
-    } else {
-      PRINTF("Error: could not handle input type to SEXP_2_NimArr\n");
-    }
+    NIM_ASSERT(isInteger(Sn) || isLogical(Sn), "Error: could not handle input type to SEXP_2_NimArr\n");
+    int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
+    std::copy(iSn, iSn + nn, ans.getPtr()); //v);
   }
 }
 

--- a/packages/nimble/inst/include/nimble/RcppNimbleUtils.h
+++ b/packages/nimble/inst/include/nimble/RcppNimbleUtils.h
@@ -156,16 +156,22 @@ void SEXP_2_NimArr<1>(SEXP Sn, NimArr<1, int> &ans);
 
 template<int ndim>
 void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, double> &ans) {
-  NIM_ASSERT(isNumeric(Sn) || isLogical(Sn), "Error: SEXP_2_NimArr<ndim> called for SEXP that is not a numeric or logica!\n");
+  NIM_ASSERT(isNumeric(Sn) || isLogical(Sn),
+    "SEXP_2_NimArr<%d, double> called for SEXP that is not a numeric or logical: actual type %s\n",
+    ndim, type2str(TYPEOF(Sn)));
   vector<int> inputDims(getSEXPdims(Sn));
-  NIM_ASSERT(inputDims.size() == ndim, "Error: Wrong number of input dimensions in SEXP_2_NimArr<ndim, double> called for SEXP that is not a numeric!\n");
-  // if(ans.size() != 0) PRINTF("Error: trying to reset a NimArr that was already sized\n");
+  NIM_ASSERT(inputDims.size() == ndim,
+    "Wrong number of input dimensions in SEXP_2_NimArr<%d, double> called for SEXP that is not a numeric: expected %d, actual %d\n",
+    ndim, ndim, inputDims.size());
+  // NIM_ASSERT(ans.size() == 0, "trying to reset a NimArr that was already sized\n");
   ans.setSize(inputDims);
   int nn = LENGTH(Sn);
   if(isReal(Sn)) {
     std::copy(REAL(Sn), REAL(Sn) + nn, ans.getPtr() );
   } else {
-    NIM_ASSERT(isInteger(Sn) || isLogical(Sn), "Error: could not handle input type to SEXP_2_NimArr\n");
+    NIM_ASSERT(isInteger(Sn) || isLogical(Sn),
+      "could not handle input of type %s to SEXP_2_NimArr<%d, double>\n",
+      type2str(TYPEOF(Sn)), ndim);
     int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
     std::copy(iSn, iSn + nn, ans.getPtr()); //v);
   }
@@ -174,16 +180,22 @@ void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, double> &ans) {
 // ACTUALLY THIS IS IDENTICAL CODE TO ABOVE, SO THEY COULD BE COMBINED WITHOUT TEMPLATE SPECIALIZATION
 template<int ndim>
 void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, int> &ans) {
-  NIM_ASSERT(isNumeric(Sn) || isLogical(Sn), "Error: SEXP_2_NimArr<ndim> called for SEXP that is not a numeric or logica!\n");
+  NIM_ASSERT(isNumeric(Sn) || isLogical(Sn),
+    "SEXP_2_NimArr<%d, int> called for SEXP that is not a numeric or logical: actual type %s\n",
+    ndim, type2str(TYPEOF(Sn)));
   vector<int> inputDims(getSEXPdims(Sn));
-  NIM_ASSERT(inputDims.size() == ndim, "Error: Wrong number of input dimensions in SEXP_2_NimArr<ndim, double> called for SEXP that is not a numeric!\n");
-  // if(ans.size() != 0) PRINTF("Error: trying to reset a NimArr that was already sized\n");
+  NIM_ASSERT(inputDims.size() == ndim,
+    "Wrong number of input dimensions in SEXP_2_NimArr<%d, int> called for SEXP that is not a numeric: expected %d, actual %d\n",
+    ndim, ndim, inputDims.size());
+  // NIM_ASSERT(ans.size() == 0, "trying to reset a NimArr that was already sized\n");
   ans.setSize(inputDims);
   int nn = LENGTH(Sn);
   if(isReal(Sn)) {
     std::copy(REAL(Sn), REAL(Sn) + nn, ans.getPtr() );
   } else {
-    NIM_ASSERT(isInteger(Sn) || isLogical(Sn), "Error: could not handle input type to SEXP_2_NimArr\n");
+    NIM_ASSERT(isInteger(Sn) || isLogical(Sn),
+      "could not handle input type %s to SEXP_2_NimArr<%d, int>\n",
+      type2str(TYPEOF(Sn)), ndim);
     int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
     std::copy(iSn, iSn + nn, ans.getPtr()); //v);
   }
@@ -191,16 +203,22 @@ void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, int> &ans) {
 
 template<int ndim>
 void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, bool> &ans) {
-  NIM_ASSERT(isNumeric(Sn) || isLogical(Sn), "Error: SEXP_2_NimArr<ndim> called for SEXP that is not a numeric or logica!\n");
+  NIM_ASSERT(isNumeric(Sn) || isLogical(Sn),
+    "SEXP_2_NimArr<%d, bool> called for SEXP that is not a numeric or logical: actual type %s\n",
+    ndim, type2str(TYPEOF(Sn)));
   vector<int> inputDims(getSEXPdims(Sn));
-  NIM_ASSERT(inputDims.size() == ndim, "Error: Wrong number of input dimensions in SEXP_2_NimArr<ndim, double> called for SEXP that is not a numeric!\n");
-  // if(ans.size() != 0) PRINTF("Error: trying to reset a NimArr that was already sized\n");
+  NIM_ASSERT(inputDims.size() == ndim,
+    "Wrong number of input dimensions in SEXP_2_NimArr<%d, bool> called for SEXP that is not a numeric: expected %d, actual %d\n",
+    ndim, ndim, inputDims.size());
+  // NIM_ASSERT(ans.size() == 0, "trying to reset a NimArr that was already sized\n");
   ans.setSize(inputDims);
   int nn = LENGTH(Sn);
   if(isReal(Sn)) {
     std::copy(REAL(Sn), REAL(Sn) + nn, ans.getPtr() );
   } else {
-    NIM_ASSERT(isInteger(Sn) || isLogical(Sn), "Error: could not handle input type to SEXP_2_NimArr\n");
+    NIM_ASSERT(isInteger(Sn) || isLogical(Sn),
+      "could not handle input type %s to SEXP_2_NimArr<%d, bool>\n",
+      type2str(TYPEOF(Sn)), ndim);
     int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
     std::copy(iSn, iSn + nn, ans.getPtr()); //v);
   }

--- a/packages/nimble/inst/include/nimble/Utils.h
+++ b/packages/nimble/inst/include/nimble/Utils.h
@@ -36,7 +36,7 @@ class nimbleTimerClass_ {
 #define PRINTF Rprintf
 #define NIMERROR error
 #define RBREAK(msg) {PRINTF(msg); return(R_NilValue);}
-#define NIM_ASSERT(cond, msg) { if(NIM_UNLIKELY(!(cond))) { NIMERROR(msg); }}
+#define NIM_ASSERT(cond, ...) { if(NIM_UNLIKELY(!(cond))) { NIMERROR("Error: " __VA_ARGS__); }}
 
 // code copied from nmath.h - useful utilities 
 # define MATHLIB_ERROR(fmt,x)		error(fmt,x);

--- a/packages/nimble/inst/include/nimble/Utils.h
+++ b/packages/nimble/inst/include/nimble/Utils.h
@@ -25,9 +25,18 @@ class nimbleTimerClass_ {
   double endNimbleTimer() { return(((double)(clock() - t_start))/CLOCKS_PER_SEC); }
 };
 
+#if defined(__GNUG__) || defined(__clang__)
+#  define NIM_LIKELY(x) __builtin_expect(!!(x), 1)
+#  define NIM_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#else
+#  define NIM_LIKELY(x) (x)
+#  define NIM_UNLIKELY(x) (x)
+#endif
+
 #define PRINTF Rprintf
 #define NIMERROR error
 #define RBREAK(msg) {PRINTF(msg); return(R_NilValue);}
+#define NIM_ASSERT(cond, msg) { if(NIM_UNLIKELY(!(cond))) { NIMERROR(msg); }}
 
 // code copied from nmath.h - useful utilities 
 # define MATHLIB_ERROR(fmt,x)		error(fmt,x);

--- a/packages/nimble/inst/tests/test-errors.R
+++ b/packages/nimble/inst/tests/test-errors.R
@@ -1,0 +1,42 @@
+source(system.file(file.path('tests', 'test_utils.R'), package = 'nimble'))
+
+context("Testing of error handling.")
+
+test_that("Testing of error handling in SEXP_2_NimArr", {
+  # First construct a nimbleFunction.
+  nimFun <- nimbleFunction(
+    run = function (x = logical(1),
+                    y = integer(1),
+                    z = double(1)) {
+      return(x + y + z)
+      returnType(double(1))
+    }
+  )
+  
+  # Make sure the nimble function works on well formed inputs.
+  x <- c(FALSE, TRUE)
+  y <- c(2, 4)
+  z <- c(8.0, 16.0)
+  expectedResult <- c(10.0, 21.0)
+  expect_equal(nimFun(x, y, z), expectedResult)
+  
+  # Next compile the nimbleFunction.
+  compiledFun = compileNimble(nimFun)
+  expect_equal(compiledFun(x, y, z), expectedResult)
+  
+  # Finally check that compiledFun behaves as expected on invalid inputs.
+  wrong_type = c("x", "y")
+  wrong_shape1 = TRUE
+  wrong_shape2 = matrix(c(1, 2, 3, 4), 2, 2)
+  
+  # The commented-out lines currently do not trigger errors.
+  expect_error(compiledFun(wrong_type, y, z))
+  expect_error(compiledFun(x, wrong_type, z))
+  expect_error(compiledFun(x, y, wrong_type))
+  # expect_error(compiledFun(wrong_shape1, y, z))
+  # expect_error(compiledFun(x, wrong_shape1, z))
+  # expect_error(compiledFun(x, y, wrong_shape1))
+  expect_error(compiledFun(wrong_shape2, y, z))
+  # expect_error(compiledFun(x, wrong_shape2, z))
+  # expect_error(compiledFun(x, y, wrong_shape2))
+})

--- a/packages/nimble/inst/tests/test-errors.R
+++ b/packages/nimble/inst/tests/test-errors.R
@@ -29,14 +29,16 @@ test_that("Testing of error handling in SEXP_2_NimArr", {
   wrong_shape1 = TRUE
   wrong_shape2 = matrix(c(1, 2, 3, 4), 2, 2)
   
-  # The commented-out lines currently do not trigger errors.
+  # These DO NOT trigger errors.
+  expect_failure(expect_error(compiledFun(wrong_shape1, y, z)))
+  expect_failure(expect_error(compiledFun(x, wrong_shape1, z)))
+  expect_failure(expect_error(compiledFun(x, y, wrong_shape1)))
+  expect_failure(expect_error(compiledFun(x, wrong_shape2, z)))
+  expect_failure(expect_error(compiledFun(x, y, wrong_shape2)))
+  
+  # These DO trigger errors.
   expect_error(compiledFun(wrong_type, y, z))
   expect_error(compiledFun(x, wrong_type, z))
   expect_error(compiledFun(x, y, wrong_type))
-  # expect_error(compiledFun(wrong_shape1, y, z))
-  # expect_error(compiledFun(x, wrong_shape1, z))
-  # expect_error(compiledFun(x, y, wrong_shape1))
   expect_error(compiledFun(wrong_shape2, y, z))
-  # expect_error(compiledFun(x, wrong_shape2, z))
-  # expect_error(compiledFun(x, y, wrong_shape2))
 })


### PR DESCRIPTION
This introduces a C++ macro `NIM_ASSERT(-,-)` that can replace existing `if(-) PRINTF(-)` with actual calls to `error()`, fixing #296 .

## What's changed
The old `if(-) PRINTF(-)` behavior simply warned the user that an error may be encountered, and then optimistically continued execution. This is problematic, in that the executed code might crash R and destroy user work, as in #296 . The new behavior immediately breaks execution, thereby avoiding crashing R.

## What remains the same
This PR intends to exactly preserve the circumstances under which NIMBLE errors. That is, the behavior-on-error does change, but there is no change to when an error happens. In particular, there is some inconsistent behavior across `bool`, `int`, `double` versions as visible in https://rpubs.com/fritzo/nimble_error_messages, but this PR does not attempt to change that behavior.

## What remains to be done
This PR currently uses `NIM_ASSERT(-,-)` only in `RcppNimbleUtils.h`, and subsequent PRs will replace other old-style `if(-) PRINTF` with the new stricter macro.