### PR TITLE
Test OS X on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: r
 sudo: false
 cache: packages
 
-os:
-  - linux
-  - osx
+matrix:
+  include:
+    - os: linux
+    - os: osx
+      env: SKIP_EXPENSIVE_TESTS=TRUE
 
 warnings_are_errors: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: r
+sudo: false
+cache: packages
 
 os:
   - linux
   - osx
-
-sudo: required
 
 warnings_are_errors: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: r
 
+os:
+  - linux
+  - osx
+
 sudo: required
 
 warnings_are_errors: true

--- a/run_tests.R
+++ b/run_tests.R
@@ -10,17 +10,19 @@ cat('SKIPPING', blacklist, sep = '\n  ')
 
 allTests <- list.files('packages/nimble/inst/tests')
 allTests <- allTests[grepl('test-.*\\.R', allTests)]
+allTests <- setdiff(allTests, blacklist)
 
 # Sort tests by duration, running the shortest tests first.
 testTimes <- read.csv('test_times.csv', sep = '\t', header = TRUE, row.names = 'filename')
 for (test in allTests) {
-    if (!(test %in% row.names(testTimes)) && !(test %in% blacklist)) {
+    if (!(test %in% row.names(testTimes))) {
         # Tests without timing data are probably new, so run them first.
         testTimes[test, 'time'] <- 0
     }
 }
 testTimes <- testTimes[order(testTimes),, drop = FALSE]
-allTests <- row.names(testTimes)
+allTests <- intersect(row.names(testTimes), allTests)
+cat('PLANNING TO TEST', allTests, sep = '\n  ')
 
 # Run under /usr/bin/time -v if possible, to gather timing information.
 if (system2('/usr/bin/time', c('-v', 'echo', 'Running under /usr/bin/time -v'))) {

--- a/run_tests.R
+++ b/run_tests.R
@@ -3,6 +3,9 @@
 
 # Avoid running these blacklisted tests, since they take too long.
 blacklist <- c('test-Math2.R', 'test-Mcmc2.R', 'test-Mcmc3.R', 'test-Filtering2.R')
+if(Sys.getenv('SKIP_EXPENSIVE_TESTS') == 'TRUE') {
+    blacklist <- c(blacklist, 'test-mcmc.R', 'test-numericTypes.R')
+}
 
 allTests <- list.files('packages/nimble/inst/tests')
 allTests <- allTests[grepl('test-.*\\.R', allTests)]

--- a/run_tests.R
+++ b/run_tests.R
@@ -6,6 +6,7 @@ blacklist <- c('test-Math2.R', 'test-Mcmc2.R', 'test-Mcmc3.R', 'test-Filtering2.
 if(Sys.getenv('SKIP_EXPENSIVE_TESTS') == 'TRUE') {
     blacklist <- c(blacklist, 'test-mcmc.R', 'test-numericTypes.R')
 }
+cat('SKIPPING', blacklist, sep = '\n  ')
 
 allTests <- list.files('packages/nimble/inst/tests')
 allTests <- allTests[grepl('test-.*\\.R', allTests)]
@@ -22,7 +23,7 @@ testTimes <- testTimes[order(testTimes),, drop = FALSE]
 allTests <- row.names(testTimes)
 
 # Run under /usr/bin/time -v if possible, to gather timing information.
-if (system2('/usr/bin/time', c('-v', 'ls'))) {
+if (system2('/usr/bin/time', c('-v', 'echo', 'Running under /usr/bin/time -v'))) {
     runner <- 'Rscript'
 } else {
     runner <- c('/usr/bin/time', '-v', 'Rscript')
@@ -30,6 +31,8 @@ if (system2('/usr/bin/time', c('-v', 'ls'))) {
 
 # Run each test in a separate process to avoid dll garbage overload.
 for (test in allTests) {
+    cat('--------------------------------------------------------------------------------\n')
+    cat('TESING', test, '\n')
     runViaTestthat <- FALSE  # TODO Fix test-size.R and set this to TRUE.
     if (runViaTestthat) {
         name <- gsub('test-(.*)\\.R', '\\1', test)
@@ -39,6 +42,7 @@ for (test in allTests) {
         command <- c(runner, file.path('packages', 'nimble', 'inst', 'tests', test))
     }
     if(system2(command[1], tail(command, -1))) {
-        stop(paste('Failed', test))
+        stop(paste('FAILED', test))
     }
+    cat('PASSED', test, '\n')
 }

--- a/run_tests.R
+++ b/run_tests.R
@@ -18,17 +18,24 @@ for (test in allTests) {
 testTimes <- testTimes[order(testTimes),, drop = FALSE]
 allTests <- row.names(testTimes)
 
+# Run under /usr/bin/time -v if possible, to gather timing information.
+if (system2('/usr/bin/time', c('-v', 'ls'))) {
+    runner <- 'Rscript'
+} else {
+    runner <- c('/usr/bin/time', '-v', 'Rscript')
+}
+
 # Run each test in a separate process to avoid dll garbage overload.
 for (test in allTests) {
     runViaTestthat <- FALSE  # TODO Fix test-size.R and set this to TRUE.
     if (runViaTestthat) {
         name <- gsub('test-(.*)\\.R', '\\1', test)
         script = paste0('library(methods); library(testthat); library(nimble); test_package("nimble", "', name, '")')
-        commmand <- c('Rscript', '-e', shQuote(script))
+        commmand <- c(runner, '-e', shQuote(script))
     } else {
-        command <- c('Rscript', file.path('packages', 'nimble', 'inst', 'tests', test))
+        command <- c(runner, file.path('packages', 'nimble', 'inst', 'tests', test))
     }
-    if(system2('/usr/bin/time', c('-v', command))) {
+    if(system2(command[1], tail(command, -1))) {
         stop(paste('Failed', test))
     }
 }


### PR DESCRIPTION
Enable both **OS X** and **Linux** builds on travis.

This also sets `sudo: false`, which is required to `cache: packages`, both of which speed up builds. These settings are recommended in the [Travis R documentation](https://docs.travis-ci.com/user/languages/r/).

Since the OS X builds appear to be 30-60 minutes slower than Linux builds, I've disabled the slowest two test files: `test-mcmc.R` and `test-numericTypes.R`, which together take nearly an hour.