### PR TITLE
support for model$getParam(nodes[i], 'mean') if nodes is empty

### DIFF
--- a/packages/nimble/R/nimbleFunction_compile.R
+++ b/packages/nimble/R/nimbleFunction_compile.R
@@ -551,8 +551,15 @@ nfProcessing$methods(makeTypeObject = function(name, instances, firstOnly = FALS
   if(inherits(instances[[1]][[name]], 'modelValuesAccessorVector')){
     return(symbolModelValuesAccessorVector(name = name) )     	
   }
-  if(inherits(instances[[1]][[name]], 'getParam_info')) {
-    return(symbolGetParamInfo(name = name, paramInfo = instances[[1]][[name]]))
+  if(inherits(instances[[1]][[name]], 'getParam_info')) { ## the paramInfo in an instance is allowed to be NULL (see GitHub Issue #327). Hence we search for the first valid case and default to double()
+      iInst <- 1
+      paramInfo <- instances[[iInst]][[name]]
+      while(is.na(paramInfo$type) & iInst < length(instances)) {
+          iInst <- iInst + 1
+          paramInfo <- instances[[iInst]][[name]]
+      }
+      if(is.na(paramInfo$type)) paramInfo <- defaultParamInfo()
+      return(symbolGetParamInfo(name = name, paramInfo = paramInfo))
   }
   if(inherits(instances[[1]][[name]], 'getBound_info')) {
     return(symbolGetBoundInfo(name = name, boundInfo = instances[[1]][[name]]))


### PR DESCRIPTION
@danielturek This fixes Issue #327.  If there are no instances with a non-empty `nodes`, it defaults to assigning a return type of double().  If subsequent compilations of the same nf are not compatible with that type, there will be an error.  But at least it works safely as you’ve requested in the Issue.