### PR TITLE
trap model[[nodeVector]]. trap invalid returnSizeArgID when assignment by first arg.  avoid eigen-casting of scalars amid non-scalar expressions.

### DIFF
--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -932,10 +932,11 @@ Details: The newly created model object will be identical to the original model 
 
 setMethod('[[', 'modelBaseClass',
           function(x, i) {
+              if(length(i) != 1) stop(paste0("Only one node can be accessed from a model using '[['."), call. = FALSE)
               if(!is.indexed(i)) {
                   eval(substitute(x$VAR, list(VAR=i)))
               } else {
-                  parsedNode <- parse(text=i)[[1]]
+                  parsedNode <- parse(text=i, keep.source = FALSE)[[1]]
                   parsedNode[[2]] <- substitute(x$VAR, list(VAR=parsedNode[[2]]))
                   eval(parsedNode)
               }
@@ -944,6 +945,7 @@ setMethod('[[', 'modelBaseClass',
 
 setMethod('[[<-', 'modelBaseClass',
           function(x, i, value) {
+              if(length(i) != 1) stop(paste0("Only one node can be accessed from a model using '[['."), call. = FALSE)
               if(!is.indexed(i)) {
                   eval(substitute(x$VAR <- value, list(VAR=i)))
               } else {

--- a/packages/nimble/R/genCpp_eigenization.R
+++ b/packages/nimble/R/genCpp_eigenization.R
@@ -436,22 +436,51 @@ promoteArgTypes <- function(code) {
     a1type <- code$args[[1]]$type
     a2type <- code$args[[2]]$type
     if(a1type == a2type) return(NULL)
-    if(code$name == '<-') return(eigenCast(code, 2, a1type))
-    if(a2type == 'double') return(eigenCast(code, 1, 'double'))
-    if(a1type == 'double') return(eigenCast(code, 2, 'double'))
-    if(a2type == 'integer') return(eigenCast(code, 1, 'integer'))
-    if(a1type == 'integer') return(eigenCast(code, 2, 'integer'))
-    ## Should never get past here, but for completeness:
-    if(a2type == 'logical') return(eigenCast(code, 1, 'logical'))
-    if(a1type == 'logical') return(eigenCast(code, 2, 'logical'))
+    ## at this point, we know both args are exprClass objects and their type doesn't match
+    argID <- 0
+    newType <- 'double'
+
+    if(code$name == '<-') {argID <- 2; newType <- a1Type} ##return(eigenCast(code, 2, a1type))
+    ## because we know arg types don't match, pairs of conditions are mutually exclusive
+    if(argID == 0) {
+        if(a2type == 'double') { argID <- 1; newType <- 'double'} ##return(eigenCast(code, 1, 'double'))
+        if(a1type == 'double') {argID <-  2; newType <- 'double'} ## return(eigenCast(code, 2, 'double'))
+    }
+    if(argID == 0) {
+        if(a2type == 'integer') {argID <- 1; newType <- 'integer'} ##return(eigenCast(code, 1, 'integer'))
+        if(a1type == 'integer') {argID <- 2; newType <- 'integer'} ##return(eigenCast(code, 2, 'integer'))
+    }
+    if(argID == 0) {
+        ## Last two should never be needed, but for completeness:
+        if(a2type == 'logical') {argID <- 1; newType <- 'logical'} ##return(eigenCast(code, 1, 'logical'))
+        if(a1type == 'logical') {argID <- 2; newType <- 'logical'} ##return(eigenCast(code, 2, 'logical'))
+    }
+    if(argID != 0)
+        if(code$args[[argID]]$nDim > 0) 
+            eigenCast(code, argID, newType)
+        
+    NULL
+
+    ## if(code$name == '<-') return(eigenCast(code, 2, a1type))
+    ## if(a2type == 'double') return(eigenCast(code, 1, 'double'))
+    ## if(a1type == 'double') return(eigenCast(code, 2, 'double'))
+    ## if(a2type == 'integer') return(eigenCast(code, 1, 'integer'))
+    ## if(a1type == 'integer') return(eigenCast(code, 2, 'integer'))
+    ## ## Should never get past here, but for completeness:
+    ## if(a2type == 'logical') return(eigenCast(code, 1, 'logical'))
+    ## if(a1type == 'logical') return(eigenCast(code, 2, 'logical'))
+
+
 }
 
 promoteTypes <- function(code) {
     resultType <- code$type
     for(i in seq_along(code$args)) {
         if(inherits(code$args[[i]], 'exprClass')) {
-            if(code$args[[i]]$type != resultType) {
-                eigenCast(code, i, resultType)
+            if(code$args[[i]]$nDim > 0) {
+                if(code$args[[i]]$type != resultType) {
+                    eigenCast(code, i, resultType)
+                }
             }
         }
     }

--- a/packages/nimble/R/genCpp_exprClass.R
+++ b/packages/nimble/R/genCpp_exprClass.R
@@ -194,7 +194,7 @@ nimDeparse <- function(code, indent = '') {
 exprClassProcessingErrorMsg <- function(code, msg) {
     contextCode <- if(!is.null(code$caller)) paste(unlist(nimDeparse(code$caller)), collapse = '\n') else character()
     ans <- paste0(msg, '\n This occurred for: ', nimDeparse(code),'\n', collapse = '')
-    if(!is.null(contextCode)) ans <- paste(ans, '\n This was part of the call: ', contextCode, collapse = '')
+    if(!is.null(contextCode)) ans <- paste(ans, 'This was part of the call: ', contextCode, collapse = '')
     ans
 }
 

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -2487,10 +2487,10 @@ sizeMatrixMult <- function(code, symTab, typeEnv) {
 
     if(a1$nDim == 1 & a2$nDim == 1) {
         origSizeExprs <- a1$sizeExprs[[1]]
-        a1 <- insertExprClassLayer(code, 1, 'asRow', type = a1$type)
+        a1 <- insertExprClassLayer(code, 1, 'asRow', type = a1$type, nDim = 2)
         a1$sizeExprs <- c(list(1), origSizeExprs)
         origSizeExprs <- a2$sizeExprs[[1]]
-        a2 <- insertExprClassLayer(code, 2, 'asCol', type = a2$type)
+        a2 <- insertExprClassLayer(code, 2, 'asCol', type = a2$type, nDim = 2)
         a2$sizeExprs <- c(origSizeExprs, list(1))
     } else {
         if(a1$nDim == 1) {
@@ -2498,22 +2498,22 @@ sizeMatrixMult <- function(code, symTab, typeEnv) {
             origSizeExprs <- a1$sizeExprs[[1]]
             ## For first argument, default to asRow unless second argument has only one row, in which case make first asCol
             if(identical(a2$sizeExprs[[1]], 1)) {
-                a1 <- insertExprClassLayer(code, 1, 'asCol', type = a1$type)
+                a1 <- insertExprClassLayer(code, 1, 'asCol', type = a1$type, nDim = 2)
                 a1$sizeExprs <- c(origSizeExprs, list(1))
             }
             else {
-                a1 <- insertExprClassLayer(code, 1, 'asRow', type = a1$type)
+                a1 <- insertExprClassLayer(code, 1, 'asRow', type = a1$type, nDim = 2)
                 a1$sizeExprs <- c(list(1), origSizeExprs)
             }
         } else if(a2$nDim == 1) {
             origSizeExprs <- a2$sizeExprs[[1]]
             if(a1$nDim != 2) stop(exprClassProcessingErrorMsg(code, paste0('In sizeMatrixMult: Second arg has nDim = 1 and 1st arg has nDim = ', a1$nDim, '.')), call. = FALSE)
             if(identical(a1$sizeExprs[[2]], 1)) {
-                a2 <- insertExprClassLayer(code, 2, 'asRow', type = a2$type)
+                a2 <- insertExprClassLayer(code, 2, 'asRow', type = a2$type, nDim = 2)
                 a2$sizeExprs <- c(list(1), origSizeExprs)
            }
             else { 
-                a2 <- insertExprClassLayer(code, 2, 'asCol', type = a2$type)
+                a2 <- insertExprClassLayer(code, 2, 'asCol', type = a2$type, nDim = 2)
                 a2$sizeExprs <- c(origSizeExprs, list(1))
             }
         }
@@ -2812,7 +2812,7 @@ sizeRmultivarFirstArg <- function(code, symTab, typeEnv) {
     notOK <- FALSE
     checkList <- mvFirstArgCheckLists[[code$name]]
     if(!is.null(checkList)) {
-        if(length(code$args) < length(checkList[[1]])) stop(exprClassProcessingErrorMsg(code, 'In sizeRmultivarFirstArg: Not enough arguments provided.'), call. = FALSE)
+        if(length(code$args) < length(checkList[[1]])) stop(exprClassProcessingErrorMsg(code, 'Not enough arguments provided.'), call. = FALSE)
         for(i in seq_along(checkList[[1]])) {
             notOK <- if(inherits(code$args[[i]], 'exprClass')) code$args[[i]]$nDim != checkList[[1]][i] else notOK            
         }
@@ -2824,9 +2824,11 @@ sizeRmultivarFirstArg <- function(code, symTab, typeEnv) {
     }
 
     if(notOK) {
-        stop(exprClassProcessingErrorMsg(code, 'In sizeRmultivarFirstArg: Some argument(s) have the wrong dimension.'), call. = FALSE) 
+        stop(exprClassProcessingErrorMsg(code, 'Some argument(s) have the wrong dimension.'), call. = FALSE) 
     }
 
+    if(!inherits(code$args[[returnSizeArgID]], 'exprClass')) stop(exprClassProcessingErrorMsg(code, paste0('Expected ', nimDeparse(code$args[[returnSizeArgID]]) ,' to be an expression.')), call. = FALSE) 
+    
     code$type <- returnType
     code$nDim <- code$args[[returnSizeArgID]]$nDim
     code$toEigenize <- 'maybe'

--- a/packages/nimble/R/nimbleFunction_keywordProcessing.R
+++ b/packages/nimble/R/nimbleFunction_keywordProcessing.R
@@ -660,13 +660,14 @@ doubleBracket_keywordInfo <- keywordInfoClass(
             singleAccess_ArgList <- list(code = code, model = code[[2]], nodeExpr = code[[3]])
             nodeArg <- code[[3]]
             if(is.character(nodeArg)){
+                if(length(nodeArg) > 1) stop(paste0("Problem in ", deparse(code), ". ", deparse(code[[3]])," is too long.  It can only have one element."), call. = FALSE)
                 varAndIndices <- getVarAndIndices(nodeArg)
                 nDim <- sum(1 - unlist(lapply(varAndIndices$indices, is.numeric) ) )
                 useMap <- nDim > 0
             }
             else{
                 allNDims <- determineNdimsFromNfproc(singleAccess_ArgList$model, nodeArg, nfProc)
-                if(length(unique(allNDims)) > 1) stop(paste0('Error for ', deparse(code), '. Inconsistent numbers of dimensions for different instances.'))
+                if(length(unique(allNDims)) > 1) stop(paste0('Error for ', deparse(code), '. Inconsistent numbers of dimensions for different instances.'), call. = FALSE)
                 nDim <- allNDims[[1]]
                 useMap <- nDim > 0
             }
@@ -1493,9 +1494,10 @@ determineNdimsFromNfproc <- function(modelExpr, varOrNodeExpr, nfProc) {
     allNDims <- lapply(nfProc$instances, function(x) {
         model <- eval(modelExpr, envir = x)
         if(!exists(as.character(varOrNodeExpr), x, inherits = FALSE) ) {
-            stop(paste0('Error, ', as.character(varOrNodeExpr), ' does not exist in an instance of this nimbleFunction.'))
+            stop(paste0('Problem accessing node ', deparse(varOrNodeExpr), '.'), call. = FALSE)
         }
         lab <- eval(varOrNodeExpr, envir = x)
+        if(length(lab) != 1) stop(paste0("Length of ", deparse(varOrNodeExpr), " requested from ", deparse(modelExpr), " using '[[' is ", length(lab),". It must be 1." ) , call. = FALSE)
         varAndIndices <- nimbleInternalFunctions$getVarAndIndices(lab)
         determineNdimFromOneCase(model, varAndIndices)
     } )


### PR DESCRIPTION
This PR addresses issues 301, 303, 304.