### PR TITLE
always lift expressions returning scalars within nimC

### DIFF
--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -362,44 +362,79 @@ sizeRecyclingRuleRfunction <- function(code, symTab, typeEnv) {
 }
 
 
+concatenateIntermLabelMaker <- labelFunctionCreator("ConcatenateInterm")
+
 sizeConcatenate <- function(code, symTab, typeEnv) { ## This is two argument version
     asserts <- recurseSetSizes(code, symTab, typeEnv)
 
-    ## must recurse to get nDims set
+    ## overall strategy is to separate runs of scaalrs and non-scalars
+    ## also in C++ we don't take arbitrary arguments.  Instead we chain together calls in groups of 4
+    ##     e.g. c(a1, a2, a3, a4, a5) will become c( c(a1, a2, a3, a4), a5)
+    
+    ## first puzzle is with nimC(scalar1, scalar2, vector1, scalar3)
+    ## we need to extract the runs of scalars like (scalar1, scalar2), so they can be packed up in an object together.
     isScalar <- unlist(lapply(code$args, function(x) if(inherits(x, 'exprClass')) x$nDim == 0 else TRUE))
-    ##isExprClass <- unlist(lapply(code$args, function(x) inherits(x, 'exprClass')))
+    ## run length encoding: This native R function returns information about repeats, so we can figure out how long each run of scalars is
     argRLE <- rle(isScalar)
+    ## How many arguments will we have after packing scalars together into single objects:
     newNumArgs <- sum(argRLE$values) + sum(argRLE$lengths[!argRLE$values]) ## number of scalar runs + sum of non-scalar runs * run-lengths
     newArgs <- vector(length(newNumArgs), mode = 'list')
     iInput <- 1
     iOutput <- 1
-    concatenateIntermLabelMaker <- labelFunctionCreator("ConcatenateInterm")
-    asserts <- NULL
+  ##  asserts <- NULL
     for(i in seq_along(argRLE$values)) {
         thisLength <- argRLE$lengths[i]
-        if(!(argRLE$values[i])) {
+        if(!(argRLE$values[i])) { ## it is a run of non-scalars, so pack them into the new argument list, newArgs
             newArgs[(iOutput-1) + (1:thisLength)] <- code$args[(iInput-1) + (1:thisLength)]
             iInput <- iInput + thisLength
             iOutput <- iOutput + thisLength
-        } else {
+        } else { ## it is a run of scalars, so construct an object for them
             newTempFixedName <- concatenateIntermLabelMaker()
             newTempVecName <- concatenateIntermLabelMaker()
+            ## Construct:
+            ## concatenateTemp(ConcatenateInterm_1),
+            ##   concatenateTemp is not output to C++. It is a placeholder
             newExpr <- exprClass(isName = FALSE, isCall = TRUE, isAssign = FALSE, name = "concatenateTemp", nDim = 1, sizeExprs = list(thisLength), type = 'double')
             setArg(newExpr, 1, exprClass(isName = TRUE, isCall = FALSE, isAssign = FALSE, name = newTempVecName, nDim = 1, sizeExprs = list(thisLength), type = 'double'))
+
+            ## hardCodedVectorInitializer is a wrapper for the "contents1, contents2, ..." below 
             valuesExpr <- quote(hardCodedVectorInitializer())
             thisType <- 'logical'
             for(j in 1:thisLength) {
-                valuesExpr[[j+1]] <- parse(text = nimDeparse(code$args[[iInput - 1 + j]]), keep.source = FALSE)[[1]]
-                if(inherits(code$args[[iInput - 1 + j]], 'exprClass'))
-                    thisType <- arithmeticOutputType(thisType, code$args[[iInput - 1 + j]]$type)
-                else
+                thisArgIndex <- iInput - 1 + j
+                if(inherits(code$args[[thisArgIndex]], 'exprClass')) {
+                    if(!code$args[[thisArgIndex]]$isName) ## a little heavy-handed: lift any expression of any kind
+                        ## to avoid dealing with eigen or other handling inside initialization values
+                        ## This is necessary for cases like nimC(model[[node]][2], 1.2)
+                        ## because model[[node]] is a map
+                        asserts <- c(asserts, sizeInsertIntermediate(code, thisArgIndex, symTab, typeEnv))
+                    thisType <- arithmeticOutputType(thisType, code$args[[thisArgIndex]]$type)
+                } else {
                     thisType <- 'double'
+                }
+                ## Putting a map, or a values access, through parse(nimDeparse) won't work
+                ## So we lift any expression element above.
+                ## This could be done more cleanly with more coding work.
+                ## STOPPED HERE: Why use parse(nimDeparse)?  I think mostly so we can use substitute below
+                ## 
+                valuesExpr[[j+1]] <- parse(text = nimDeparse(code$args[[thisArgIndex]]), keep.source = FALSE)[[1]]
+                ## if(inherits(code$args[[thisArgIndex]], 'exprClass'))
+                ##     thisType <- arithmeticOutputType(thisType, code$args[[thisArgIndex]]$type)
+                ## else
+                ##     thisType <- 'double'
             }
             newExpr$type <- thisType
             newExpr$args[[1]]$type <- thisType
             iInput <- iInput + thisLength
             if(thisType == 'integer') thisType <- 'int'
             if(thisType == 'logical') thisType <- 'bool'
+            ## MAKE_FIXED_VECTOR("ConcatenateInterm_2", "ConcatenateInterm_1", numArgs, values, type) goes through a customized output generator
+            ##  to create something like
+            ##    double ConcatenateIterm_1[] = {contents1, contents2}
+            ##    std::vector<double> ConcatenateInterm_2(ConcatenateInterm_1, ConcatenateInterm_1 + length)
+            ##  so there is one intermediate whose only purpose is to achieve initialization by value and a second intermediate copied from the first.
+            ##     The second intermediate can later be used in the templated nimCd/nimCi/nimCb
+            ## 
             newAssert <- substitute(MAKE_FIXED_VECTOR(newTempVecName, newTempFixedName, thisLength, valuesExpr, thisType),
                                     list(newTempVecName = newTempVecName, newTempFixedName = newTempFixedName,
                                          thisLength = as.numeric(thisLength), valuesExpr = valuesExpr, thisType = thisType))
@@ -410,6 +445,7 @@ sizeConcatenate <- function(code, symTab, typeEnv) { ## This is two argument ver
         }
     }
 
+    ## Next step: chain together multiple calls:
     maxArgsOneCall <- 4
     numArgGroups <- ceiling(newNumArgs / (maxArgsOneCall-1))
     splitArgIDs <- split(1:newNumArgs, rep(1:numArgGroups, each = maxArgsOneCall-1, length.out = newNumArgs))
@@ -427,7 +463,8 @@ sizeConcatenate <- function(code, symTab, typeEnv) { ## This is two argument ver
         newExprList[[i]] <- exprClass(isName = FALSE, isCall = TRUE, isAssign = FALSE, name = 'nimC', nDim = 1, toEigenize = 'yes', type = 'double')
         for(j in seq_along(splitArgIDs[[i]])) setArg(newExprList[[i]], j, newArgs[[splitArgIDs[[i]][j]]])
     }
-    ## Last step is to set up nesting and make sizeExprs
+
+    ## Last step is to set up nesting and make sizeExprs for each constructed argument
     for(i in seq_along(splitArgIDs)) {
         if(i != length(splitArgIDs)) {
             setArg(newExprList[[i]], maxArgsOneCall, newExprList[[i+1]])


### PR DESCRIPTION
I modified sizeConcatenate (size processor for nimC) to always lift arguments that are expressions that return scalars.  There is heavy reconstruction of expressions in this size processor, and that broke on a NimArr map such as created by model[[node]][i] or values(model, nodes)[i].  I also fixed collection of asserts from recursion (which were accidentally thrown away) and redundant label generation.  

It would be a good idea to test other core-R features in cases that involve model nodes, values and modelValues.  The testing was all within nimbleFunctions not interaction with models. 