### PR TITLE
put all of `test_math` inside `test_that` and remove `try()`s

### DIFF
--- a/packages/nimble/inst/tests/test-math.R
+++ b/packages/nimble/inst/tests/test-math.R
@@ -198,16 +198,16 @@ testsMatrix = list(
 
 
 set.seed(0)
-sapply(testsVaried, test_math)    ## 12
-sapply(testsBasicMath, test_math) ## 70
+ans1 <- sapply(testsVaried, test_math)    ## 12
+ans2 <- sapply(testsBasicMath, test_math) ## 70
 if(.Platform$OS.type == 'windows') {
     message("Since you are running on Windows, tests stopped prior to reaching max DLL limit.  Please use test-math2 to continue")
     stop()
 }
-sapply(testsMoreMath, test_math)  ## 41
-sapply(testsReduction, test_math) ## 13
-sapply(testsComparison, test_math)## 6
-sapply(testsMatrix, test_math)    ## 19
+ans3 <- sapply(testsMoreMath, test_math)  ## 41
+ans4 <- sapply(testsReduction, test_math) ## 13
+ans5 <- sapply(testsComparison, test_math)## 6
+ans6 <- sapply(testsMatrix, test_math)    ## 19
 
 
 

--- a/packages/nimble/inst/tests/test_utils.R
+++ b/packages/nimble/inst/tests/test_utils.R
@@ -183,6 +183,11 @@ make_input <- function(dim, size = 3, logicalArg) {
 }
 
 test_math <- function(input, verbose = TRUE, size = 3, dirName = NULL) {
+    test_that(input$name, {
+        test_math_internal(input, verbose, size, dirName)
+    })
+}
+test_math_internal <- function(input, verbose = TRUE, size = 3, dirName = NULL) {
   if(verbose) cat("### Testing", input$name, "###\n")
   runFun <- gen_runFun(input)
   nfR <- nimbleFunction(  
@@ -222,12 +227,10 @@ test_math <- function(input, verbose = TRUE, size = 3, dirName = NULL) {
   attributes(out) <- attributes(out_nfR) <- attributes(out_nfC) <- NULL
   if(is.logical(out)) out <- as.numeric(out)
   if(is.logical(out_nfR)) out_nfR <- as.numeric(out_nfR)
-  try(test_that(paste0("Test of math (direct R calc vs. R nimbleFunction): ", input$name),
-                expect_equal(out, out_nfR)))
-  try(test_that(paste0("Test of math (direct R calc vs. C nimbleFunction): ", input$name),
-                expect_equal(out, out_nfC)))
+  expect_equal(out, out_nfR, info = paste0("Test of math (direct R calc vs. R nimbleFunction): ", input$name))
+  expect_equal(out, out_nfC, info = paste0("Test of math (direct R calc vs. C nimbleFunction): ", input$name))
   # unload DLL as R doesn't like to have too many loaded
-  if(.Platform$OS.type != 'windows') nimble:::clearCompiled(nfR) ##dyn.unload(project$cppProjects[[1]]$getSOName())
+  if(.Platform$OS.type != 'windows') nimble:::clearCompiled(nfR)
   invisible(NULL)
 }
 


### PR DESCRIPTION
This PR updates `test_math`, used by `test-math.R`, so all steps are inside `test_that` and `try(expect_<condition>(…))` idioms are removed.