### PR TITLE
test_coreRfeature_batch, like test_coreRfeature for batches

### DIFF
--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -927,7 +927,8 @@ Checks for size/dimension mismatches and for presence of NAs in model variables 
                                           if(!nimble:::isValid(.self[[v]]))
                                               varsWithNAs <- c(varsWithNAs, v)
                                       if(!is.null(varsWithNAs))
-                                          message(' note that missing values (NAs) or non-finite values were found in model variables: ', paste(varsWithNAs, collapse = ', '), '. This is not an error, but some or all variables may need to be initialized for certain algorithms to operate properly.', appendLF = FALSE)
+                                          if(isTRUE(nimbleOptions('verbose')))
+                                              message(' note that missing values (NAs) or non-finite values were found in model variables: ', paste(varsWithNAs, collapse = ', '), '. This is not an error, but some or all variables may need to be initialized for certain algorithms to operate properly.', appendLF = FALSE)
                                   },
 
                                   check = function() {

--- a/packages/nimble/inst/tests/test-allocation.R
+++ b/packages/nimble/inst/tests/test-allocation.R
@@ -3,14 +3,18 @@
 library(nimble)
 source(system.file(file.path('tests', 'test_utils.R'), package = 'nimble'))
 
+RwarnLevel <- options('warn')$warn
+options(warn = -1)
+nimbleVerboseSetting <- nimbleOptions('verbose')
+nimbleOptions(verbose = TRUE)
+
 
 numericTests <- list(
     list(name = 'numeric: length',
          expr = quote(out <- numeric(5)),
          outputType = quote(double(1) ),
          args = list(),
-         setArgVals = quote({}),
-         safeCompilerFail = FALSE
+         setArgVals = quote({})
          ),
     list(name = 'numeric: length 0',
          expr = quote({
@@ -26,8 +30,7 @@ numericTests <- list(
          expr = quote(out <- nimNumeric(5, value = 2, recycle = FALSE, fillZeros = TRUE)),
          outputType = quote(double(1) ),
          args = list(),
-         setArgVals = quote({}),
-         safeCompilerFail = FALSE
+         setArgVals = quote({})
          ),
     list(name = 'numeric: length, scalar value, init=FALSE',
          expr = quote({out <- nimNumeric(5, value = 1.5, init = FALSE);
@@ -47,22 +50,6 @@ numericTests <- list(
              out <- nimNumeric(sum(a) + 1, value = mean(b) + 0.5, init = (c > 2)[4]);
          }),
          outputType = quote(double(1))
-         ),
-    list(name = 'numeric: fail for length given as vector',
-         expr = quote({
-             a <- 2:4
-             out <- nimNumeric(a, value = 1.5);
-         }),
-         outputType = quote(double(1)),
-         safeCompilerFail = TRUE
-         ),
-    list(name = 'numeric: fail for init given as vector',
-         expr = quote({
-             b <- c(TRUE, FALSE, TRUE)
-             out <- nimNumeric(3, value = 1.5, init = b);
-         }),
-         outputType = quote(double(1)),
-         safeCompilerFail = TRUE
          ),
     list(name = 'numeric: length, vector value',
          expr = quote({
@@ -113,8 +100,7 @@ integerTests <- list(
          expr = quote(out <- integer(5)),
          outputType = quote(integer(1) ),
          args = list(),
-         setArgVals = quote({}),
-         safeCompilerFail = FALSE
+         setArgVals = quote({})
          ),
     list(name = 'integer: length, scalar value',
          expr = quote(out <- nimInteger(5, value = 1.5)),
@@ -124,8 +110,7 @@ integerTests <- list(
          expr = quote(out <- nimInteger(5, value = 2, recycle = FALSE, fillZeros = TRUE)),
          outputType = quote(integer(1) ),
          args = list(),
-         setArgVals = quote({}),
-         safeCompilerFail = FALSE
+         setArgVals = quote({})
          ),
     list(name = 'integer: length, scalar value, init=FALSE',
          expr = quote({out <- nimInteger(5, value = 1.5, init = FALSE);
@@ -147,22 +132,6 @@ integerTests <- list(
              out <- nimInteger(sum(a) + 1, value = round(mean(b)), init = (c > 2)[4]);
          }),
          outputType = quote(integer(1))
-         ),
-    list(name = 'integer: fail for length given as vector',
-         expr = quote({
-             a <- 2:4
-             out <- nimInteger(a, value = 15);
-         }),
-         outputType = quote(integer(1)),
-         safeCompilerFail = TRUE
-         ),
-    list(name = 'integer: fail for init given as vector',
-         expr = quote({
-             b <- c(TRUE, FALSE, TRUE)
-             out <- nimInteger(3, value = 15, init = b);
-         }),
-         outputType = quote(integer(1)),
-         safeCompilerFail = TRUE
          ),
     list(name = 'integer: length, vector value',
          expr = quote({
@@ -213,8 +182,7 @@ logicalTests <- list(
          expr = quote(out <- logical(5)),
          outputType = quote(logical(1) ),
          args = list(),
-         setArgVals = quote({}),
-         safeCompilerFail = FALSE
+         setArgVals = quote({})
          ),
     list(name = 'logical: length, scalar value',
          expr = quote(out <- nimLogical(5, value = 1.5)),
@@ -224,8 +192,7 @@ logicalTests <- list(
          expr = quote(out <- nimLogical(5, value = TRUE, recycle = FALSE, fillZeros = TRUE)),
          outputType = quote(logical(1) ),
          args = list(),
-         setArgVals = quote({}),
-         safeCompilerFail = FALSE
+         setArgVals = quote({})
          ),
     list(name = 'logical: length, scalar value, init=FALSE',
          expr = quote({out <- nimLogical(5, value = FALSE, init = FALSE);
@@ -245,22 +212,6 @@ logicalTests <- list(
              out <- nimLogical(sum(a) + 1, value = mean(b) > 0, init = (c > 2)[4]);
          }),
          outputType = quote(logical(1))
-         ),
-    list(name = 'logical: fail for length given as vector',
-         expr = quote({
-             a <- 2:4
-             out <- nimLogical(a, value = TRUE);
-         }),
-         outputType = quote(logical(1)),
-         safeCompilerFail = TRUE
-         ),
-    list(name = 'logical: fail for init given as vector',
-         expr = quote({
-             b <- c(TRUE, FALSE, TRUE)
-             out <- nimLogical(3, value = TRUE, init = b);
-         }),
-         outputType = quote(logical(1)),
-         safeCompilerFail = TRUE
          ),
     list(name = 'logical: length, vector value',
          expr = quote({
@@ -475,14 +426,6 @@ arrayTests1D <- list(
          }),
          outputType = quote(double(1))
          ),
-    list(name = 'array 1D (dim vector without nDim: safe compiler fail)',
-         expr = quote({
-             dim <- c(2)
-             out <- nimArray(6, dim = dim);
-         }),
-         outputType = quote(double(1)),
-         safeCompilerFail = TRUE
-         ),
     list(name = 'array 1D (dim vector)',
          expr = quote({
              dim <- c(2)
@@ -557,14 +500,6 @@ arrayTests3D <- list(
              out <- nimArray(1.23, dim = c(2, 3, 4), fillZeros = TRUE, recycle = FALSE);
          }),
          outputType = quote(double(3))
-         ),
-    list(name = 'array 3D (dim vector without nDim: safe compiler fail)',
-         expr = quote({
-             dim <- c(2, 3, 4)
-             out <- nimArray(6, dim = dim);
-         }),
-         outputType = quote(double(3)),
-         safeCompilerFail = TRUE
          ),
     list(name = 'array 3D (dim vector)',
          expr = quote({
@@ -654,14 +589,6 @@ arrayTests2D <- list(
              out <- nimArray(1.23, dim = c(2, 3), fillZeros = TRUE, recycle = FALSE);
          }),
          outputType = quote(double(2))
-         ),
-    list(name = 'array 2D (dim vector without nDim: safe compiler fail)',
-         expr = quote({
-             dim <- c(2, 3)
-             out <- nimArray(6, dim = dim);
-         }),
-         outputType = quote(double(2)),
-         safeCompilerFail = TRUE
          ),
     list(name = 'array 2D (dim vector)',
          expr = quote({
@@ -914,14 +841,94 @@ setSize3D <- list(
          )
     )
 
-numericTestResults <- lapply(numericTests, test_coreRfeature)
-numericTestResults <- lapply(integerTests, test_coreRfeature)
-logicalTestResults <- lapply(logicalTests, test_coreRfeature)
-matrixTestResults <- lapply(matrixTests, test_coreRfeature)
-array1DTestResults <- lapply(arrayTests1D, test_coreRfeature)
-array2DTestResults <- lapply(arrayTests2D, test_coreRfeature)
-array3DTestResults <- lapply(arrayTests3D, test_coreRfeature)
-setSize1DResults <- lapply(setSize1D, test_coreRfeature)
-setSize1DintegerResults <- lapply(setSize1Dinteger, test_coreRfeature)
-setSize2DResults <- lapply(setSize2D, test_coreRfeature)
-setSize3DResults <- lapply(setSize3D, test_coreRfeature)
+expectedCompilerFailures <- list(
+    list(name = 'numeric: fail for length given as vector',
+         expr = quote({
+             a <- 2:4
+             out <- nimNumeric(a, value = 1.5);
+         }),
+         outputType = quote(double(1)),
+         safeCompilerFail = TRUE
+         ),
+    list(name = 'numeric: fail for init given as vector',
+         expr = quote({
+             b <- c(TRUE, FALSE, TRUE)
+             out <- nimNumeric(3, value = 1.5, init = b);
+         }),
+         outputType = quote(double(1)),
+         safeCompilerFail = TRUE
+         ),
+    list(name = 'integer: fail for length given as vector',
+         expr = quote({
+             a <- 2:4
+             out <- nimInteger(a, value = 15);
+         }),
+         outputType = quote(integer(1)),
+         safeCompilerFail = TRUE
+         ),
+    list(name = 'integer: fail for init given as vector',
+         expr = quote({
+             b <- c(TRUE, FALSE, TRUE)
+             out <- nimInteger(3, value = 15, init = b);
+         }),
+         outputType = quote(integer(1)),
+         safeCompilerFail = TRUE
+         ),
+    list(name = 'logical: fail for length given as vector',
+         expr = quote({
+             a <- 2:4
+             out <- nimLogical(a, value = TRUE);
+         }),
+         outputType = quote(logical(1)),
+         safeCompilerFail = TRUE
+         ),
+    list(name = 'logical: fail for init given as vector',
+         expr = quote({
+             b <- c(TRUE, FALSE, TRUE)
+             out <- nimLogical(3, value = TRUE, init = b);
+         }),
+         outputType = quote(logical(1)),
+         safeCompilerFail = TRUE
+         ),
+    list(name = 'array 1D (dim vector without nDim: safe compiler fail)',
+         expr = quote({
+             dim <- c(2)
+             out <- nimArray(6, dim = dim);
+         }),
+         outputType = quote(double(1)),
+         safeCompilerFail = TRUE
+         ),
+    list(name = 'array 3D (dim vector without nDim: safe compiler fail)',
+         expr = quote({
+             dim <- c(2, 3, 4)
+             out <- nimArray(6, dim = dim);
+         }),
+         outputType = quote(double(3)),
+         safeCompilerFail = TRUE
+         ),
+    list(name = 'array 2D (dim vector without nDim: safe compiler fail)',
+         expr = quote({
+             dim <- c(2, 3)
+             out <- nimArray(6, dim = dim);
+         }),
+         outputType = quote(double(2)),
+         safeCompilerFail = TRUE
+         )
+    )
+
+numericTestResults <- test_coreRfeature_batch(numericTests, 'numericTests') ## lapply(numericTests, test_coreRfeature)
+numericTestResults <- test_coreRfeature_batch(integerTests, 'integerTests') ## lapply(integerTests, test_coreRfeature)
+logicalTestResults <- test_coreRfeature_batch(logicalTests, 'logicalTests') ## lapply(logicalTests, test_coreRfeature)
+matrixTestResults <- test_coreRfeature_batch(matrixTests, 'matrixTests') ## lapply(matrixTests, test_coreRfeature)
+array1DTestResults <- test_coreRfeature_batch(arrayTests1D, 'arrayTests1D') ## lapply(arrayTests1D, test_coreRfeature)
+array2DTestResults <- test_coreRfeature_batch(arrayTests2D, 'arrayTests2D') ## lapply(arrayTests2D, test_coreRfeature)
+array3DTestResults <- test_coreRfeature_batch(arrayTests3D, 'arrayTests3D') ## lapply(arrayTests3D, test_coreRfeature)
+setSize1DResults <- test_coreRfeature_batch(setSize1D, 'setSize1D') ## lapply(setSize1D, test_coreRfeature)
+setSize1DintegerResults <- test_coreRfeature_batch(setSize1Dinteger, 'setSize1Dinteger') ## lapply(setSize1Dinteger, test_coreRfeature)
+setSize2DResults <- test_coreRfeature_batch(setSize2D, 'setSize2D') ## lapply(setSize2D, test_coreRfeature)
+setSize3DResults <- test_coreRfeature_batch(setSize3D, 'setSize3D') ## lapply(setSize3D, test_coreRfeature)
+
+allocationExpectedCompilerFailures <- lapply(expectedCompilerFailures, test_coreRfeature)
+
+options(warn = RwarnLevel)
+nimbleOptions(verbose = nimbleVerboseSetting)

--- a/packages/nimble/inst/tests/test-coreR.R
+++ b/packages/nimble/inst/tests/test-coreR.R
@@ -2,6 +2,12 @@
 source(system.file(file.path('tests', 'test_utils.R'), package = 'nimble'))
 context("Testing of core R functions in NIMBLE code")
 
+RwarnLevel <- options('warn')$warn
+options(warn = -1)
+nimbleVerboseSetting <- nimbleOptions('verbose')
+nimbleOptions(verbose = TRUE)
+
+
 ## fix result_type in nimbleEigen.h
 
 cTests <- list(
@@ -755,17 +761,17 @@ returnTests <- list(
          outputType = quote(double(1))) 
 )
 
-cTestsResults <- lapply(cTests, test_coreRfeature)
-blockTestsResults <- lapply(blockTests, test_coreRfeature)
-repTestsResults <- lapply(repTests, test_coreRfeature)
-diagTestsResults <- lapply(diagTests, test_coreRfeature)
-recyclingRuleTestsResults <- lapply(recyclingRuleTests, test_coreRfeature)
-rRecyclingRuleTestsResults <- lapply(rRecyclingRuleTests, test_coreRfeature)
-seqTestsResults <- lapply(seqTests, test_coreRfeature)
-nonSeqIndexTestsResults <- lapply(nonSeqIndexTests, test_coreRfeature)
-indexChainTestsResults <- lapply(indexChainTests, test_coreRfeature)
-logicalTestsResults <- lapply(logicalTests, test_coreRfeature)
-returnTestResults <- lapply(returnTests, test_coreRfeature)
+cTestsResults <- test_coreRfeature_batch(cTests, 'cTests') ##lapply(cTests, test_coreRfeature)
+blockTestsResults <- test_coreRfeature_batch(blockTests, 'blockTests') ##lapply(blockTests, test_coreRfeature)
+repTestsResults <- test_coreRfeature_batch(repTests, 'repTests') ## lapply(repTests, test_coreRfeature)
+diagTestsResults <- test_coreRfeature_batch(diagTests, 'diagTests') ## lapply(diagTests, test_coreRfeature)
+recyclingRuleTestsResults <- test_coreRfeature_batch(recyclingRuleTests, 'recyclingRuleTests') ## lapply(recyclingRuleTests, test_coreRfeature)
+rRecyclingRuleTestsResults <- test_coreRfeature_batch(rRecyclingRuleTests, 'rRecyclingRuleTests') ## lapply(rRecyclingRuleTests, test_coreRfeature)
+seqTestsResults <- test_coreRfeature_batch(seqTests, 'seqTests') ## lapply(seqTests, test_coreRfeature)
+nonSeqIndexTestsResults <- test_coreRfeature_batch(nonSeqIndexTests, 'nonSeqIndexTests') ## lapply(nonSeqIndexTests, test_coreRfeature)
+indexChainTestsResults <- test_coreRfeature_batch(indexChainTests, 'indexChainTests') ## lapply(indexChainTests, test_coreRfeature)
+logicalTestsResults <- test_coreRfeature_batch(logicalTests, 'logicalTests') ## lapply(logicalTests, test_coreRfeature)
+returnTestResults <- test_coreRfeature_batch(returnTests, 'returnTests') ## lapply(returnTests, test_coreRfeature)
 
 
 ## Some tests of using coreR features in BUGS models
@@ -878,3 +884,5 @@ test_that('diag(3) in BUGS works', {
 }
 )
 
+options(warn = RwarnLevel)
+nimbleOptions(verbose = nimbleVerboseSetting)

--- a/packages/nimble/inst/tests/test-graphStructure.R
+++ b/packages/nimble/inst/tests/test-graphStructure.R
@@ -2,6 +2,10 @@
 ## test-getDependencies has some more basic tests.
 source(system.file(file.path('tests', 'test_utils.R'), package = 'nimble'))
 
+RwarnLevel <- options('warn')$warn
+options(warn = -1)
+nimbleVerboseSetting <- nimbleOptions('verbose')
+nimbleOptions(verbose = FALSE)
 
 correctOutputFilename <- 'graphStructureTestResults_Correct.Rout'
 ## Use this to regenerate results in the test directory:
@@ -178,3 +182,6 @@ trialResults <- readLines(testOutputFilename)
 correctResults <- readLines(system.file(file.path('tests', correctOutputFilename), package = 'nimble'))
 
 compareFilesByLine(trialResults, correctResults)
+
+options(warn = RwarnLevel)
+nimbleOptions(verbose = nimbleVerboseSetting)

--- a/packages/nimble/inst/tests/test-numericTypes.R
+++ b/packages/nimble/inst/tests/test-numericTypes.R
@@ -1,6 +1,12 @@
 source(system.file(file.path('tests', 'test_utils.R'), package = 'nimble'))
 context("Testing of numeric type handling and casting")
 
+RwarnLevel <- options('warn')$warn
+options(warn = -1)
+nimbleVerboseSetting <- nimbleOptions('verbose')
+nimbleOptions(verbose = TRUE)
+
+
 inverseCallReplacements <- as.list(names(nimble:::specificCallReplacements))
 names(inverseCallReplacements) <- unlist(nimble:::specificCallReplacements)
 inverseReplace <- function(x) {
@@ -263,13 +269,16 @@ binaryMatrixOpTypeTests <- unlist(recursive = FALSE,
 binaryMatrixOpTypeTests <- indexNames(binaryMatrixOpTypeTests)
 
 
-unaryCwiseResults <- lapply(unaryCwiseTypeTests, test_coreRfeature)
-binaryCwiseResults <- lapply(binaryCwiseTypeTests, test_coreRfeature)
-binaryCwiseLogicalResults <- lapply(binaryCwiseTypeTestsLogicals, test_coreRfeature)
-reductionResults <- lapply(reductionTypeTests, test_coreRfeature)
-reductionLogicalResults <- lapply(reductionTypeTestsLogical, test_coreRfeature)
-reductionMatrixSquareResults <- lapply(reductionTypeTestsMatrixSquare[3:4], test_coreRfeature)
-binaryCwiseMidOpsResults <- lapply(binaryCwiseTypeTestsMidOps, test_coreRfeature)
-binaryCwiseInProdResults <- lapply(binaryCwiseTypeTestsInprod, test_coreRfeature)
-binaryCwiseLeftPromoteResults <- lapply(binaryCwiseTypeTestsLeftPromotOps, test_coreRfeature)
-binaryMatrixOpResults <- lapply(binaryMatrixOpTypeTests, test_coreRfeature)
+unaryCwiseResults <- test_coreRfeature_batch(unaryCwiseTypeTests, 'unaryCwiseTypeTests') ## lapply(unaryCwiseTypeTests, test_coreRfeature)
+binaryCwiseResults <- test_coreRfeature_batch(binaryCwiseTypeTests, 'binaryCwiseTypeTests') ## lapply(binaryCwiseTypeTests, test_coreRfeature)
+binaryCwiseLogicalResults <- test_coreRfeature_batch(binaryCwiseTypeTestsLogicals, 'binaryCwiseTypeTestsLogicals') ## lapply(binaryCwiseTypeTestsLogicals, test_coreRfeature)
+reductionResults <- test_coreRfeature_batch(reductionTypeTests, 'reductionTypeTests') ## lapply(reductionTypeTests, test_coreRfeature)
+reductionLogicalResults <- test_coreRfeature_batch(reductionTypeTestsLogical, 'reductionTypeTestsLogical') ## lapply(reductionTypeTestsLogical, test_coreRfeature)
+reductionMatrixSquareResults <- test_coreRfeature_batch(reductionTypeTestsMatrixSquare[3:4], 'reductionTypeTestsMatrixSquare[3:4]') ## lapply(reductionTypeTestsMatrixSquare[3:4], test_coreRfeature)
+binaryCwiseMidOpsResults <- test_coreRfeature_batch(binaryCwiseTypeTestsMidOps, 'binaryCwiseTypeTestsMidOps') ## lapply(binaryCwiseTypeTestsMidOps, test_coreRfeature)
+binaryCwiseInProdResults <- test_coreRfeature_batch(binaryCwiseTypeTestsInprod, 'binaryCwiseTypeTestsInprod') ## lapply(binaryCwiseTypeTestsInprod, test_coreRfeature)
+binaryCwiseLeftPromoteResults <- test_coreRfeature_batch(binaryCwiseTypeTestsLeftPromotOps, 'binaryCwiseTypeTestsLeftPromotOps') ## lapply(binaryCwiseTypeTestsLeftPromotOps, test_coreRfeature)
+binaryMatrixOpResults <- test_coreRfeature_batch(binaryMatrixOpTypeTests, 'binaryMatrixOpTypeTests') ## lapply(binaryMatrixOpTypeTests, test_coreRfeature)
+
+options(warn = RwarnLevel)
+nimbleOptions(verbose = nimbleVerboseSetting)

--- a/packages/nimble/inst/tests/test-refactorCompilationSteps.R
+++ b/packages/nimble/inst/tests/test-refactorCompilationSteps.R
@@ -2,8 +2,12 @@ source(system.file(file.path('tests', 'test_utils.R'), package = 'nimble'))
 
 context("Testing of old vs. new generated C++ during refactoring steps")
 
-oldWarnLevel <- options('warn')
+RwarnLevel <- options('warn')$warn
 options(warn = -1)
+nimbleVerboseSetting <- nimbleOptions('verbose')
+nimbleOptions(verbose = FALSE)
+
+
 
 ## Known concern: ordering of asRow()/asCol() and intermediates
 
@@ -56,4 +60,5 @@ compareOldAndNewMathTest <- function(input) {
 source(system.file(file.path('tests', 'mathTestLists.R'), package = 'nimble'))
 ans2 <- lapply(testsBasicMath, compareOldAndNewMathTest)
 
-options(warn = as.numeric(oldWarnLevel))
+options(warn = RwarnLevel)
+nimbleOptions(verbose = nimbleVerboseSetting)

--- a/packages/nimble/inst/tests/test-returnTypeErrorTrapping.R
+++ b/packages/nimble/inst/tests/test-returnTypeErrorTrapping.R
@@ -1,6 +1,13 @@
 source(system.file(file.path('tests', 'test_utils.R'), package = 'nimble'))
 context('testing return() type error trapping')
 
+RwarnLevel <- options('warn')$warn
+options(warn = -1)
+nimbleVerboseSetting <- nimbleOptions('verbose')
+nimbleOptions(verbose = FALSE)
+nimbleVerboseErrorsSetting <- nimbleOptions('verboseErrors')
+nimbleOptions(verboseErrors = FALSE)
+
 ## We can use upcoming expect_compiles in the future,
 ## but for now I'm doing it more crudely
 
@@ -68,3 +75,7 @@ test_that('return type error caught when non-void object is returned', {
     cfoo <- try(compileNimble(foo))
     expect_failure(expect_identical(class(cfoo), "function"))
 })
+
+options(warn = RwarnLevel)
+nimbleOptions(verbose = nimbleVerboseSetting)
+nimbleOptions(verboseErrors = nimbleVerboseErrorsSetting)

--- a/packages/nimble/inst/tests/test-size.R
+++ b/packages/nimble/inst/tests/test-size.R
@@ -1,5 +1,8 @@
 source(system.file(file.path('tests', 'test_utils.R'), package = 'nimble'))
 
+RwarnLevel <- options('warn')$warn
+options(warn = -1)
+
 context("Testing of size/dimension checks in NIMBLE code.\nNote that numerous error messages are expected here; check for test failures not denoted with 'KNOWN PROBLEM'.")
 
 vec2 <- c(1,1)
@@ -482,3 +485,6 @@ sapply(testsTrunc, test_size)
 
 # for these we want errors caught by NIMBLE error-checking not by R errors at model-building
 sapply(testsLHSRHSmismatch, test_size_specific_error)
+
+RwarnLevel <- options('warn')$warn
+options(warn = -1)

--- a/packages/nimble/inst/tests/test_utils.R
+++ b/packages/nimble/inst/tests/test_utils.R
@@ -56,6 +56,109 @@ indexNames <- function(x) {
     lapply(x, function(z) {z$name <- paste(i, z$name); i <<- i + 1; z})
 }
 
+test_coreRfeature_batch <- function(input_batch, info = '', verbose = TRUE, dirName = NULL) {
+    test_that(info, {
+        test_coreRfeature_batch_internal(input_batch, verbose, dirName)
+    })
+}
+
+test_coreRfeature_batch_internal <- function(input_batch, verbose = TRUE, dirName = NULL) { ## a lot like test_math but a bit more flexible
+    names(input_batch) <- paste0('batch_case_', seq_along(input_batch))
+    runFuns <- lapply(input_batch, gen_runFunCore)
+    nfR <- nimbleFunction(setup = TRUE, methods = runFuns)()
+
+    nfC <- compileNimble(nfR, dirName = dirName)
+
+    for(i in seq_along(input_batch)) {
+        input <- input_batch[[i]]
+        if(verbose) cat("### Testing", input$name, "###\n")
+        funName <- names(input_batch)[i]
+        nArgs <- length(input$args)
+        evalEnv <- new.env()
+        eval(input$setArgVals, envir = evalEnv)
+        savedArgs <- as.list(evalEnv)
+        seedToUse <- if(is.null(input[['seed']])) 31415927 else input[['seed']]
+        set.seed(seedToUse)
+        eval(input$expr, envir = evalEnv)
+        savedOutputs <- as.list(evalEnv)
+        list2env(savedArgs, envir = evalEnv)
+        ## with R ref classes, lookup of methods via `[[` does not work until it has been done via `$`
+        ## force it via `$` here to allow simpler syntax below
+        forceFind <- eval(substitute(nfR$FUNNAME, list(FUNNAME = as.name(funName))))
+        forceFind <- eval(substitute(nfC$FUNNAME, list(FUNNAME = as.name(funName))))
+        if(nArgs == 5) {
+            set.seed(seedToUse)
+            out_nfR = nfR[[funName]](evalEnv$arg1, evalEnv$arg2, evalEnv$arg3, evalEnv$arg4, evalEnv$arg5)
+            list2env(savedArgs, envir = evalEnv)
+            set.seed(seedToUse)
+            out_nfC = nfC[[funName]](evalEnv$arg1, evalEnv$arg2, evalEnv$arg3, evalEnv$arg4, evalEnv$arg5)
+        }  
+        if(nArgs == 4) {
+            set.seed(seedToUse)
+            out_nfR = nfR[[funName]](evalEnv$arg1, evalEnv$arg2, evalEnv$arg3, evalEnv$arg4)
+            list2env(savedArgs, envir = evalEnv)
+            set.seed(seedToUse)
+            out_nfC = nfC[[funName]](evalEnv$arg1, evalEnv$arg2, evalEnv$arg3, evalEnv$arg4)
+        }  
+        if(nArgs == 3) {
+            set.seed(seedToUse)
+            out_nfR = nfR[[funName]](evalEnv$arg1, evalEnv$arg2, evalEnv$arg3)
+            list2env(savedArgs, envir = evalEnv)
+            set.seed(seedToUse)
+            out_nfC = nfC[[funName]](evalEnv$arg1, evalEnv$arg2, evalEnv$arg3)
+        }  
+        if(nArgs == 2) {
+            set.seed(seedToUse)
+            out_nfR = nfR[[funName]](evalEnv$arg1, evalEnv$arg2)
+            list2env(savedArgs, envir = evalEnv)
+            set.seed(seedToUse)
+            out_nfC = nfC[[funName]](evalEnv$arg1, evalEnv$arg2)
+        }
+        if(nArgs == 1) {
+            set.seed(seedToUse)
+            out_nfR = nfR[[funName]](evalEnv$arg1)
+            list2env(savedArgs, envir = evalEnv)
+            set.seed(seedToUse)
+            out_nfC = nfC[[funName]](evalEnv$arg1)
+        }
+        if(nArgs == 0) {
+            set.seed(seedToUse)
+            out_nfR = nfR[[funName]]()
+            list2env(savedArgs, envir = evalEnv)
+            set.seed(seedToUse)
+            out_nfC = nfC[[funName]]()
+        }
+        out <- savedOutputs$out
+        ## clearn any attributes except dim
+        dimOut <- attr(out, 'dim')
+        dimOutR <- attr(out_nfR, 'dim')
+        dimOutC <- attr(out_nfC, 'dim')
+        attributes(out) <- attributes(out_nfR) <- attributes(out_nfC) <- NULL
+        attr(out, 'dim') <- dimOut
+        attr(out_nfR, 'dim') <- dimOutR
+        attr(out_nfC, 'dim') <- dimOutC
+        checkEqual <- input[['checkEqual']]
+        if(is.null(checkEqual)) checkEqual <- FALSE
+        if(is.null(input[['return']])) { ## use default 'out' object
+            if(!checkEqual) {
+                expect_identical(out, out_nfR, info = paste0("Identical test of coreRfeature (direct R vs. R nimbleFunction): ", input$name))
+                expect_identical(out, out_nfC, info = paste0("Identical test of coreRfeature (direct R vs. C++ nimbleFunction): ", input$name))
+            } else {
+                expect_equal(out, out_nfR, info = paste0("Equal test of coreRfeature (direct R vs. R nimbleFunction): ", input$name) )
+                expect_equal(out, out_nfC, info = paste0("Equal test of coreRfeature (direct R vs. C++ nimbleFunction): ", input$name))
+            }
+        } else { ## not using default return(out), so only compare out_nfR to out_nfC
+            if(!checkEqual) {
+                expect_identical(out_nfC, out_nfR, info = paste0("Identical test of coreRfeature (compiled vs. uncompied nimbleFunction): ", input$name))
+            } else {
+                expect_identical(out_nfC, out_nfR, info = paste0("Equal test of coreRfeature (compiled vs. uncompied nimbleFunction): ", input$name))
+            }
+        }
+    }
+    ## unload DLL as R doesn't like to have too many loaded
+    if(.Platform$OS.type != 'windows') nimble:::clearCompiled(nfR) ##dyn.unload(project$cppProjects[[1]]$getSOName())
+    invisible(NULL)
+}
 
 test_coreRfeature <- function(input, verbose = TRUE, dirName = NULL) {
     test_that(input$name, {

--- a/run_tests.R
+++ b/run_tests.R
@@ -34,7 +34,7 @@ if (system2('/usr/bin/time', c('-v', 'echo', 'Running under /usr/bin/time -v')))
 # Run each test in a separate process to avoid dll garbage overload.
 for (test in allTests) {
     cat('--------------------------------------------------------------------------------\n')
-    cat('TESING', test, '\n')
+    cat('TESTING', test, '\n')
     runViaTestthat <- TRUE
     if (runViaTestthat) {
         name <- gsub('test-(.*)\\.R', '\\1', test)


### PR DESCRIPTION
Not yet ready to merge.  Still has some cleanup to do but I’m making PR for Travis testing.

This PR quiets some tests and speeds up others.  It is incremental progress on our test suite.

Quieting: The following tests now have opening and closing code to set `options(warn = -1)` and `nimbleOptions(verbose = FALSE)` and restore original settings upon completion:

`graphStructure`, `refactorCompilationSteps`, `returnTypeErrorTrapping`, `coreR`, `numericTypes`, `allocation`

Speeding up: There is a new `test_coreRfeature_batch` that compiles many test cases together as methods of one large `nimbleFunction`.  This is now used for `coreR`, `numericTypes`, and `allocation`.  It appears to yield substantial speedup, but we’ll have to see on benchmark machine.
