### PR TITLE
Attempt to fix broken calls to internal methods of roxygen2

### DIFF
--- a/packages/Makefile.nimble
+++ b/packages/Makefile.nimble
@@ -6,7 +6,7 @@ nimble_0.1.tar.gz :  nimble/*
 prep:  nimble/R nimble_0.1.tar.gz nimble/NAMESPACE nimble/man
       # need installed pkg to be able to list all fxns/classes
       R CMD INSTALL nimble_0.1.tar.gz
-      ./prep_pkg
+      ./prep_pkg.R
 
 all:  nimble/man/* nimble_0.1.tar.gz nimble/NAMESPACE
 

--- a/packages/RELEASE_INSTRUCTIONS
+++ b/packages/RELEASE_INSTRUCTIONS
@@ -11,9 +11,9 @@ Make sure src/Makevars.win is present.
 
 R CMD build nimble
 R CMD INSTALL nimble_${VERSION}.tar.gz
-# before running prep_pkg make sure there is a config.R in nimble/R - copy over from another repos if needed but it should not be in the repository per DTL instructions (or do in separate copy of repository: make configure; cd nimble; ./configure - note that if do this the configure step will have an error in building libnimble.a and that a bunch of files will be created in src that should not be in the repository (all but *.in and nimble.cpp do not belong)
+# before running prep_pkg.R make sure there is a config.R in nimble/R - copy over from another repos if needed but it should not be in the repository per DTL instructions (or do in separate copy of repository: make configure; cd nimble; ./configure - note that if do this the configure step will have an error in building libnimble.a and that a bunch of files will be created in src that should not be in the repository (all but *.in and nimble.cpp do not belong)
 
-./prep_pkg # this creates man pages and updates NAMESPACE; note various warnings of things that can go wrong in prep_pkg and make sure these don't happen
+./prep_pkg.R # this creates man pages and updates NAMESPACE; note various warnings of things that can go wrong in prep_pkg.R and make sure these don't happen
 
 
 R CMD build nimble

--- a/packages/prep_pkg.R
+++ b/packages/prep_pkg.R
@@ -69,7 +69,7 @@ for(file in files) {
   print(file)
   test <- try(a <- roxygen2:::roc_proc_text(roclet, paste(readLines(file.path(Rpath, file)), sep="\n")))
   if(!is(test, 'try-error'))
-    roxygen2:::roc_output(roclet, a, "nimble", options = list(wrap=FALSE, roclets = "rd"), check = FALSE)
+    roxygen2:::roclet_output(roclet, a, "nimble", options = list(wrap=FALSE, roclets = "rd"), check = FALSE)
 }
 
 
@@ -138,7 +138,7 @@ cat(paste(text, collapse = "\n"), file = file.path("nimble", "man", "nimble-math
 # now create real NAMESPACE file
 ## NAMESPACE
 system(paste("mv", file.path('nimble','NAMESPACE'), file.path('/tmp', 'NAMESPACE')))
-roxygenise('nimble','namespace')
+devtools::document('nimble', roclets = c('namespace'))
 
 namespace <- readLines(file.path('nimble','NAMESPACE'))
 
@@ -157,3 +157,4 @@ exportText <- c(exportTextAdd, exportText)
 
 #cat(paste(imports, "\n", importFroms, "\n", dynLibLine, "\n", exportText, "\n", collapse = ''),
 cat(paste(imports, importFroms, dynLibLine, S3methods, collapse = '\n', sep = '\n'), '\n', paste0(exportText, collapse = '\n'), sep = '', file = file.path("nimble", "NAMESPACE"))
+


### PR DESCRIPTION
- Renames `prep_pkg` to `prep_pkg.R` (so I can debug it line-by-line in RSudio)
- Updates our use of the internal `roxygenize2:::roc_output` to `roxygenize:::roclet_output`
- Replaces `roxygenise()` with `devtools::document()` to work around https://github.com/klutometis/roxygen/issues/595

This fixes a few bugs, but I still haven't been able to generate documentation :-( 