### PR TITLE
Add resetFunctions flag to buildMCEM.

### DIFF
--- a/packages/nimble/R/MCEM_build.R
+++ b/packages/nimble/R/MCEM_build.R
@@ -238,24 +238,26 @@ buildMCEM <- function(model, latentNodes, burnIn = 500 , mcmcControl = list(adap
   if(length(maxNodes) == 0)
     stop('no nodes to be maximized over')
   
-  
+  resetFunctions <- FALSE
   if(is(model, "RmodelBaseClass") ){
     Rmodel = model
     if(is(model$CobjectInterface, "uninitializedField")){
       cModel <- compileNimble(model)
     }
-    else
+    else{
       cModel = model$CobjectInterface
+      resetFunctions <- TRUE
+    }
   }
   else{
     cModel <- model
     Rmodel <- model$Rmodel
+    resetFunctions <- TRUE
   }
   
   zAlpha <- qnorm(alpha, 0, 1, lower.tail=FALSE)
   zBeta <- qnorm(beta, 0, 1, lower.tail=FALSE)
   zGamma <- qnorm(gamma, 0, 1, lower.tail=FALSE)
-  
   
   mcmc_Latent_Conf <- configureMCMC(Rmodel, nodes = latentNodes, monitors = model$getVarNames(), control = mcmcControl) 
   Rmcmc_Latent <- buildMCMC(mcmc_Latent_Conf)
@@ -265,7 +267,7 @@ buildMCEM <- function(model, latentNodes, burnIn = 500 , mcmcControl = list(adap
   RvarCalc <- calc_asympVar(model, fixedNodes = maxNodes, sampledNodes = latentNodes, burnIn = burnIn, mvBlock, mvSample = sampledMV, numReps = numReps)
   RgetCov <- bootstrapGetCov(model, fixedNodes = maxNodes, sampledNodes = latentNodes, burnIn = burnIn, mvSample = sampledMV)
   
-  cmcmc_Latent = compileNimble(Rmcmc_Latent, project = Rmodel)
+  cmcmc_Latent = compileNimble(Rmcmc_Latent, project = Rmodel, resetFunctions = resetFunctions)
   cGetCov = compileNimble(RgetCov, project = Rmodel)  
   cvarCalc <- compileNimble(RvarCalc, project = Rmodel)
   cCalc_E_llk = compileNimble(Rcalc_E_llk, project = Rmodel)  


### PR DESCRIPTION
If buildMCEM detects that the `model` argument has already been compiled, it will now set `resetFunctions = TRUE` when compiling it's latent state MCMC algorithm.