### PR TITLE
Fixes #443 by ensuring that use of unique in splitVertices operates on a vector rather than matrix or array

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -1406,7 +1406,7 @@ splitVertices <- function(var2vertexID, unrolledBUGSindices, indexExprs = NULL, 
         ## construct argList
         for(iRow in iRowRange) {
             currentVertexIDblock <- eval(accessExpr)
-            uniqueCurrentVertexIDs <- unique(currentVertexIDblock)
+            uniqueCurrentVertexIDs <- unique(c(currentVertexIDblock))
             if(length(uniqueCurrentVertexIDs)==1) { ## current block has only 1 ID
                 if( is.na(uniqueCurrentVertexIDs[1]) |      ## It's all unassigned OR
                    currentVertexCounts[ uniqueCurrentVertexIDs[1] ] != length(currentVertexIDblock) ) { ## It does not fully cover  existing vertexID


### PR DESCRIPTION
This PR uses @paciorek ’s suggestion for fixing Issue #443 .  This appears to be a harmless bug but would be good to clean up.