### PR TITLE
fix use of predefined nimbleLists

### DIFF
--- a/packages/nimble/R/nimbleProject.R
+++ b/packages/nimble/R/nimbleProject.R
@@ -821,13 +821,16 @@ nimbleProjectClass <- setRefClass('nimbleProjectClass',
                                    if(!is.nl(nl)) stop("Can't instantiateNimbleList, nl is not a nimbleList")
                                    className <- nl$nimbleListDef$className
                                    nlCppDef <- getNimbleListCppDef(generatorName = className)
-                                   ok <- TRUE
+                                     ok <- TRUE
+                                     dllToUse <- if(isTRUE(nl.getDefinitionContent(nl.getGenerator(nl), 'predefined')))
+                                                     nimbleUserNamespace$sessionSpecificDll
+                                                 else dll
                                    if(asTopLevel) {
                                      if(is.null(nlCppDef$Rgenerator)) ok <- FALSE
-                                     else ans <- nlCppDef$Rgenerator(nl, dll = dll, project = .self)
+                                     else ans <- nlCppDef$Rgenerator(nl, dll = dllToUse, project = .self)
                                    } else {
                                      if(is.null(nlCppDef$CmultiInterface)) ok <- FALSE
-                                     else ans <- nlCppDef$CmultiInterface$addInstance(nl, dll = dll)
+                                     else ans <- nlCppDef$CmultiInterface$addInstance(nl, dll = dllToUse)
                                    }
                                    if(!ok) stop("Oops, there is something in this compilation job that doesn\'t fit together.  This can happen in some cases if you are trying to compile new pieces into an exising project.  If that is the situation, please try including \"resetFunctions = TRUE\" as an argument to compileNimble.  Alternatively please try rebuilding the project from the beginning with more pieces in the same call to compileNimble.  For example, if you are compiling multiple algorithms for the same model in multiple calls to compileNimble, try compiling them all with one call.", call. = FALSE) 
                                    ans

--- a/packages/nimble/inst/include/nimble/dynamicRegistrations.h
+++ b/packages/nimble/inst/include/nimble/dynamicRegistrations.h
@@ -11,6 +11,7 @@
 #include <nimble/NamedObjects.h>
 #include <nimble/dllFinalizer.h>
 #include <nimble/smartPtrs.h>
+#include <nimble/predefinedNimbleLists.h>
 
 #include <R_ext/Rdynload.h>
 
@@ -121,6 +122,20 @@ R_CallMethodDef CallEntries[] = {
   FUN(RNimble_Ptr_ManualFinalizer, 1),
   FUN(RNimble_Ptr_CheckAndRunAllDllFinalizers, 2),
   FUN(CountDllObjects, 1),
+
+  // predefinedNimbleList
+  FUN(new_EIGEN_EIGENCLASS, 0),
+  FUN(EIGEN_EIGENCLASS_castPtrPtrToNamedObjectsPtrSEXP, 1),
+  FUN(EIGEN_EIGENCLASS_castDerivedPtrPtrToPairOfPtrsSEXP, 1),
+
+  FUN(new_EIGEN_SVDCLASS, 0),
+  FUN(EIGEN_SVDCLASS_castPtrPtrToNamedObjectsPtrSEXP, 1),
+  FUN(EIGEN_SVDCLASS_castDerivedPtrPtrToPairOfPtrsSEXP, 1),
+
+  FUN(new_OptimResultNimbleList, 0),
+  FUN(OptimResultNimbleList_castPtrPtrToNamedObjectsPtrSEXP, 1),
+  FUN(OptimResultNimbleList_castDerivedPtrPtrToPairOfPtrsSEXP, 1),
+  
   {NULL, NULL, 0}
 };
 


### PR DESCRIPTION
This PR:

1. Adds predefined `nimbleList` `SEXP` functions to dynamicRegistrations.h, so they will be compiled into the `sessionSpecificDll`

2. Updates `nimbleList` interface system to handle the case that the dll where relevant functions are (in a predefined list) may not be the same as the one other parts of a compiled project are in.

Managing the registrations and dlls correctly will be important since CRAN is moving towards enforcement of registration, and we are generally in good shape as we do use registration extensively.