### PR TITLE
Fix travis test script that was not failing

### DIFF
--- a/test-devel.sh
+++ b/test-devel.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh -ex
 
 Rscript packages/nimble/inst/tests/test-allocation.R
 Rscript packages/nimble/inst/tests/test-checkDSL.R


### PR DESCRIPTION
The original script accidentally omitted the -e flag from the shell invocation.