### PR TITLE
Fix filter regex used to specify tests in run_tests.R

### DIFF
--- a/run_tests.R
+++ b/run_tests.R
@@ -38,7 +38,7 @@ for (test in allTests) {
     runViaTestthat <- TRUE
     if (runViaTestthat) {
         name <- gsub('test-(.*)\\.R', '\\1', test)
-        script = paste0('library(methods); library(testthat); library(nimble); test_package("nimble", "', name, '")')
+        script = paste0('library(methods); library(testthat); library(nimble); test_package("nimble", "^', name, '$")')
         command <- c(runner, '-e', shQuote(script))
     } else {
         command <- c(runner, file.path('packages', 'nimble', 'inst', 'tests', test))


### PR DESCRIPTION
This problem was surfaced by @NLMichaud when adding a test to the blacklist.