### PR TITLE
ReturnErrorTrapping

### DIFF
--- a/packages/nimble/R/RCfunction_compile.R
+++ b/packages/nimble/R/RCfunction_compile.R
@@ -245,7 +245,8 @@ RCfunProcessing <- setRefClass('RCfunProcessing',
                                                                         .GlobalEnv$.nimble.traceback <- capture.output(traceback(stack))
                                                                     }),
                                                 error = function(e) {
-                                                    message <- paste('There was some problem in the the setSizes processing step for this code:',
+                                                    eMessage <- if(!is.null(e$message)) paste0(as.character(e$message),"\n") else ""
+                                                    message <- paste(eMessage, 'There was some problem in the the setSizes processing step for this code:',
                                                                      paste(deparse(compileInfo$origRcode), collapse = '\n'))
                                                     if(getNimbleOption('verboseErrors')) {
                                                         message <- paste(message,

--- a/packages/nimble/R/genCpp_RparseTree2exprClasses.R
+++ b/packages/nimble/R/genCpp_RparseTree2exprClasses.R
@@ -65,7 +65,7 @@ RparseTree2ExprClasses <- function(code, caller = NULL, callerArgID = numeric())
                     if(name == '[' & i == length(code))
                         ans$args[[i-1]] <- code[[i]]
                     else ## cast logical to numeric unless it is last arg of a [, in which case it could be for drop.  This is not a very logical place for this step, but it works.
-                        ans$args[[i-1]] <- as.numeric(code[[i]])
+                        ans$args[[i-1]] <- code[[i]] ## try keeping logicals instead of casting to numeric as.numeric(code[[i]])
                 } else {
                     ans$args[[i-1]] <- if(is.numeric(code[[i]]) | is.character(code[[i]]) | is.null(code[[i]])) code[[i]] else RparseTree2ExprClasses(code[[i]], caller = ans, callerArgID = i-1)
                 }

--- a/packages/nimble/R/genCpp_exprClass.R
+++ b/packages/nimble/R/genCpp_exprClass.R
@@ -94,7 +94,7 @@ addIndentToList <- function(x, indent) {
 ### Deparse from exprClass back to R code: not guaranteed to be identical, but valid.
 nimDeparse <- function(code, indent = '') {
     ## numeric case
-    if(is.numeric(code)) return(code)
+    if(is.numeric(code) | is.logical(code)) return(code)
     if(is.character(code)) return(paste0('\"', code, '\"'))
     if(is.null(code)) return('NULL')
     ## name

--- a/packages/nimble/R/genCpp_generateCpp.R
+++ b/packages/nimble/R/genCpp_generateCpp.R
@@ -83,7 +83,7 @@ nimGenerateCpp <- function(code, symTab = NULL, indent = '', showBracket = TRUE,
     if(is.numeric(code)) return(code)
     if(is.character(code)) return(paste0('\"', gsub("\\n","\\\\n", code), '\"'))
     if(is.null(code)) return('R_NilValue')
-    if(is.logical(code) ) return(code)
+    if(is.logical(code) ) return(if(code) 'true' else 'false')
     if(is.list(code) ) stop("Error generating C++ code, there is a list where there shouldn't be one.  It is probably inside map information.", call. = FALSE)
 
     if(length(code$isName) == 0) browser()

--- a/packages/nimble/R/genCpp_processSpecificCalls.R
+++ b/packages/nimble/R/genCpp_processSpecificCalls.R
@@ -176,19 +176,15 @@ nimArrayGeneralHandler <- function(code, symTab) {
     switch(code$name,
            ##nimNumeric(length = 0, value = 0, init = TRUE)
            nimNumeric = {
-##               if(inherits(code$args[[1]], 'exprClass') && code$args[[1]]$isCall && code$args[[1]]$name == 'c') stop('numeric doesnt handle c() in length')
                sizeExprs <- exprClass$new(isName=FALSE, isCall=TRUE, isAssign=FALSE, name='collectSizes', args=code$args[1], caller=code, callerArgID=3)
                newArgs <- list(type = 'double', nDim = 1, dim = sizeExprs, value = code$args[['value']], init = code$args[['init']],  fillZeros = code$args[['fillZeros']], recycle = code$args[['recycle']])
            },
            ##nimInteger(length = 0, value = 0, init = TRUE)
            nimInteger = {
-##               if(inherits(code$args[[1]], 'exprClass') && code$args[[1]]$isCall && code$args[[1]]$name == 'c') stop('integer doesnt handle c() in length')
                sizeExprs <- exprClass$new(isName=FALSE, isCall=TRUE, isAssign=FALSE, name='collectSizes', args=code$args[1], caller=code, callerArgID=3)
                newArgs <- list(type = 'integer', nDim = 1, dim = sizeExprs, value = code$args[['value']], init = code$args[['init']],  fillZeros = code$args[['fillZeros']], recycle = code$args[['recycle']])
            },
-           ##nimLogical(length = 0, value = 0, init = TRUE)
            nimLogical = {
-##               if(inherits(code$args[[1]], 'exprClass') && code$args[[1]]$isCall && code$args[[1]]$name == 'c') stop('integer doesnt handle c() in length')
                sizeExprs <- exprClass$new(isName=FALSE, isCall=TRUE, isAssign=FALSE, name='collectSizes', args=code$args[1], caller=code, callerArgID=3)
                newArgs <- list(type = 'logical', nDim = 1, dim = sizeExprs, value = code$args[['value']], init = code$args[['init']],  fillZeros = code$args[['fillZeros']], recycle = code$args[['recycle']])
            },

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -2553,7 +2553,6 @@ sizeReturn <- function(code, symTab, typeEnv) {
         if(!identical(typeEnv$returnType$type, 'void')) stop(exprClassProcessingErrorMsg(code, 'return() with no argument can only be used with returnType(void()), which is the default if there is no returnType() statement.'), call. = FALSE)
         return(invisible(NULL))
     }
-    
     asserts <- recurseSetSizes(code, symTab, typeEnv)
     if(inherits(code$args[[1]], 'exprClass')) {
 

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -421,7 +421,7 @@ sizeConcatenate <- function(code, symTab, typeEnv) { ## This is two argument ver
                         asserts <- c(asserts, sizeInsertIntermediate(code, thisArgIndex, symTab, typeEnv))
                     thisType <- arithmeticOutputType(thisType, code$args[[thisArgIndex]]$type)
                 } else {
-                    thisType <- 'double'
+                    thisType <- storage.mode(code$args[[thisArgIndex]]) ##'double'
                 }
                 ## Putting a map, or a values access, through parse(nimDeparse) won't work
                 ## So we lift any expression element above.
@@ -752,7 +752,7 @@ sizeNimArrayGeneral <- function(code, symTab, typeEnv) {
 
     annotationSizeExprs <- lapply(cSizeExprs$args, nimbleGeneralParseDeparse) ## and this is for purposes of the sizeExprs in the AST exprClass object
     
-    missingSizes <- unlist(lapply(cSizeExprs$args, identical, as.numeric(NA)))
+    missingSizes <- unlist(lapply(cSizeExprs$args, function(x) identical(x, as.numeric(NA)) | identical(x, NA))) ## note is.na doesn't work b/c the argument can be an expression and is.na warns on that ##old: identical, as.numeric(NA)))
     ## only case where we do something useful with missingSizes is matrix(value = non-scalar, ...)
     if(any(missingSizes)) {
         ## modify sizes in generated C++ line
@@ -1348,6 +1348,13 @@ sizeforceEigenize <- function(code, symTab, typeEnv) {
     toEigs <- lapply(code$args, function(x) {
         if(inherits(x, 'exprClass')) x$toEigenize else 'unknown'
     })
+    toLift <- lapply(code$args, function(x) {
+        if(inherits(x, 'exprClass')) (identical(x$type, 'logical') & !x$isName) else FALSE
+    })
+    for(i in seq_along(toLift)) {
+        if(toLift[[i]])
+            asserts <- c(asserts, sizeInsertIntermediate(code, i, symTab, typeEnv)) 
+    }
     code$toEigenize <- if(any( unlist(toEigs) %in% c('maybe', 'yes'))) 'yes' else 'no'
     code$type <- 'unknown'
     if(length(asserts) == 0) NULL else asserts
@@ -1551,7 +1558,7 @@ sizeAssignAfterRecursing <- function(code, symTab, typeEnv, NoEigenizeMap = FALS
         RHStype <- RHS$type
         RHSsizeExprs <- RHS$sizeExprs
     } else {
-        if(is.numeric(RHS)) {
+        if(is.numeric(RHS) | is.logical(RHS)) {
             RHSname = ''
             RHSnDim <- 0
             RHStype <- storage.mode(RHS)
@@ -2561,11 +2568,13 @@ sizeReturn <- function(code, symTab, typeEnv) {
             if(code$args[[1]]$type != 'nimbleList') stop(exprClassProcessingErrorMsg(code, paste0('returnType statement gives a nimbleList type but return() argument is not the right type')), call. = FALSE)
             ## equivalent to symTab$getSymbolObject(code$args[[1]]$name)$nlProc, if it is a name
             if(!identical(code$args[[1]]$sizeExprs$nlProc, typeEnv$return$sizeExprs$nlProc)) stop(exprClassProcessingErrorMsg(code, paste0('nimbleList given in return() argument does not match nimbleList type declared in returnType()')), call. = FALSE)
-        } else {
+        } else { ## check numeric types and nDim
             fail <- FALSE
             if(!identical(code$args[[1]]$type, typeEnv$return$type)) {
-                failMsg <- paste0('Type ', code$args[[1]]$type, ' of the return() argument does not match type ',  typeEnv$return$type, ' given in the returnType() statement (void is default).')
-                fail <- TRUE
+                if(typeEnv$return$nDim > 0) { ## allow scalar casting of returns without error
+                    failMsg <- paste0('Type ', code$args[[1]]$type, ' of the return() argument does not match type ',  typeEnv$return$type, ' given in the returnType() statement (void is default).')
+                    fail <- TRUE
+                }
             }
             if(!identical(code$args[[1]]$nDim, typeEnv$return$nDim)) {
                 failMsg <- paste0( if(exists("failMsg", inherits = FALSE)) paste0(failMsg,' ') else character(),

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -2557,11 +2557,11 @@ sizeReturn <- function(code, symTab, typeEnv) {
     if(!exists('return', env = typeEnv)) stop(exprClassProcessingErrorMsg(code, 'There was no returnType declaration and the default is missing.'), call. = FALSE)
 
     if(length(code$args) == 0) {
-        if(!is.null(typeEnv$returnType$type))
+        if(!identical(typeEnv$return$type, 'void'))
             stop(exprClassProcessingErrorMsg(code, 'return() with no argument can only be used with returnType(void()), which is the default if there is no returnType() statement.'), call. = FALSE)
         return(invisible(NULL))
     }
-    if(is.null(typeEnv$returnType$type))
+    if(identical(typeEnv$return$type, 'void'))
         stop(exprClassProcessingErrorMsg(code, 'returnType was declared void() (default) (or something invalid), which is not consistent with the object you are trying to return.'), call. = FALSE)
     asserts <- recurseSetSizes(code, symTab, typeEnv)
     if(inherits(code$args[[1]], 'exprClass')) {

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -2557,9 +2557,12 @@ sizeReturn <- function(code, symTab, typeEnv) {
     if(!exists('return', env = typeEnv)) stop(exprClassProcessingErrorMsg(code, 'There was no returnType declaration and the default is missing.'), call. = FALSE)
 
     if(length(code$args) == 0) {
-        if(!identical(typeEnv$returnType$type, 'void')) stop(exprClassProcessingErrorMsg(code, 'return() with no argument can only be used with returnType(void()), which is the default if there is no returnType() statement.'), call. = FALSE)
+        if(!is.null(typeEnv$returnType$type))
+            stop(exprClassProcessingErrorMsg(code, 'return() with no argument can only be used with returnType(void()), which is the default if there is no returnType() statement.'), call. = FALSE)
         return(invisible(NULL))
     }
+    if(is.null(typeEnv$returnType$type))
+        stop(exprClassProcessingErrorMsg(code, 'returnType was declared void() (default) (or something invalid), which is not consistent with the object you are trying to return.'), call. = FALSE)
     asserts <- recurseSetSizes(code, symTab, typeEnv)
     if(inherits(code$args[[1]], 'exprClass')) {
 

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -2559,7 +2559,8 @@ sizeReturn <- function(code, symTab, typeEnv) {
         if(typeEnv$return$type == 'nimbleList' || code$args[[1]]$type == 'nimbleList') {
             if(typeEnv$return$type != 'nimbleList') stop(exprClassProcessingErrorMsg(code, paste0('return() argument is a nimbleList but returnType() statement gives a different type')), call. = FALSE)
             if(code$args[[1]]$type != 'nimbleList') stop(exprClassProcessingErrorMsg(code, paste0('returnType statement gives a nimbleList type but return() argument is not the right type')), call. = FALSE)
-            if(!identical(symTab$getSymbolObject(code$args[[1]]$name)$nlProc, typeEnv$return$sizeExprs$nlProc)) stop(exprClassProcessingErrorMsg(code, paste0('nimbleList given in return() argument does not match nimbleList type declared in returnType()')), call. = FALSE)
+            ## equivalent to symTab$getSymbolObject(code$args[[1]]$name)$nlProc, if it is a name
+            if(!identical(code$args[[1]]$sizeExprs$nlProc, typeEnv$return$sizeExprs$nlProc)) stop(exprClassProcessingErrorMsg(code, paste0('nimbleList given in return() argument does not match nimbleList type declared in returnType()')), call. = FALSE)
         } else {
             fail <- FALSE
             if(!identical(code$args[[1]]$type, typeEnv$return$type)) {

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -2557,10 +2557,10 @@ sizeReturn <- function(code, symTab, typeEnv) {
     asserts <- recurseSetSizes(code, symTab, typeEnv)
     if(inherits(code$args[[1]], 'exprClass')) {
 
-        if(inherits(typeEnv$return, 'symbolNimbleListGenerator') || code$args[[1]]$type == 'symbolNimbleList') {
-            if(!inherits(typeEnv$return, 'symbolNimbleListGenerator')) stop(exprClassProcessingErrorMsg(code, paste0('return() argument is a nimbleList but returnType() statement gives a different type')), call. = FALSE)
-            if(!(code$args[[1]]$type == 'symbolNimbleList')) stop(exprClassProcessingErrorMsg(code, paste0('returnType statement gives a nimbleList type but return() argument is not the right type')), call. = FALSE)
-            if(!identical(symTab$getSymbolObject(RHS$name)$nlProc, typeEnv$return$nlProc)) stop(exprClassProcessingErrorMsg(code, paste0('nimbleList given in return() argument does not match nimbleList type declared in returnType()')), call. = FALSE)
+        if(typeEnv$return$type == 'nimbleList' || code$args[[1]]$type == 'nimbleList') {
+            if(typeEnv$return$type != 'nimbleList') stop(exprClassProcessingErrorMsg(code, paste0('return() argument is a nimbleList but returnType() statement gives a different type')), call. = FALSE)
+            if(code$args[[1]]$type != 'nimbleList') stop(exprClassProcessingErrorMsg(code, paste0('returnType statement gives a nimbleList type but return() argument is not the right type')), call. = FALSE)
+            if(!identical(symTab$getSymbolObject(code$args[[1]]$name)$nlProc, typeEnv$return$sizeExprs$nlProc)) stop(exprClassProcessingErrorMsg(code, paste0('nimbleList given in return() argument does not match nimbleList type declared in returnType()')), call. = FALSE)
         } else {
             fail <- FALSE
             if(!identical(code$args[[1]]$type, typeEnv$return$type)) {

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -2576,7 +2576,7 @@ sizeReturn <- function(code, symTab, typeEnv) {
                     fail <- TRUE
                 }
             }
-            if(!identical(code$args[[1]]$nDim, typeEnv$return$nDim)) {
+            if(!isTRUE(all.equal(code$args[[1]]$nDim, typeEnv$return$nDim))) {
                 failMsg <- paste0( if(exists("failMsg", inherits = FALSE)) paste0(failMsg,' ') else character(),
                                   paste0('Number of dimensions ', code$args[[1]]$nDim, ' of the return() argument does not match number ',  typeEnv$return$nDim, ' given in the returnType() statement.'))
                 fail <- TRUE

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -2547,10 +2547,34 @@ sizeUnaryReduction <- function(code, symTab, typeEnv) {
 sizeReturn <- function(code, symTab, typeEnv) {
     if(length(code$args) > 1) stop(exprClassProcessingErrorMsg(code, 'return has argument length > 1.'), call. = FALSE)
     code$toEigenize <- 'no'
-    if(length(code$args) == 0) return(invisible(NULL))
+    if(!exists('return', env = typeEnv)) stop(exprClassProcessingErrorMsg(code, 'There was no returnType declaration and the default is missing.'), call. = FALSE)
+
+    if(length(code$args) == 0) {
+        if(!identical(typeEnv$returnType$type, 'void')) stop(exprClassProcessingErrorMsg(code, 'return() with no argument can only be used with returnType(void()), which is the default if there is no returnType() statement.'), call. = FALSE)
+        return(invisible(NULL))
+    }
     
     asserts <- recurseSetSizes(code, symTab, typeEnv)
     if(inherits(code$args[[1]], 'exprClass')) {
+
+        if(inherits(typeEnv$return, 'symbolNimbleListGenerator') || code$args[[1]]$type == 'symbolNimbleList') {
+            if(!inherits(typeEnv$return, 'symbolNimbleListGenerator')) stop(exprClassProcessingErrorMsg(code, paste0('return() argument is a nimbleList but returnType() statement gives a different type')), call. = FALSE)
+            if(!(code$args[[1]]$type == 'symbolNimbleList')) stop(exprClassProcessingErrorMsg(code, paste0('returnType statement gives a nimbleList type but return() argument is not the right type')), call. = FALSE)
+            if(!identical(symTab$getSymbolObject(RHS$name)$nlProc, typeEnv$return$nlProc)) stop(exprClassProcessingErrorMsg(code, paste0('nimbleList given in return() argument does not match nimbleList type declared in returnType()')), call. = FALSE)
+        } else {
+            fail <- FALSE
+            if(!identical(code$args[[1]]$type, typeEnv$return$type)) {
+                failMsg <- paste0('Type ', code$args[[1]]$type, ' of the return() argument does not match type ',  typeEnv$return$type, ' given in the returnType() statement (void is default).')
+                fail <- TRUE
+            }
+            if(!identical(code$args[[1]]$nDim, typeEnv$return$nDim)) {
+                failMsg <- paste0( if(exists("failMsg", inherits = FALSE)) paste0(failMsg,' ') else character(),
+                                  paste0('Number of dimensions ', code$args[[1]]$nDim, ' of the return() argument does not match number ',  typeEnv$return$nDim, ' given in the returnType() statement.'))
+                fail <- TRUE
+            }
+            if(fail)
+                stop(exprClassProcessingErrorMsg(code, failMsg), call. = FALSE)
+        }
         if(!code$args[[1]]$isName) {
             liftArg <- FALSE
             if(code$args[[1]]$toEigenize == 'yes')

--- a/packages/nimble/R/nimbleFunction_nodeFunctionNew.R
+++ b/packages/nimble/R/nimbleFunction_nodeFunctionNew.R
@@ -137,6 +137,22 @@ nndf_createMethodList <- function(LHS, RHS, altParams, bounds, logProbNodeExpr, 
             boolThisCase <- typesNDims == nDimSupported ## & typesTypes == 'double' ## until (if ever) we have separate handling of integer params, these should be folded in with doubles.  We don't normally have any integer params, because we handle integers as doubles
             paramNamesToUse <- getParamNames(distName)[boolThisCase]
             caseName <- paste0("getParam_",nDimSupported,"D_double")
+
+            ## Special handling needed for dinterval
+            ## Second parameter is a vector but is expected to handle a scalar
+            ## It goes in nDimSupported == 1, but we need it's return type cast to vector
+            ## if it is in fact only a scalar. We do so by wrapping in c() if
+            ## it doesn't any `:` in it
+            if(nDimSupported == 1) {
+                allParams[paramNamesToUse] <- lapply(allParams[paramNamesToUse],
+                                                     function(x) {
+                                                         if(':' %in% all.names(x))
+                                                             x
+                                                         else
+                                                             substitute(c(X), list(X = x))
+                                                     })
+            }
+            
             if(length(paramNamesToUse) > 0)
                 methodList[[caseName]] <- nndf_generateGetParamSwitchFunction(allParams[paramNamesToUse], paramIDs[paramNamesToUse], type = 'double', nDim = nDimSupported)
         }

--- a/packages/nimble/inst/tests/test-returnTypeErrorTrapping.R
+++ b/packages/nimble/inst/tests/test-returnTypeErrorTrapping.R
@@ -1,0 +1,52 @@
+source(system.file(file.path('tests', 'test_utils.R'), package = 'nimble'))
+context('testing return() type error trapping')
+
+## We can use upcoming expect_compiles in the future,
+## but for now I'm doing it more crudely
+
+test_that('return type error caught', {
+    foo <- nimbleFunction(
+        run = function(x = double(1)) {
+            return(x + 1)
+            returnType(integer(1))
+        })
+    cfoo <- try(compileNimble(foo))
+    expect_failure(expect_identical(class(cfoo), "function"))
+})
+
+test_that('return nDim error caught', {
+    foo <- nimbleFunction(
+        run = function(x = double(1)) {
+            return(x + 1)
+            returnType(double(2))
+        })
+    cfoo <- try(compileNimble(foo))
+    expect_failure(expect_identical(class(cfoo), "function"))
+})
+
+test_that('return type and nDim error caught', {
+    foo <- nimbleFunction(
+        run = function(x = double(1)) {
+            return(x + 1)
+            returnType(integer())
+        })
+    cfoo <- try(compileNimble(foo))
+    expect_failure(expect_identical(class(cfoo), "function"))
+})
+
+test_that('nimbleList return type error caught', {
+    nlConf1 <- nimbleList(nlVector = double(1))
+    nlConf2 <- nimbleList(nlVector = double(1)) ## same content, different conf
+    temporarilyAssignInGlobalEnv(nlConf1)
+    temporarilyAssignInGlobalEnv(nlConf2)
+    nf1 <- nimbleFunction(
+        run = function(){
+            l1 <- nlConf1$new()
+            returnType(nlConf2())
+            return(l1)
+        }
+    )    
+    Cnf1 <- try(compileNimble(nf1))
+    expect_failure(expect_identical(class(Cnf1), "function"))
+})
+

--- a/packages/nimble/inst/tests/test-returnTypeErrorTrapping.R
+++ b/packages/nimble/inst/tests/test-returnTypeErrorTrapping.R
@@ -50,3 +50,21 @@ test_that('nimbleList return type error caught', {
     expect_failure(expect_identical(class(Cnf1), "function"))
 })
 
+test_that('void() return passes return type error trapping', {
+    foo <- nimbleFunction(
+        run = function(x = double(1)) {
+            return()
+        })
+    cfoo <- try(compileNimble(foo))
+    expect_success(expect_identical(class(cfoo), "function"))
+})
+
+test_that('return type error caught when non-void object is returned', {
+    foo <- nimbleFunction(
+        run = function(x = double(1)) {
+            return(x)
+            returnType(void())
+        })
+    cfoo <- try(compileNimble(foo))
+    expect_failure(expect_identical(class(cfoo), "function"))
+})


### PR DESCRIPTION
This traps errors where the type or dimensionality of the argument to return() does not match the declared returnType.

It also fixes a bug where the messages from carefully trapped errors in size processing were not being displayed to the user.  That explains some of the frustrations we’ve had with error trapping recently.