### PR TITLE
Enable codecov reporting on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,10 @@ r_packages:
   - abind    # needed for test-compareMCMCs.R
   - covr     # needed for code coverage reports
 
-install:
+script:
   - R CMD build packages/nimble
   - R CMD INSTALL packages/nimble
-
-script: ./run_tests.R
+  - ./run_tests.R
 
 after_success:
   - Rscript -e 'library(covr); if(R.version$os == "linux-gnu") codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: r
-
-sudo: required
+sudo: false
+cache: packages
 
 warnings_are_errors: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,19 @@ branches:
   only:
     - devel
 
+r_packages:
+  - igraph
+  - coda
+  - testthat
+  - mvtnorm  # needed for test-distributions.R
+  - abind    # needed for test-compareMCMCs.R
+  - covr     # needed for code coverage reports
+
 install:
-##  - Rscript -e "install.packages('devtools', repos = 'http://cran.us.r-project.org')"
-  - Rscript -e "install.packages('igraph', repos = 'http://cran.us.r-project.org')"
-  - Rscript -e "install.packages('coda', repos = 'http://cran.us.r-project.org')"
-  - Rscript -e "install.packages('testthat', repos = 'http://cran.us.r-project.org')"
-  - Rscript -e "install.packages('mvtnorm', repos = 'http://cran.us.r-project.org')"  ## needed for test-distributions.R
-  - Rscript -e "install.packages('abind', repos = 'http://cran.us.r-project.org')"    ## needed for test-compareMCMCs.R
   - R CMD build packages/nimble
   - R CMD INSTALL packages/nimble
 
 script: ./run_tests.R
 
+after_success:
+  - Rscript -e 'library(covr); if(R.version$os == "linux-gnu") codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,18 +21,17 @@ branches:
   only:
     - devel
 
-r_packages:
-  - igraph
-  - coda
-  - testthat
-  - mvtnorm  # needed for test-distributions.R
-  - abind    # needed for test-compareMCMCs.R
-  - covr     # needed for code coverage reports
-
-script:
+install:
+  - Rscript -e "install.packages('igraph', repos = 'http://cran.us.r-project.org')"
+  - Rscript -e "install.packages('coda', repos = 'http://cran.us.r-project.org')"
+  - Rscript -e "install.packages('testthat', repos = 'http://cran.us.r-project.org')"
+  - Rscript -e "install.packages('mvtnorm', repos = 'http://cran.us.r-project.org')"  ## needed for test-distributions.R
+  - Rscript -e "install.packages('abind', repos = 'http://cran.us.r-project.org')"    ## needed for test-compareMCMCs.R
+  - Rscript -e "install.packages('covr', repos = 'http://cran.us.r-project.org')"  ## needed for code coverage reports
   - R CMD build packages/nimble
   - R CMD INSTALL packages/nimble
-  - ./run_tests.R
+
+script: ./run_tests.R
 
 after_success:
   - Rscript -e 'library(covr); if(R.version$os == "linux-gnu") codecov()'

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ NIMBLE
 ======
 
 [![Build Status](https://travis-ci.org/nimble-dev/nimble.svg?branch=devel)](https://travis-ci.org/nimble-dev/nimble)
+[![Coverage](https://codecov.io/github/nimble-dev/nimble/branch/devel/graphs/badge.svg)](https://codecov.io/github/nimble-dev/nimble) 
 [![CRAN](http://www.r-pkg.org/badges/version/nimble)](https://cran.r-project.org/web/packages/nimble)
-[![Rdoc](http://www.rdocumentation.org/badges/version/nimble)](http://www.rdocumentation.org/packages/nimble)
 
 NIMBLE is an R package for programming with BUGS models and compiling parts of R.
 


### PR DESCRIPTION
**Status:** Do not merge.

This enables R code coverage reporting on the travis linux build.