### PR TITLE
Remove extraneous round,nimRound from processSpecificCalls

### DIFF
--- a/packages/nimble/R/genCpp_processSpecificCalls.R
+++ b/packages/nimble/R/genCpp_processSpecificCalls.R
@@ -22,7 +22,6 @@ specificCallReplacements <- list(
     gamma = 'gammafn',
     expit = 'ilogit',
     phi = 'iprobit',
-    round = 'nimRound',
     ceiling = 'ceil',
     trunc = 'ftrunc',
     nimDim = 'dim',

--- a/packages/nimble/inst/tests/test-misc.R
+++ b/packages/nimble/inst/tests/test-misc.R
@@ -14,3 +14,17 @@ try(m <- nimbleModel(code, data = list(y = 0), check = TRUE))
 errmsg <- geterrmessage()    
 
 test_that("Test of full model check", expect_equal(oldmsg, errmsg, info = "found error in running full model check"))
+
+test_that("No nimKeyword appears in specificCallReplacements", {
+    duplicates <- intersect(names(nimble:::nimKeyWords), names(nimble:::specificCallReplacements))
+    if (length(duplicates) > 0) {
+        fail(paste('These symbols appear in both nimKeywords and specificCallReplacements:', paste(duplicates, collapse = ', ')))
+    }
+})
+
+test_that("No nimKeyword appears in specificCallHandlers", {
+    duplicates <- intersect(names(nimble:::nimKeyWords), names(nimble:::specificCallHandlers))
+    if (length(duplicates) > 0) {
+        fail(paste('These symbols appear in both nimKeywords and specificCallHandlers:', paste(duplicates, collapse = ', ')))
+    }
+})


### PR DESCRIPTION
This fixes an old error where `round` is included in both [RCfunction_core.R's `nimKeywords`](https://github.com/nimble-dev/nimble/blob/066adab7c9f2887cdc245dd95160588e5f2a955f/packages/nimble/R/RCfunction_core.R#L17) and [genCpp_processSpecificCalls.R's `specificCallReplacements`](https://github.com/nimble-dev/nimble/blob/066adab7c9f2887cdc245dd95160588e5f2a955f/packages/nimble/R/genCpp_processSpecificCalls.R#L25). This should result in no change to behavior, since the logic in processSpecificCalls should never have been triggered.

**Tested:**  Added two regression tests to ensure that no symbols appear in both places.