### PR TITLE
set checkEqual=TRUE for "index assignment from boolean vector 2 (2D, mixed types)"

### DIFF
--- a/packages/nimble/inst/tests/test-coreR.R
+++ b/packages/nimble/inst/tests/test-coreR.R
@@ -713,7 +713,7 @@ logicalTests <- list(
          expr = quote({out <- matrix(rep(100, length(arg1)), nrow = dim(arg1)[1]); out[arg2 < 5, 30:40] <- (arg1[arg2 < 5, 30:40]^2) + 1}),
          args = list(arg1 = quote(double(2)), arg2 = quote(double(1))),
          setArgVals = quote({arg1 <- matrix(seq(1, 8, length = 10000), nrow = 100); arg2 <- seq(2, 9, length = 100)}),
-         outputType = quote(double(2)))
+         outputType = quote(double(2)), checkEqual = TRUE)
 )
 
 returnTests <- list(

--- a/packages/nimble/inst/tests/test_utils.R
+++ b/packages/nimble/inst/tests/test_utils.R
@@ -146,10 +146,10 @@ test_coreRfeature_internal <- function(input, verbose = TRUE, dirName = NULL) { 
   if(is.null(input[['return']])) { ## use default 'out' object
       if(!checkEqual) {
           expect_identical(out, out_nfR, info = paste0("Identical test of coreRfeature (direct R vs. R nimbleFunction): ", input$name))
-          expect_identical(out, out_nfC, info = paste0("Identical test of math (direct R vs. C++ nimbleFunction): ", input$name))
+          expect_identical(out, out_nfC, info = paste0("Identical test of coreRfeature (direct R vs. C++ nimbleFunction): ", input$name))
       } else {
           expect_equal(out, out_nfR, info = paste0("Equal test of coreRfeature (direct R vs. R nimbleFunction): ", input$name) )
-          expect_equal(out, out_nfC, info = paste0("Equal test of math (direct R vs. C++ nimbleFunction): ", input$name))
+          expect_equal(out, out_nfC, info = paste0("Equal test of coreRfeature (direct R vs. C++ nimbleFunction): ", input$name))
       }
   } else { ## not using default return(out), so only compare out_nfR to out_nfC
       if(!checkEqual) {


### PR DESCRIPTION
This single test in test-coreR works with check_identical on my machine but appears to need to be check_equal on Travis’ OS X.  It was newly revealed by adding OS X testing on Travis.