### PR TITLE
Add option to quiet down errors

### DIFF
--- a/packages/nimble/R/RCfunction_compile.R
+++ b/packages/nimble/R/RCfunction_compile.R
@@ -236,18 +236,23 @@ RCfunProcessing <- setRefClass('RCfunProcessing',
                                        names(passedArgNames) <- compileInfo$origLocalSymTab$getSymbolNames() 
 
                                        compileInfo$typeEnv[['passedArgumentNames']] <<- passedArgNames ## only the names are used.
+                                       ## This attempts to prevent the traceback from being hidden by multiple layers of error trapping.
+                                       ## A better solution might be to avoid layered trapping so that options(error = recover) could function.
                                        tryCatch(withCallingHandlers(exprClasses_setSizes(compileInfo$nimExpr, compileInfo$newLocalSymTab, compileInfo$typeEnv),
                                                                     error = function(e) {
                                                                         stack <- sapply(sys.calls(), deparse)
                                                                         .GlobalEnv$.nimble.traceback <- capture.output(traceback(stack))
                                                                     }),
                                                 error = function(e) {
-                                                    stop(paste('There was some problem in the the setSizes processing step for this code:',
-                                                               paste(deparse(compileInfo$origRcode), collapse = '\n'),
-                                                               'Internal Error:', e,
-                                                               'Traceback:', paste0(.GlobalEnv$.nimble.traceback, collapse = '\n'),
-                                                               sep = '\n'),
-                                                         call. = FALSE)
+                                                    message <- paste('There was some problem in the the setSizes processing step for this code:',
+                                                                     paste(deparse(compileInfo$origRcode), collapse = '\n'))
+                                                    if(getNimbleOption('verboseErrors')) {
+                                                        message <- paste(message,
+                                                                         'Internal Error:', e,
+                                                                         'Traceback:', paste0(.GlobalEnv$.nimble.traceback, collapse = '\n'),
+                                                                         sep = '\n')
+                                                    }
+                                                    stop(message, call. = FALSE)
                                                 })
                                        neededRCfuns <<- c(neededRCfuns, compileInfo$typeEnv[['neededRCfuns']])
                                        

--- a/packages/nimble/R/options.R
+++ b/packages/nimble/R/options.R
@@ -26,6 +26,7 @@ nimbleUserNamespace <- as.environment(list(sessionSpecificDll = NULL))
         checkModel = FALSE,
         checkNimbleFunction = TRUE,
         verbose = TRUE,
+        verboseErrors = FALSE,
 
         ## verifies the correct posterior is created for any conjugate samplers, at run-time.
         ## if this option is changed, then congugate sampler functions can be rebuilt using:
@@ -94,7 +95,8 @@ getNimbleOption <- function(x) {
 #' NIMBLE Options Settings
 #'
 #' Allow the user to set and examine a variety of global _options_
-#' that affect the way in which NIMBLE operates
+#' that affect the way in which NIMBLE operates. Call \code{nimbleOptions()}
+#' with no arguments to see a list of available opions.
 #' 
 #' @param ... any options to be defined as one or more 'name = value' pairs.
 #' Options can also be passed by giving a single unnamed argument that is a named list.


### PR DESCRIPTION
This quiets down the verbose error messaging introduced in #323 and gates it behind a global option. 