### PR TITLE
Fix silent test failures in test-size.R

### DIFF
--- a/packages/nimble/inst/tests/test-size.R
+++ b/packages/nimble/inst/tests/test-size.R
@@ -474,11 +474,12 @@ testsLHSRHSmismatch <- list(
 )
 
 # for these we simply want errors caught at model-building not compilation
+if(0){
 sapply(testsScalar, test_size)
 sapply(testsMultivarParam, test_size)
 sapply(testsDeterm, test_size)
 sapply(testsMultivar, test_size)
 sapply(testsTrunc, test_size)
-
+}
 # for these we want errors caught by NIMBLE error-checking not by R errors at model-building
 sapply(testsLHSRHSmismatch, test_size_specific_error)

--- a/packages/nimble/inst/tests/test-size.R
+++ b/packages/nimble/inst/tests/test-size.R
@@ -28,21 +28,23 @@ testsScalar <- list(
     list(name = 'scalar stochastic, parameter expression', expectPass = TRUE,
          expr = quote({y ~ dnorm(mu1 + mu2, sd = sig)}), 
          inits = list(mu1 = 0, mu2 = 0, sig = 1) ),
-    list(name = 'scalar stochastic, parameter expression non-scalar, no indices', expectPass = FALSE, expectPassWithConst = TRUE,
-         knownProblem = TRUE,
+    list(name = 'scalar stochastic, parameter expression non-scalar, no indices',
+         expectPass = FALSE, expectPassWithConst = TRUE,
+         knownProblem = TRUE, knownProblemWithConst = FALSE,
          expr = quote({y ~ dnorm(mu1%*%mu2, sd = sig)}), 
          inits = list(mu1 = vec2, mu2 = vec2, sig = 1) ),
     
     list(name = 'scalar stochastic, parameter expression non-scalar, RHS index',
-         expectPass = FALSE,
-         knownProblem = TRUE,
+         expectPass = FALSE, expectPassWithConst = FALSE,
+         knownProblem = TRUE, knownProblemWithConst = FALSE,
          expr = quote({y ~ dnorm((mu1%*%mu2)[1,1], sd = sig)}), 
          inits = list(mu1 = vec2, mu2 = vec2, sig = 1) ),
     # passes for RHS init, though compileNimble does give helpful error message
     # passes for RHS const but fails in compilation because of lack of indexing
     
-    list(name = 'scalar stochastic, parameter expression non-scalar', expectPass = FALSE, expectPassWithConst = TRUE,
-         knownProblem = TRUE,
+    list(name = 'scalar stochastic, parameter expression non-scalar',
+         expectPass = FALSE, expectPassWithConst = TRUE,
+         knownProblem = TRUE, knownProblemWithConst = FALSE,
          expr = quote({y ~ dnorm(mu1[1:2]%*%mu2[1:2], sd = sig)}), 
          inits = list(mu1 = vec2, mu2 = vec2, sig = 1) ),
     # passes when shouldn't for RHS init (compileNimble puts one into a browser)
@@ -57,8 +59,9 @@ testsScalar <- list(
          inits = list(mu1 = mat2, mu2 = vec2, sig = 1) ),
     # gives warning with RHS const
     
-    list(name = 'scalar stochastic, non-scalar parameter, demotion', expectPass = FALSE, expectPassWithConst = TRUE,
-         knownProblem = TRUE,
+    list(name = 'scalar stochastic, non-scalar parameter, demotion',
+         expectPass = FALSE, expectPassWithConst = TRUE,
+         knownProblem = TRUE, knownProblemWithConst = FALSE,
          expr = quote({y ~ dnorm((mu1[1:2, 1:2]%*%mu2[1:2])[1], sd = sig)}), 
          inits = list(mu1 = mat2, mu2 = vec2, sig = 1) ),
     # passes test with RHS inits when it shouldn't, though compileNimble does give helpful error msg; warning with RHS const
@@ -77,8 +80,9 @@ testsScalar <- list(
          inits = list(mu = 0, sig = 1) ),
     # test passes with RHS init and model building is fine, though not clear if we want it to be ok to instantiate a 1x1 matrix with a scalar
 
-    list(name = 'scalar stochastic, scalar within multivar variable 2', expectPass = TRUE,
-         knownProblem = TRUE,
+    list(name = 'scalar stochastic, scalar within multivar variable 2',
+         expectPass = TRUE,
+         knownProblem = FALSE, knownProblemWithConst = TRUE,
          expr = quote({for(i in 1:1)
                            for(j in 1:1)
                                y[i,j] ~ dnorm(mu[i,j], sd = sig)}), 
@@ -97,7 +101,6 @@ testsMultivarParam <- list(
          expr = quote({y ~ dcat(p[1:3])}), 
          inits = list(p = p3) ),
     list(name = 'mv param stochastic, no indices', expectPass = FALSE,
-         knownProblem = TRUE,
          expr = quote({y ~ dcat(p)}), 
          inits = list(p = p3) ),
     # with p as constant ERRORS in compileNimble(); not caught in size check, but replaceConstantsRecurse warning regarding dimensionality is given
@@ -168,16 +171,16 @@ testsDeterm <- list(
                                y[i,j] <- a[i,j] + b}),
          inits = list(a = mat2, b = 3 )),
     
-    list(name = 'deterministic, non-scalar expression, no indices', expectPass = FALSE,
-         expectPassWithConst = TRUE,
-         knownProblem = TRUE,
+    list(name = 'deterministic, non-scalar expression, no indices',
+         expectPass = FALSE, expectPassWithConst = TRUE,
+         knownProblem = TRUE, knownProblemWithConst = FALSE,
          expr = quote({y <- a %*% b}),
          inits = list(a = vec2, b = vec2 )),
     # this compiles fine with RHS const, though warning is given during model building
     
-    list(name = 'deterministic, non-scalar expression', expectPass = FALSE,
-         expectPassWithConst = TRUE,
-         knownProblem = TRUE,
+    list(name = 'deterministic, non-scalar expression',
+         expectPass = FALSE, expectPassWithConst = TRUE,
+         knownProblem = TRUE, knownProblemWithConst = FALSE,
          expr = quote({y <- a[1:2] %*% b[1:2]}),
          inits = list(a = vec2, b = vec2 )),
 
@@ -185,8 +188,9 @@ testsDeterm <- list(
     ## In old system, a[1:2] %*% b[1:2] would be evaluated at model definition time so this would pass
     ## In newNodeFxns, non-scalare constants are not baked in or evaluated, so this does not pass.
     ## KNOWN ISSUE shows correctly as TRUE
-    list(name = 'deterministic, non-scalar expression with LHS indexing', expectPass = FALSE, expectPassWithConst = TRUE,
-         knownProblem = TRUE,
+    list(name = 'deterministic, non-scalar expression with LHS indexing',
+         expectPass = FALSE, expectPassWithConst = TRUE,
+         knownProblem = TRUE, knownProblemWithConst = FALSE,
          expr = quote({y[1] <- a[1:2] %*% b[1:2]}),
          inits = list(a = vec2, b = vec2 )),
     
@@ -194,11 +198,15 @@ testsDeterm <- list(
          expr = quote({y <- (a[1:2] %*% b[1:2])[1]}),
          inits = list(a = vec2, b = vec2 )),
     
-    list(name = 'deterministic, non-scalar expression, dimension mismatch', expectPass = FALSE,
+    list(name = 'deterministic, non-scalar expression, dimension mismatch',
+         expectPass = FALSE,
+         knownProblem = TRUE,
          expr = quote({y <- a[1:2,1:2] %*% b[1:2]}),
          inits = list(a = mat2, b = vec2 )),
 
-    list(name = 'deterministic, vector value, dimension mismatch', expectPass = FALSE,
+    list(name = 'deterministic, vector value, dimension mismatch',
+         expectPass = FALSE,
+         knownProblem = TRUE,
          expr = quote({y[1:2] <- a + b}),
          inits = list(a = 3, b = 3)),
     
@@ -213,26 +221,37 @@ testsDeterm <- list(
          expr = quote({y[1:2] <- a[1:2,1:2] %*% b[1:2]}),
          inits = list(a = mat2, b = vec2 )),
     
-    list(name = 'deterministic, basic vector, missing indices', expectPass = FALSE,
-         knownProblem = TRUE,
+    list(name = 'deterministic, basic vector, missing indices',
+         expectPass = FALSE,
+         knownProblem = TRUE, knownProblemWithConst = FALSE,
          expr = quote({y[1:2] <- a %*% b[1:2]}),
          inits = list(a = mat2, b = vec2 )),
     # passes for RHS inits case, but compileNimble does give useful error msg; 
     # errors for RHS const but not in model_check()
     
-    list(name = 'deterministic, basic vector, dimension mismatch', expectPass = FALSE,
+    list(name = 'deterministic, basic vector, dimension mismatch',
+         expectPass = FALSE,
+         knownProblem = TRUE,
          expr = quote({y[1:2] <- a %*% b}),
          inits = list(a = 3, b = 2 )),
-    list(name = 'deterministic, basic vector, RHS dimension mismatch', expectPass = FALSE,
+    list(name = 'deterministic, basic vector, RHS dimension mismatch',
+         expectPass = FALSE,
+         knownProblem = TRUE,
          expr = quote({y[1:2] <- a[1:2] + b[1:2, 1:2]}),
          inits = list(a = vec2, b = mat2 )),
-    list(name = 'deterministic, basic vector, size mismatch', expectPass = FALSE,
+    list(name = 'deterministic, basic vector, size mismatch',
+         expectPass = FALSE,
+         knownProblem = TRUE,
          expr = quote({y[1:3] <- a[1:2,1:2] %*% b[1:2]}),
          inits = list(a = mat2, b = vec2 )),
-    list(name = 'deterministic, basic vector, size mismatch 2', expectPass = FALSE,
+    list(name = 'deterministic, basic vector, size mismatch 2',
+         expectPass = FALSE,
+         knownProblem = TRUE,
          expr = quote({y[1:2] <- a[1:3,1:3] %*% b[1:3]}),
          inits = list(a = mat3, b = rep(1,3) )),
-    list(name = 'deterministic, basic vector dimension mismatch', expectPass = FALSE,
+    list(name = 'deterministic, basic vector dimension mismatch',
+         expectPass = FALSE,
+         knownProblem = TRUE,
          expr = quote({y[1:3] <- a[1:3,1:3] %*% b[1:3,1:3]}),
          inits = list(a = mat3, b = mat3 )),
     list(name = 'deterministic, basic matrix', expectPass = TRUE,
@@ -263,9 +282,8 @@ testsDeterm <- list(
                  y[1:2, i] <- a[1:2,1:2] %*% b[1:2, 1:2]}),
          inits = list(a = mat2, b = mat2 )),
 
-    ## Used to generate KNOWN ISSUE, not any more
-    list(name = 'deterministic, nodes within multivar variables, input wrong dimension', expectPass = FALSE,
-         knownProblem = TRUE,
+    list(name = 'deterministic, nodes within multivar variables, input wrong dimension',
+         expectPass = FALSE,
          expr = quote({
              for(i in 1:1)
                  y[1:2, i] <- a[1:2,1:2] %*% b[1:2, 1:2]}),
@@ -295,7 +313,6 @@ testsMultivar <- list(
          }),
          inits = list(mu = vec2, prec = mat2)),
     list(name = 'multivar, param missing index', expectPass = FALSE,
-         knownProblem = TRUE,
          expr = quote({
                  y[1:2] ~ dmnorm(mu, prec[1:2, 1:2])
          }),

--- a/packages/nimble/inst/tests/test-size.R
+++ b/packages/nimble/inst/tests/test-size.R
@@ -474,12 +474,11 @@ testsLHSRHSmismatch <- list(
 )
 
 # for these we simply want errors caught at model-building not compilation
-if(0){
 sapply(testsScalar, test_size)
 sapply(testsMultivarParam, test_size)
 sapply(testsDeterm, test_size)
 sapply(testsMultivar, test_size)
 sapply(testsTrunc, test_size)
-}
+
 # for these we want errors caught by NIMBLE error-checking not by R errors at model-building
 sapply(testsLHSRHSmismatch, test_size_specific_error)

--- a/packages/nimble/inst/tests/test_utils.R
+++ b/packages/nimble/inst/tests/test_utils.R
@@ -821,13 +821,12 @@ test_size <- function(input, verbose = TRUE) {
 
 # could redo test_size to always expect specific error, but not taking time to do that now
 test_size_specific_error <- function(input, verbose = TRUE) {
-    errorMsg <- paste0(ifelse(input$knownProblem, "KNOWN ISSUE: ", ""), "Result does not match ", input$expectPass)
     if(verbose) cat("### Testing", input$name, "###\n")
-    try(test_that(paste0("Test 1 of size/dimension check: ", input$name),
-                  expect_error(
-                      m <- nimbleModel(code = input$expr, data = input$data, inits = input$inits),
-                      regexp = input$correctErrorMsg,
-                      info = errorMsg)))    
+    test_that(paste0("Test 1 of size/dimension check: ", input$name), {
+        expect_error(nimbleModel(code = input$expr, data = input$data, inits = input$inits),
+                     regexp = input$correctErrorMsg, info = paste("Result does not match", input$expectPass))
+    })
+
     invisible(NULL)
 }
 

--- a/packages/nimble/inst/tests/test_utils.R
+++ b/packages/nimble/inst/tests/test_utils.R
@@ -18,6 +18,23 @@ system.in.dir <- function(cmd, dir = '.') {
         system(cmd)
 }
 
+## Use this function to mark tests as known failures, e.g.
+## ```r
+##   test_that('This test is known to fail', {
+##       KNOWN_FAILURE('due to Eigen issue')
+##       # Rest of testing code here...
+##   })
+## ```
+## To run all tests including KNOWN_FAILURES, set an environment variable, e.g.
+## ```sh
+##   RUN_KNOWN_FAILURES=true Rscript nimble/inst/tests/test-sizes.R
+## ```
+KNOWN_FAILURE <- function(...) {
+    if(length(Sys.getenv('RUN_KNOWN_FAILURES')) == 0) {
+        skip(paste('Skipping KNOWN_FAILURE', ...))
+    }
+}
+
 ## This is useful for working around scoping issues with nimbleFunctions using other nimbleFunctions.
 temporarilyAssignInGlobalEnv <- function(value) {
     name <- deparse(substitute(value))

--- a/packages/nimble/inst/tests/test_utils.R
+++ b/packages/nimble/inst/tests/test_utils.R
@@ -798,10 +798,12 @@ test_size <- function(input, verbose = TRUE) {
         calculate(m)  ## Calculates from scratch.
         calculate(m)  ## Uses cached value.
     })
+    message = paste(input$name, 'with RHS', ifelse(input$expectPass, 'works', 'fails'), 'as expected')
+    if (input$knownProblem) message = paste(message, 'marked as KNOWN ISSUE')
     if(xor(input$expectPass, input$knownProblem)) {
-        test_that(paste(input$name, 'with RHS variable works as expected'), eval(code))
+        test_that(message, eval(code))
     } else {
-        test_that(paste(input$name, 'with RHS variable fails as expected'), expect_error(eval(code)))
+        test_that(message, expect_error(eval(code)))
     }
 
     if(verbose) cat("### Testing", input$name, "with RHS constant ###\n")
@@ -810,10 +812,12 @@ test_size <- function(input, verbose = TRUE) {
         calculate(m)  ## Calculates from scratch.
         calculate(m)  ## Uses cached value.
     })
+    message = paste(input$name, 'with RHS', ifelse(input$expectPassWithConst, 'works', 'fails'), 'as expected')
+    if (input$knownProblemWithConst) message = paste(message, 'marked as KNOWN ISSUE')
     if(xor(input$expectPassWithConst, input$knownProblemWithConst)) {
-        test_that(paste(input$name, 'with RHS constant works as expected'), eval(code))
+        test_that(message, eval(code))
     } else {
-        test_that(paste(input$name, 'with RHS constant fails as expected'), expect_error(eval(code)))
+        test_that(message, expect_error(eval(code)))
     }
 
     invisible(NULL)

--- a/run_tests.R
+++ b/run_tests.R
@@ -20,7 +20,7 @@ allTests <- row.names(testTimes)
 
 # Run each test in a separate process to avoid dll garbage overload.
 for (test in allTests) {
-    runViaTestthat <- TRUE  # TODO Fix test-size.R and set this to TRUE.
+    runViaTestthat <- FALSE  # TODO Fix test-size.R and set this to TRUE.
     if (runViaTestthat) {
         name <- gsub('test-(.*)\\.R', '\\1', test)
         script = paste0('library(methods); library(testthat); library(nimble); test_package("nimble", "', name, '")')

--- a/run_tests.R
+++ b/run_tests.R
@@ -20,11 +20,11 @@ allTests <- row.names(testTimes)
 
 # Run each test in a separate process to avoid dll garbage overload.
 for (test in allTests) {
-    runViaTestthat <- FALSE  # TODO Fix test-size.R and set this to TRUE.
+    runViaTestthat <- TRUE  # TODO Fix test-size.R and set this to TRUE.
     if (runViaTestthat) {
         name <- gsub('test-(.*)\\.R', '\\1', test)
         script = paste0('library(methods); library(testthat); library(nimble); test_package("nimble", "', name, '")')
-        commmand <- c('Rscript', '-e', shQuote(script))
+        command <- c('Rscript', '-e', shQuote(script))
     } else {
         command <- c('Rscript', file.path('packages', 'nimble', 'inst', 'tests', test))
     }


### PR DESCRIPTION
This addresses #363 and #395 by avoding the `try(test_that())` idiom in the helper functions `test_size()` and `test_size_specific_error()`. This fix surfaced a few new failures and a few previous failures that have silently been fixed.

@paciorek After this PR it should no longer be necessary to compare the text outputs against a golden file.
 any change will be considered an error (both pass-to-fail and fail-to-pass). All changes will need to be accounted for in the `knownProblem` arguments. But at least we're more automated :smile: .

Note that the automated checking against golden `knownProblem` values required splitting that flag into a finer-grained pair of flags `knownProblem` and `knownProblemWithConst`.