### PR TITLE
Support nimbleFunction classes as fn argument to optim()

### DIFF
--- a/packages/nimble/R/genCpp_generateCpp.R
+++ b/packages/nimble/R/genCpp_generateCpp.R
@@ -332,7 +332,16 @@ cppOutputNFvar <- function(code, symTab) {
 
 cppOutputNFmethod <- function(code, symTab) {
     if(length(code$args) < 2) stop('Error: expecting at least 2 arguments for operator ',code$name)
-    paste0( nimGenerateCpp(code$args[[1]], symTab), '.', code$args[[2]]) ##, ## No nimGenerateCpp on code$args[[2]] because it should be a string
+    if(code$caller$name == 'chainedCall') {
+        paste0( nimGenerateCpp(code$args[[1]], symTab), '.', code$args[[2]]) ##, ## No nimGenerateCpp on code$args[[2]] because it should be a string
+    } else {
+        ## This bound method obj$run is not part of a call, so we transform it to NimBoundMethod<T>(&T::run, obj).
+        objectName <- code$args[[1]]$name
+        typeName <- symTab$getSymbolObject(objectName, inherits = TRUE)$baseType
+        methodName <- code$args[[2]]
+        #paste0('NimBoundMethod<', typeName, '>(&', typeName, '::', methodName, ', ', objectName, ')')
+        paste0('NimBind(&', typeName, '::', methodName, ', ', objectName, ')')
+    }
     ## This used to take method args in this argList.  But now they are in a chainedCall
 }
 

--- a/packages/nimble/R/genCpp_processSpecificCalls.R
+++ b/packages/nimble/R/genCpp_processSpecificCalls.R
@@ -34,7 +34,6 @@ specificCallHandlers = c(
          mvAccess = 'mvAccessHandler',
          numListAccess = 'mvAccessHandler',
          declare = 'declareHandler',
-         nfMethod = 'nfMethodErrorHandler',
          min = 'minMaxHandler',
          max = 'minMaxHandler'),
     makeCallList(names(specificCallReplacements), 'replacementHandler'),
@@ -61,12 +60,6 @@ exprClasses_processSpecificCalls <- function(code, symTab) {
         handler <- specificCallHandlers[[code$name]]
         if(!is.null(handler)) eval(call(handler, code, symTab))
     }
-}
-
-nfMethodErrorHandler <- function(code, symTab) {
-    if(code$caller$name != 'chainedCall')
-        stop(paste0('Error with ', nimDeparse(code), ': an nfMethod call always needs arguments. e.g. nfMethod(mf, \'foo\')().'), call. = FALSE)
-    NULL
 }
 
 seqAlongHandler <- function(code, symTab) {

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -1013,8 +1013,7 @@ sizeOptim <- function(code, symTab, typeEnv) {
     fnCode <- code$args$fn
 
     if (fnCode$name == 'nfMethod') {
-        # Handle fn arguments that are nfMethods.
-        # stop('TODO')
+        # This is handled in cppOutputNFmethod.
     } else if(exists(fnCode$name) && is.rcf(get(fnCode$name))) {
         # Handle fn arguments that are RCfunctions.
         fnCode$name <- environment(get(fnCode$name))$nfMethodRCobject$uniqueName

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -1010,12 +1010,17 @@ sizeOptim <- function(code, symTab, typeEnv) {
     if(!(code$caller$name %in% assignmentOperators)) {
         asserts <- c(asserts, sizeInsertIntermediate(code$caller, code$callerArgID, symTab, typeEnv))
     }
-
-    # Handle fn arguments that are RCfunctions.
     fnCode <- code$args$fn
-    if(!exists(fnCode$name)) stop(paste0('fn argument is undefined in optim(par, fn = ', fnCode$name, ')'))
-    if(!is.rcf(get(fnCode$name))) stop(paste0('fn argument is not an RCfunction optim(par, fn = ', fnCode$name, ')'))
-    fnCode$name <- environment(get(fnCode$name))$nfMethodRCobject$uniqueName
+
+    if (fnCode$name == 'nfMethod') {
+        # Handle fn arguments that are nfMethods.
+        # stop('TODO')
+    } else if(exists(fnCode$name) && is.rcf(get(fnCode$name))) {
+        # Handle fn arguments that are RCfunctions.
+        fnCode$name <- environment(get(fnCode$name))$nfMethodRCobject$uniqueName
+    } else {
+        stop(paste0('unsupported fn argument in optim(par, fn = ', fnCode$name, '); try an RCfunction or nfMethod instead'))
+    }
     if(length(asserts) == 0) NULL else asserts
 }
 

--- a/packages/nimble/inst/CppCode/nimOptim.cpp
+++ b/packages/nimble/inst/CppCode/nimOptim.cpp
@@ -1,8 +1,7 @@
 #include <R_ext/Applic.h>
-#include <algorithm>
+#include <nimble/nimOptim.h>
 #include <cmath>
 #include <limits>
-#include <nimble/nimOptim.h>
 
 // This wraps a NimObjectiveFn as an R `optimfn` type
 //   typedef double optimfn(int, double *, void *);
@@ -15,14 +14,19 @@ static double optimfn_wrapper(int n, double* par, void* fn) {
     return ((NimObjectiveFn*)fn)(nim_par);
 }
 
+nimSmartPtr<OptimResultNimbleList> nimOptim(NimArr<1, double>& par,
+                                            NimObjectiveFn fn) {
+    return nimOptim_internal(par, optimfn_wrapper, (void*)(fn));
+}
+
 // This attempts to match the behavior of optim() defined in the documentation
 //   https://stat.ethz.ch/R-manual/R-devel/library/stats/html/optim.html
 // and in the reference implementation
 //   https://svn.r-project.org/R/trunk/src/library/stats/R/optim.R
 //   https://svn.r-project.org/R/trunk/src/library/stats/src/optim.c
 //   https://svn.r-project.org/R/trunk/src/include/R_ext/Applic.h
-nimSmartPtr<OptimResultNimbleList> nimOptim(NimArr<1, double>& par,
-                                            NimObjectiveFn fn) {
+nimSmartPtr<OptimResultNimbleList> nimOptim_internal(NimArr<1, double>& par,
+                                                     optimfn fn, void* ex) {
     const int n = par.dimSize(0);
     NimArr<1, double> par_nomap = par;
 
@@ -38,15 +42,14 @@ nimSmartPtr<OptimResultNimbleList> nimOptim(NimArr<1, double>& par,
     int* fail = &(result->convergence);
     double abstol = -INFINITY;
     double reltol = std::sqrt(std::numeric_limits<double>::epsilon());
-    void* ex = (void*)(fn);
     double alpha = 1.0;
     double bet = 0.5;
     double gamm = 2.0;
     int trace = 0;
     int* fncount = result->counts.getPtr();
     int maxit = 100;
-    nmmin(n, Bvec, X, Fmin, optimfn_wrapper, fail, abstol, reltol,
-          ex, alpha, bet, gamm, trace, fncount, maxit);
+    nmmin(n, Bvec, X, Fmin, fn, fail, abstol, reltol, ex, alpha, bet, gamm,
+          trace, fncount, maxit);
 
     return result;
 }

--- a/packages/nimble/inst/include/nimble/nimOptim.h
+++ b/packages/nimble/inst/include/nimble/nimOptim.h
@@ -4,11 +4,60 @@
 #include <nimble/NimArr.h>
 #include <nimble/optimTypes.h>
 #include <nimble/smartPtrs.h>
+#include <algorithm>
 
-typedef double NimObjectiveFn(NimArr<1, double>& par);
+// ---------------------------------------------------------------------------
+// Interface for RCfunction functions.
 
-// This behaves like R's native optim() function.
+nimSmartPtr<OptimResultNimbleList> nimOptim_internal(
+    NimArr<1, double> &par, double (*fn)(int, double *, void *), void *ex);
+
+typedef double NimObjectiveFn(NimArr<1, double> &par);
+
+// This behaves like R's native optim() function on RCfunction functions.
 nimSmartPtr<OptimResultNimbleList> nimOptim(NimArr<1, double> &par,
                                             NimObjectiveFn fn);
 
-#endif // __NIMBLE_NIMOPTIM_H
+// ---------------------------------------------------------------------------
+// Interface for nimbleFunction classes.
+
+// This class and wrapper are equivalent to std::bind(-,-) in C++11, so that:
+//   object->method(par) == NimBoundMethod<T>(&T::method, object)(par);
+//                       == NimBind(&T::method, object)(par);
+//                       == std::bind(&T::method, object)(par);
+template <class T>
+class NimBoundMethod {
+   public:
+    NimBoundMethod(double (T::*method)(NimArr<1, double> &), T *object)
+        : method_(method), object_(object) {}
+    double operator()(NimArr<1, double> &par) {
+        return (object_->*method_)(par);
+    }
+
+   private:
+    double (T::*method_)(NimArr<1, double> &);
+    T *object_;
+};
+
+template <class T>
+inline NimBoundMethod<T> NimBind(double (T::*method)(NimArr<1, double> &),
+                                 T *object) {
+    return NimBoundMethod<T>(method, object);
+}
+
+template <class T>
+double optimfn_method_wrapper(int n, double *par, void *fn) {
+    NimArr<1, double> nim_par;
+    nim_par.setSize(n, false, false);
+    std::copy(par, par + n, nim_par.getPtr());
+    return static_cast<NimBoundMethod<T> *>(fn)->operator()(nim_par);
+}
+
+// This behaves like R's native optim() function on nimbleFunction classes.
+template <class T>
+nimSmartPtr<OptimResultNimbleList> nimOptim(NimArr<1, double> &par,
+                                            NimBoundMethod<T> fn) {
+    return nimOptim_internal(par, &optimfn_method_wrapper<T>, &fn);
+}
+
+#endif  // __NIMBLE_NIMOPTIM_H

--- a/packages/nimble/inst/tests/test_utils.R
+++ b/packages/nimble/inst/tests/test_utils.R
@@ -18,6 +18,14 @@ system.in.dir <- function(cmd, dir = '.') {
         system(cmd)
 }
 
+## This is useful for working around scoping issues with nimbleFunctions using other nimbleFunctions.
+temporarilyAssignInGlobalEnv <- function(value) {
+    name <- deparse(substitute(value))
+    assign(name, value, envir = .GlobalEnv)
+    rmCommand <- substitute(remove(name, envir = .GlobalEnv))
+    do.call('on.exit', list(rmCommand), envir = parent.frame())
+}
+
 gen_runFunCore <- function(input) {
     runFun <- function() {}
     formalsList <- input$args


### PR DESCRIPTION
**Status:** Do not merge. This will be merged into devel after optim-support #318 is merged.

This adds a simple C++ binding layer `NimBind(-,-)` that gives us some of the functionality of C++11's [`std::bind`](http://en.cppreference.com/w/cpp/utility/functional/bind). This pattern suggests one way we can start to allow higher-order functional programming in NIMBLE, i.e. to allow passing unapplied methods around as arguments to other functions.