### PR TITLE
Avoid installing latex on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ branches:
   only:
     - devel
 
+latex: false  # Work around tlmgr issues.
+
 install:
   - Rscript -e "install.packages('igraph', repos = 'http://cran.us.r-project.org')"
   - Rscript -e "install.packages('coda', repos = 'http://cran.us.r-project.org')"


### PR DESCRIPTION
**Status:** Merge either this or #419 (not both)

This attempts to avoid the `tlmgr` issue with recent travis builds:
```
$ tlmgr update --self
TeX Live 2016 is frozen forever and will no
longer be updated.  This happens in preparation for a new release.
If you're interested in helping to pretest the new release (when
pretests are available), please read http://tug.org/texlive/pretest.html.
Otherwise, just wait, and the new release will be ready in due time.
tlmgr: package repository http://ctan.sharelatex.com/tex-archive/systems/texlive/tlnet (verified)
tlmgr: saving backups to /home/travis/texlive/tlpkg/backups
TLUtils::check_file: removing /tmp/w5DZjHHDo5/ZHBmIwn3W4/texlive.infra.tar.xz, sizes differ:
TLUtils::check_file:   TL=200472, arg=194264
TLPDB::_install_package: downloading did not succeed
tlmgr: Installation of new version of texlive.infra failed, trying to unwind.
[1/1, ??:??/??:??] update: texlive.infra [190k] (41280 -> 41476) ... tlmgr: Restoring old package state succeeded.
done
tlmgr: action update returned an error; continuing.
tlmgr: package log updated: /home/travis/texlive/texmf-var/web2c/tlmgr.log
tlmgr: An error has occurred. See above messages. Exiting.
The command "tlmgr update --self" failed and exited with 1 during .
```
as recommended by https://docs.travis-ci.com/user/languages/r/