### PR TITLE
fix getDependencies with self=TRUE and with omit that includes input nodes

### DIFF
--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -641,7 +641,6 @@ returnScalar Componenets: Logical argument specifying whether multivariate nodes
 
 Details: The downward search for dependent nodes propagates through deterministic nodes, but by default will halt at the first level of stochastic nodes encountered.
 '
-
                                       if(inherits(nodes, 'character')) {
                                           ## elementIDs <- modelDef$nodeName2GraphIDs(nodes, !returnScalarComponents)
                                           ## if(returnScalarComponents)
@@ -664,18 +663,22 @@ Details: The downward search for dependent nodes propagates through deterministi
                                           nodeIDs <- nodes
                                       
                                       if(inherits(omit, 'character')) { ## mimic above if it works
-                                          elementIDs <- modelDef$nodeName2GraphIDs(omit, !returnScalarComponents)
-                                          if(returnScalarComponents)
-                                              omitIDs <- unique(modelDef$maps$elementID_2_vertexID[elementIDs],
-                                                                   FALSE,
-                                                                   FALSE,
-                                                                   NA)
-                                          else
-                                              omitIDs <- elementIDs
+                                      ##     elementIDs <- modelDef$nodeName2GraphIDs(omit, !returnScalarComponents)
+                                      ##     if(returnScalarComponents)
+                                      ##         omitIDs <- unique(modelDef$maps$elementID_2_vertexID[elementIDs],
+                                      ##                              FALSE,
+                                      ##                              FALSE,
+                                      ##                              NA)
+                                      ##     else
+                                      ##         omitIDs <- elementIDs
+                                          elementIDs <- modelDef$nodeName2GraphIDs(omit, FALSE)
+                                          omitIDs <- unique(modelDef$maps$elementID_2_vertexID[elementIDs],     ## turn into IDs in the graph
+                                                            FALSE,
+                                                            FALSE,
+                                                            NA)
                                       }
                                       else if(inherits(omit, 'numeric'))
                                           omitIDs <- omit
-
 
 ## new C++ version
  depIDs <- modelDef$maps$nimbleGraph$getDependencies(nodes = nodeIDs, omit = if(is.null(omitIDs)) integer() else omitIDs, downstream = downstream)
@@ -690,7 +693,10 @@ Details: The downward search for dependent nodes propagates through deterministi
                                       if(!includeRHSonly) depIDs <- depIDs[modelDef$maps$types[depIDs] != 'RHSonly']
                                       if(determOnly)	depIDs <- depIDs[modelDef$maps$types[depIDs] == 'determ']
                                       if(stochOnly)	depIDs <- depIDs[modelDef$maps$types[depIDs] == 'stoch']
-                                      if(!self)	depIDs <- setdiff(depIDs, nodeIDs)
+if(!self)	{
+    nodeFunIDs <- unique(modelDef$maps$vertexID_2_nodeID[ nodeIDs ])
+    depIDs <- setdiff(depIDs, nodeFunIDs)
+}
                                       if(!includeData)	depIDs <- depIDs[!isDataFromGraphID(depIDs)]
                                       if(dataOnly)		depIDs <- depIDs[isDataFromGraphID(depIDs)]
                                       

--- a/packages/nimble/inst/CppCode/nimbleGraph.cpp
+++ b/packages/nimble/inst/CppCode/nimbleGraph.cpp
@@ -322,8 +322,17 @@ vector<int> nimbleGraph::getDependencies(const vector<int> &Cnodes, const vector
   n = Cnodes.size();
   graphNode *thisGraphNode;
   int thisGraphNodeID;
+  vector<int>::const_iterator omitFinder; 
   for(i = 0; i < n; i++) {
     thisGraphNodeID = Cnodes[i];
+
+    // Need to check Comit
+    // the touching of all Comit nodes still blocks them in the recursion
+    // but for the input nodes, we need to check if they are in Comit because
+    // being touched could also occur from another input node
+    omitFinder = std::find(Comit.begin(), Comit.end(), thisGraphNodeID);
+    if(omitFinder != Comit.end()) continue; // it was in omits
+    
     thisGraphNode = graphNodeVec[ thisGraphNodeID ];
 #ifdef _DEBUG_GETDEPS
     PRINTF("Working on input node %i\n", thisGraphNodeID);

--- a/packages/nimble/inst/tests/graphStructureTestResults_Correct.Rout
+++ b/packages/nimble/inst/tests/graphStructureTestResults_Correct.Rout
@@ -1,0 +1,31 @@
+graph structure tests case 1
+1: a x[1] x[2] x[3] x[4] x[5] x[6] x[7] x[8] x[9] x[10]
+1: 
+1: x[1] x[2] x[3] x[4] x[5] x[6] x[7] x[8] x[9] x[10]
+1: 
+1: x[2] y[2]
+1: y[2]
+1: 
+1: x[2]
+1: x[2] x[3] x[4] y[2] y[3] y[4]
+1: y[2] y[3] y[4]
+1: x[2] x[3] y[2] y[3]
+1: a x[1] x[2] x[3] x[4] x[5] x[6] x[7] x[8] x[9] x[10] y[1] y[2] y[3] y[4] y[5] y[6] y[7] y[8] y[9] y[10]
+1: x[1] x[2] x[3] x[4] x[5] x[6] x[7] x[8] x[9] x[10] y[1] y[2] y[3] y[4] y[5] y[6] y[7] y[8] y[9] y[10]
+1: a x[1] x[2] x[3] x[4] x[5] x[6] x[7] x[8] x[9] x[10] y[1] y[2] y[3] y[4] y[5] y[6] y[7] y[8] y[9] y[10]
+1: x[1] x[2] x[3] x[4] x[5] x[6] x[7] x[8] x[9] x[10] y[1] y[2] y[3] y[4] y[5] y[6] y[7] y[8] y[9] y[10]
+graph structure tests case 2 (dmnorm fully split)
+2: x[1:5] ypred[1] ypred[2] ypred[3] ypred[4] ypred[5] y[1] y[2] y[3] y[4] y[5]
+2: x[1] x[2] x[3] x[4] x[5] ypred[1] ypred[2] ypred[3] ypred[4] ypred[5] y[1] y[2] y[3] y[4] y[5]
+2: ypred[1] ypred[2] ypred[3] ypred[4] ypred[5] y[1] y[2] y[3] y[4] y[5]
+2: ypred[1] ypred[2] ypred[3] ypred[4] ypred[5] y[1] y[2] y[3] y[4] y[5]
+2: x[1:5] ypred[1] ypred[4] ypred[5] y[4]
+2: x[1:5] ypred[2] y[2]
+2: x[1] x[2] x[3] x[4] x[5] ypred[2] y[2]
+2: ypred[2] y[2]
+2: x[1:5] ypred[2] ypred[3] ypred[4] y[2] y[3] y[4]
+2: ypred[2] ypred[3] ypred[4] y[2] y[3] y[4]
+2: x[1:5]
+2: mu[1:5] x[1:5]
+2: mu[1] mu[2] mu[3] mu[4] mu[5] x[1] x[2] x[3] x[4] x[5]
+2: mu[1:5] x[1:5]

--- a/packages/nimble/inst/tests/test-graphStructure.R
+++ b/packages/nimble/inst/tests/test-graphStructure.R
@@ -1,0 +1,100 @@
+## These tests address construction and querying of the graph structure
+## test-getDependencies has some more basic tests.
+source(system.file(file.path('tests', 'test_utils.R'), package = 'nimble'))
+
+
+correctOutputFilename <- 'graphStructureTestResults_Correct.Rout'
+## Use this to regenerate results in the test directory:
+## library(testthat)
+## library(nimble)
+## run code below, then:
+## writeOutput(cases, correctOutputFilename)
+testOutputFilename <- 'graphStructureTestResults.Rout'
+
+clearOldOutput <- function(filename) {
+    if(file.exists(filename)) file.remove(filename)
+}
+
+appendOutput <- function(filename, case, caseName, casePrefix = "") {
+    outputConnection <- file(filename, open = 'at')
+    writeLines(caseName, con = outputConnection)
+    outputAns <- lapply(case, function(x) writeLines(paste0(casePrefix, paste(x, collapse = " ")), con = outputConnection))
+    close(outputConnection)
+}
+
+writeOutput <- function(cases, filename) {
+    clearOldOutput(filename)
+    for(i in seq_along(cases)) appendOutput(filename, cases[[i]], names(cases)[i], casePrefix = paste0(i,": "))
+}
+
+
+
+cases <- list()
+caseName <- 'graph structure tests case 1'
+m <- nimbleModel(
+    code = nimbleCode({
+        a ~ dnorm(0,1)
+        for(i in 1:10) x[i] ~ dnorm(a, 1)
+        for(j in 1:10) y[j] ~ dnorm(x[j], 1)
+    })
+)
+cases[[caseName]] <- list(
+    m$getDependencies('a'),
+    m$getDependencies('a', omit = 'a'),
+    m$getDependencies('a', self = FALSE),
+    m$getDependencies('a', omit = 'a', self = FALSE),
+    m$getDependencies('x[2]'),
+    m$getDependencies('x[2]', self = FALSE),
+    m$getDependencies('x[2]', omit = 'x[2]'),
+    m$getDependencies('x[2]', omit = 'y[2:3]'),
+    m$getDependencies('x[2:4]'),
+    m$getDependencies('x[2:4]', self = FALSE),
+    m$getDependencies('x[2:4]', omit = 'x[4:6]'),
+    m$getDependencies('a', downstream = TRUE),
+    m$getDependencies('a', downstream = TRUE, self = FALSE),
+    m$getDependencies('a', downstream = TRUE, returnScalarComponents = TRUE),
+    m$getDependencies('a', downstream = TRUE, self = FALSE, returnScalarComponents = TRUE)
+    )
+
+caseName <- 'graph structure tests case 2 (dmnorm fully split)'
+m <- nimbleModel(
+    code = nimbleCode({
+        x[1:5] ~ dmnorm(mu[1:5], cov[1:5, 1:5])                        
+        for(i in 1:5) {
+            ypred[i] <- x[i] + 1
+            y[i] ~ dnorm(ypred[i], 1)
+        }
+    }),
+    constants = list(mu = rep(0,5), cov = diag(5))
+)
+
+cases[[caseName]] <- list(
+    m$getDependencies('x[1:5]'),
+    m$getDependencies('x[1:5]', returnScalarComponents = TRUE),
+    m$getDependencies('x[1:5]', self = FALSE),
+    m$getDependencies('x[1:5]', self = FALSE, returnScalarComponents = TRUE),
+    m$getDependencies('x[1:5]',  omit = c('x[2:3]','y[c(1, 5)]')),
+    m$getDependencies('x[2]'),
+    m$getDependencies('x[2]', returnScalarComponents = TRUE),
+    m$getDependencies('x[2]', self = FALSE),
+    m$getDependencies('x[2:4]'),
+    m$getDependencies('x[2:4]', self = FALSE),
+    m$getDependencies('mu[2:4]'),
+    m$getDependencies('mu[2:4]', includeRHSonly = TRUE),
+    m$getDependencies('mu[2:4]', includeRHSonly = TRUE, returnScalarComponents = TRUE),
+    m$getDependencies('mu', includeRHSonly = TRUE)
+)
+
+writeOutput(cases, testOutputFilename)
+trialResults <- readLines(testOutputFilename)
+##correctResults <- trialResults
+correctResults <- readLines(system.file(file.path('tests', correctOutputFilename), package = 'nimble'))
+
+test_that('same number of output lines',
+          expect_equal(length(trialResults), length(correctResults)))
+
+linesToTest <- min(length(trialResults), length(correctResults))
+mapply(function(lineno, trialLine, correctLine) {
+    test_that(paste0("output line #", lineno),
+              expect_identical(trialLine, correctLine))
+}, 1:linesToTest, trialResults, correctResults)


### PR DESCRIPTION
@danielturek This PR fixes Issue #341 .  See also new test-graphStructure.  This test works by comparing to a saved output file confirmed by inspection to give desired results.  Please check and add more cases as you see fit.