### PR TITLE
Re-enable `sort = TRUE` functionality for `model$expandNodeNames()`.

### DIFF
--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -453,7 +453,7 @@ unique: should names be the unique names or should original ordering of nodes (a
 
                                       if(length(nodes) == 0) return(if(returnType=='names') character() else numeric())
                                       graphID <- modelDef$nodeName2GraphIDs(nodes, !returnScalarComponents, unique = unique)
-                                      expandNodeNamesFromGraphIDs(graphID, returnScalarComponents, returnType)
+                                      expandNodeNamesFromGraphIDs(graphID, returnScalarComponents, returnType, sort)
                                       ## if(sort) 
                                       ##     graphID <- sort(graphID)
                                       ## if(returnType == 'names'){

--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -418,7 +418,7 @@ Details: Multiple logical input arguments may be used simultaneously.  For examp
                                       }
                                       return(ans)                                      
                                   },
-expandNodeNamesFromGraphIDs = function(graphID, returnScalarComponents = FALSE, returnType = 'names', sort = FALSE, unique = TRUE) {
+expandNodeNamesFromGraphIDs = function(graphID, returnScalarComponents = FALSE, returnType = 'names', sort = FALSE) {
     if(length(graphID)==0) return(if(returnType=='names') character() else numeric())
     if(sort) 
         graphID <- sort(graphID)


### PR DESCRIPTION
When the `expandNodeNames()` function was revised in #347, the `sort` argument lost its functionality.  This PR simply passes the `sort` argument from the `expandNodeNames()` function into the `expandNodeNamesFromGraphIDs()` function, which should allow nodes to be topologically sorted again.