### PR TITLE
Add assertthat to Imports: section of DESCRIPTION

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
 ##  - Rscript -e "install.packages('devtools', repos = 'http://cran.us.r-project.org')"
   - Rscript -e "install.packages('igraph', repos = 'http://cran.us.r-project.org')"
   - Rscript -e "install.packages('coda', repos = 'http://cran.us.r-project.org')"
+  - Rscript -e "install.packages('assertthat', repos = 'http://cran.us.r-project.org')"
   - Rscript -e "install.packages('testthat', repos = 'http://cran.us.r-project.org')"
   - Rscript -e "install.packages('mvtnorm', repos = 'http://cran.us.r-project.org')"  ## needed for test-distributions.R
   - Rscript -e "install.packages('abind', repos = 'http://cran.us.r-project.org')"    ## needed for test-compareMCMCs.R

--- a/packages/nimble/DESCRIPTION
+++ b/packages/nimble/DESCRIPTION
@@ -12,7 +12,7 @@ Author: Perry de Valpine, Christopher Paciorek, Daniel Turek, Cliff Anderson-
 Depends:
     R (>= 3.1.2)
 Imports:
-    methods,igraph,coda
+    methods,igraph,coda,assertthat
 Suggests:
     testthat,R2WinBUGS,rjags,rstan,xtable,abind,ggplot2
 URL: http://r-nimble.org


### PR DESCRIPTION
This adds the [assertthat](https://cran.r-project.org/web/packages/assertthat/index.html) package in preparation for adding many more assertions to our codebase.

## Why?
The `asserthat` package makes it easier to add preconditions and postconditions in code. In particular, it encourages custom assertions rather than verbose `if(-)stop(-)` syntax, which improves readability.

Roughly half of NIMBLE's issues appear to be of the form "poor error reporting in circumstance ___". I believe NIMBLE could benefit from having many more assertions of pre- and post-conditions to detect errors closer to where they occur. I've personally wasted half of today diagnosing an error that was detected only distantly from where it occurred.

## Caveats
This package is still beta (version 0.2.0).