### PR TITLE
force lifting of any return argument with toEigenize=='yes'. add tests of return expressions in test-coreR.

### DIFF
--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -368,7 +368,7 @@ sizeRecyclingRuleRfunction <- function(code, symTab, typeEnv) {
     code$sizeExprs <- newSizeExprs
     code$type <- 'double' ## will need to look up from a list
     code$nDim <- 1
-    code$toEigenize <- TRUE
+    code$toEigenize <- 'yes'
     return(asserts)
 }
 
@@ -2267,8 +2267,8 @@ isIntegerEquivalent <- function(code) {
 }
 
 sizeSeq <- function(code, symTab, typeEnv, recurse = TRUE) {
-    message('still need to handle -1L sequences')
-    message('check that arguments are scalars')
+    ##message('still need to handle -1L sequences')
+    ##message('check that arguments are scalars')
     asserts <- if(recurse) recurseSetSizes(code, symTab, typeEnv) else list()
     byProvided <- code$name == 'nimSeqBy' | code$name == 'nimSeqByLen'
     lengthProvided <- code$name == 'nimSeqLen' | code$name == 'nimSeqByLen'
@@ -2560,11 +2560,13 @@ sizeReturn <- function(code, symTab, typeEnv) {
     asserts <- recurseSetSizes(code, symTab, typeEnv)
     if(inherits(code$args[[1]], 'exprClass')) {
         if(!code$args[[1]]$isName) {
-##            if(code$args[[1]]$toEigenize == 'yes') {
-            if(anyNonScalar(code$args[[1]])) {
+            liftArg <- FALSE
+            if(code$args[[1]]$toEigenize == 'yes')
+                liftArg <- TRUE
+            else if(anyNonScalar(code$args[[1]]))
+                liftArg <- TRUE
+            if(liftArg)
                 asserts <- c(asserts, sizeInsertIntermediate(code, 1, symTab, typeEnv, forceAssign = TRUE))
-            }
-            ##            }
         }
     }
     invisible(asserts)

--- a/packages/nimble/inst/tests/test-coreR.R
+++ b/packages/nimble/inst/tests/test-coreR.R
@@ -716,6 +716,45 @@ logicalTests <- list(
          outputType = quote(double(2)))
 )
 
+returnTests <- list(
+    list(name = "return(rnorm scalar)",
+         expr = quote({}),
+         return = quote(return(rnorm(1))),
+         args = list(),
+         setArgVals = quote({}),
+         outputType = quote(double())),
+    list(name = "return(rnorm vector)",
+         expr = quote({}),
+         return = quote(return(rnorm(4))),
+         args = list(),
+         setArgVals = quote({}),
+         outputType = quote(double(1))),
+    list(name = "return(rep(...))",
+         expr = quote({}),
+         return = quote(return(rep(1.23, 4))),
+         args = list(),
+         setArgVals = quote({}),
+         outputType = quote(double(1))),
+    list(name = "return(seq(...))",
+         expr = quote({}),
+         return = quote(return(seq(from = .1, to = .5, by = .15))),
+         args = list(),
+         setArgVals = quote({}),
+         outputType = quote(double(1))),
+    list(name = "return(A + B scalar)",
+         expr = quote({A <- .1; B <- .2}),
+         return = quote(return(A + B)),
+         args = list(),
+         setArgVals = quote({}),
+         outputType = quote(double(0))),
+    list(name = "return(A + B vector)",
+         expr = quote({A <- rep(.1, 3); B <- rep(.2, 3)}),
+         return = quote(return(A + B)),
+         args = list(),
+         setArgVals = quote({}),
+         outputType = quote(double(1))) 
+)
+
 cTestsResults <- lapply(cTests, test_coreRfeature)
 blockTestsResults <- lapply(blockTests, test_coreRfeature)
 repTestsResults <- lapply(repTests, test_coreRfeature)
@@ -726,3 +765,4 @@ seqTestsResults <- lapply(seqTests, test_coreRfeature)
 nonSeqIndexTestsResults <- lapply(nonSeqIndexTests, test_coreRfeature)
 indexChainTestsResults <- lapply(indexChainTests, test_coreRfeature)
 logicalTestsResults <- lapply(logicalTests, test_coreRfeature)
+returnTestResults <- lapply(returnTests, test_coreRfeature)


### PR DESCRIPTION
This fixes Issue #351.  There was commented-out old logic forcing lifting of any return argument with toEigenize==‘yes’.  It had been replaced with different logic.  I reinstated the toEigenize check and combined with the other logic.