### PR TITLE
add name to every package-defined nimbleFunction

### DIFF
--- a/packages/nimble/R/MCEM_build.R
+++ b/packages/nimble/R/MCEM_build.R
@@ -2,6 +2,7 @@
 # bootstrap method of "Markov Chain Monte Carlo in Statistical Mechanics"
 # by Mignani & Rosa, 2001 (p. 350)
 calc_asympVar = nimbleFunction(
+    name = 'calc_asympVar',
   setup = function(model, fixedNodes, sampledNodes, mvBlock, mvSample, burnIn = 0, numReps){
     calc_E_llk <- calc_E_llk_gen(model, fixedNodes = fixedNodes, sampledNodes = sampledNodes, burnIn = 0, mvSample = mvBlock)
   },
@@ -33,6 +34,7 @@ calc_asympVar = nimbleFunction(
 
 # Calculates Q function if diff = 0, calculates difference in Q functions if diff = 1.
 calc_E_llk_gen = nimbleFunction(
+    name = 'calc_E_llk_gen',
   setup = function(model, fixedNodes, sampledNodes, mvSample, burnIn = 0){
     fixedCalcNodes <- model$getDependencies(fixedNodes)	
     latentCalcNodes <- model$getDependencies(sampledNodes)
@@ -83,6 +85,7 @@ calc_E_llk_gen = nimbleFunction(
 
 ## helper function to extract ranges of nodes to be maximized
 getMCEMRanges <- nimbleFunction(
+    name = 'getMCEMRanges',
   setup = function(model, maxNodes, buffer){
     low_limits = rep(-Inf, length(maxNodes) ) 
     hi_limits  = rep(Inf,  length(maxNodes) ) 
@@ -395,6 +398,7 @@ buildMCEM <- function(model, latentNodes, burnIn = 500 , mcmcControl = list(adap
 }
 
 bootstrapGetCov <- nimbleFunction(
+    name = 'bootstrapGetCov',
     setup = function(model, fixedNodes, sampledNodes, mvSample, burnIn = 0){
       fixedCalcNodes <- model$getDependencies(fixedNodes)	
       latentCalcNodes <- model$getDependencies(sampledNodes)

--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -49,6 +49,7 @@
 #' head(samples)
 #' }
 buildMCMC <- nimbleFunction(
+    name = 'MCMC',
     setup = function(conf, ...) {
     	if(inherits(conf, 'modelBaseClass'))
     		conf <- configureMCMC(conf, ...)

--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -22,6 +22,7 @@ sampler_BASE <- nimbleFunctionVirtual(
 #' @rdname samplers
 #' @export
 sampler_posterior_predictive <- nimbleFunction(
+    name = 'sampler_posterior_predictive',
     contains = sampler_BASE,
     setup = function(model, mvSaved, target, control) {
         ## node list generation
@@ -46,6 +47,7 @@ sampler_posterior_predictive <- nimbleFunction(
 #' @rdname samplers
 #' @export
 sampler_binary <- nimbleFunction(
+    name = 'sampler_binary',
     contains = sampler_BASE,
     setup = function(model, mvSaved, target, control) {
         ## node list generation
@@ -79,6 +81,7 @@ sampler_binary <- nimbleFunction(
 #' @rdname samplers
 #' @export
 sampler_RW <- nimbleFunction(
+    name = 'sampler_RW',
     contains = sampler_BASE,
     setup = function(model, mvSaved, target, control) {
         ## control list extraction
@@ -168,6 +171,7 @@ sampler_RW <- nimbleFunction(
 #' @rdname samplers
 #' @export
 sampler_RW_block <- nimbleFunction(
+    name = 'sampler_RW_block',
     contains = sampler_BASE,
     setup = function(model, mvSaved, target, control) {
         ## control list extraction
@@ -282,6 +286,7 @@ sampler_RW_block <- nimbleFunction(
 #' @rdname samplers
 #' @export
 sampler_RW_llFunction <- nimbleFunction(
+    name = 'sampler_RW_llFunction',
     contains = sampler_BASE,
     setup = function(model, mvSaved, target, control) {
         ## control list extraction
@@ -328,6 +333,7 @@ sampler_RW_llFunction <- nimbleFunction(
 #' @rdname samplers
 #' @export
 sampler_slice <- nimbleFunction(
+    name = 'sampler_slice',
     contains = sampler_BASE,
     setup = function(model, mvSaved, target, control) {
         ## control list extraction
@@ -417,6 +423,7 @@ sampler_slice <- nimbleFunction(
 #' @rdname samplers
 #' @export
 sampler_ess <- nimbleFunction(
+    name = 'sampler_ess',
     contains = sampler_BASE,
     setup = function(model, mvSaved, target, control) {
         ## node list generation
@@ -464,6 +471,7 @@ sampler_ess <- nimbleFunction(
 #' @rdname samplers
 #' @export
 sampler_AF_slice <- nimbleFunction(
+    name = 'sampler_AF_slice',
   contains = sampler_BASE,
   setup = function(model, mvSaved, target, control) {
     ## control list extraction
@@ -631,6 +639,7 @@ getPosteriorDensityFromConjSampler_virtual <- nimbleFunctionVirtual(
 )
 
 getPosteriorDensityFromConjSampler <- nimbleFunction(
+    name = 'getPosteriorDensityFromConjSampler',
     contains = getPosteriorDensityFromConjSampler_virtual,
     setup = function(conjugateSamplerFunction) {},
     run = function() {
@@ -643,6 +652,7 @@ getPosteriorDensityFromConjSampler <- nimbleFunction(
 #' @rdname samplers
 #' @export
 sampler_crossLevel <- nimbleFunction(
+    name = 'sampler_crossLevel',
     contains = sampler_BASE,
     setup = function(model, mvSaved, target, control) {
         ## control list extraction
@@ -721,6 +731,7 @@ sampler_crossLevel <- nimbleFunction(
 #' @rdname samplers
 #' @export
 sampler_RW_llFunction_block <- nimbleFunction(
+    name = 'sampler_RW_llFunction_block',
     contains = sampler_BASE,
     setup = function(model, mvSaved, target, control) {
         ## control list extraction
@@ -814,6 +825,7 @@ sampler_RW_llFunction_block <- nimbleFunction(
 #' @rdname samplers
 #' @export
 sampler_RW_PF <- nimbleFunction(
+    name = 'sampler_RW_PF',
     contains = sampler_BASE,
     setup = function(model, mvSaved, target, control) {
         ## control list extraction
@@ -961,6 +973,7 @@ sampler_RW_PF <- nimbleFunction(
 #' @rdname samplers
 #' @export
 sampler_RW_PF_block <- nimbleFunction(
+    name = 'sampler_RW_PF_block',
     contains = sampler_BASE,
     setup = function(model, mvSaved, target,  control) {
         ## control list extraction
@@ -1133,7 +1146,8 @@ sampler_RW_PF_block <- nimbleFunction(
 
 #' @rdname samplers
 #' @export
-sampler_RW_multinomial <- nimbleFunction( 
+sampler_RW_multinomial <- nimbleFunction(
+    name = 'sampler_RW_multinomial',
     contains = sampler_BASE,
     setup = function(model, mvSaved, target, control) {
         ## control list extraction
@@ -1264,6 +1278,7 @@ sampler_RW_multinomial <- nimbleFunction(
 #' @rdname samplers
 #' @export
 sampler_RW_dirichlet <- nimbleFunction(
+    name = 'sampler_RW_dirichlet',
     contains = sampler_BASE,
     setup = function(model, mvSaved, target, control) {
         ## control list extraction

--- a/packages/nimble/R/MCMC_utils.R
+++ b/packages/nimble/R/MCMC_utils.R
@@ -48,6 +48,7 @@ decide <- function(logMetropolisRatio) {
 #' -- If the proposal is rejected, the values and associated logProbs of all calcNodes are copied from the mvSaved object into the model object
 #' -- Return a logical value, indicating whether the proposal was accepted
 decideAndJump <- nimbleFunction(
+    name = 'decideAndJump',
     setup = function(model, mvSaved, calcNodes) { },
     run = function(modelLP1 = double(), modelLP0 = double(), propLP1 = double(), propLP0 = double()) {
         logMHR <- modelLP1 - modelLP0 - propLP1 + propLP0
@@ -88,6 +89,7 @@ decideAndJump <- nimbleFunction(
 #' my_setAndCalc <- setAndCalculateOne(Rmodel, 'x[1]')
 #' lp <- my_setAndCalc$run(2)
 setAndCalculateOne <- nimbleFunction(
+    name = 'setAndCalculateOne',
     setup = function(model, targetNode) {
         targetNodeAsScalar <- model$expandNodeNames(targetNode, returnScalarComponents = TRUE)
         if(length(targetNodeAsScalar) > 1)     stop('more than one targetNode; cannot use setAndCalculateOne()')
@@ -131,6 +133,7 @@ setAndCalculateOne <- nimbleFunction(
 #' my_setAndCalc <- setAndCalculate(Rmodel, c('x[1]', 'x[2]', 'y[1]', 'y[2]'))
 #' lp <- my_setAndCalc$run(c(1.2, 1.4, 7.6, 8.9))
 setAndCalculate <- nimbleFunction(
+    name = 'setAndCalculate',
     setup = function(model, targetNodes) {
         targetNodesAsScalar <- model$expandNodeNames(targetNodes, returnScalarComponents = TRUE)
         calcNodes <- model$getDependencies(targetNodes)
@@ -146,6 +149,7 @@ setAndCalculate <- nimbleFunction(
 #' @rdname setAndCalculate
 #' @export
 setAndCalculateDiff <- nimbleFunction(
+    name = 'setAndCalculateDiff',
     setup = function(model, targetNodes) {
         targetNodesAsScalar <- model$expandNodeNames(targetNodes, returnScalarComponents = TRUE)
         calcNodes <- model$getDependencies(targetNodes)
@@ -160,6 +164,7 @@ setAndCalculateDiff <- nimbleFunction(
 
 
 calcAdaptationFactor <- nimbleFunction(
+    name = 'calcAdaptationFactor',
     setup = function(paramDimension) {
         ## optimal acceptance rates:  (dim=1) .44,    (dim=2) .35,    (dim=3) .32,    (dim=4) .25,    (dim>=5) .234
         acceptanceRates <- c(0.44, 0.35, 0.32, 0.25, 0.234)

--- a/packages/nimble/R/NF_utils.R
+++ b/packages/nimble/R/NF_utils.R
@@ -17,6 +17,7 @@
 #' Run code: \code{for(i in seq_along(myCalcs)) {ans[i] <- myCalcs[[i]]()} }
 #' 
 simNodes <- nimbleFunction(
+    name = 'simNodes',
     setup = function(model, nodes){
         if(missing(nodes) )
             nodes <- model$getNodeNames()
@@ -33,6 +34,7 @@ simNodes <- nimbleFunction(
 #' @rdname simNodes
 #' @export
 calcNodes <- nimbleFunction(
+    name = 'calcNodes',
 	setup = function(model, nodes){
 		if(missing(nodes) )
                     depNodes <- model$getNodeNames()
@@ -49,6 +51,7 @@ calcNodes <- nimbleFunction(
 #' @rdname simNodes
 #' @export
 getLogProbNodes <- nimbleFunction(
+    name = 'getLogProbNodes',
 	setup = function(model, nodes) {
 		if(missing(nodes) )
                     depNodes <- model$getNodeNames()
@@ -122,6 +125,7 @@ getLogProbNodes <- nimbleFunction(
 #'   Cglp$run()	  #Gives wrong answers because logProbs were not saved
 #' }
 simNodesMV <- nimbleFunction(
+    name = 'simNodesMV',
     setup = function(model, mv, nodes) {
         if(missing(nodes) )
             nodes <- model$getNodeNames()
@@ -143,6 +147,7 @@ simNodesMV <- nimbleFunction(
 #' @rdname simNodesMV
 #' @export
 calcNodesMV <- nimbleFunction(
+    name = 'calcNodesMV',
 	setup = function(model, mv, nodes) {
 		if(missing(nodes) )
                     nodes <- depNodes <- model$getNodeNames()
@@ -168,6 +173,7 @@ where = getLoadingNamespace())
 #' @rdname simNodesMV
 #' @export
 getLogProbNodesMV <- nimbleFunction(
+    name = 'getLogProbNodesMV',
 	setup = function(model, mv, nodes) {
 		if(missing(nodes) )
                     nodes <- depNodes <- model$getNodeNames()
@@ -207,6 +213,7 @@ getLogProbNodesMV <- nimbleFunction(
 #'
 #' @export
 identityMatrix <- nimbleFunction(
+    name = 'identityMatrix',
     run = function(d = double()) {
         declare(arr, double(2, c(d, d)))
         for(i in 1:d)   for(j in 1:d)   arr[i, j] <- 0

--- a/packages/nimble/R/filtering_auxiliary.R
+++ b/packages/nimble/R/filtering_auxiliary.R
@@ -17,6 +17,7 @@ auxFuncVirtual <- nimbleFunctionVirtual(
 )
 
 auxLookFunc = nimbleFunction(
+    name = 'auxLookFunc',
   contains = auxFuncVirtual,
   setup = function(model, node){
   },
@@ -29,6 +30,7 @@ auxLookFunc = nimbleFunction(
 
 
 auxSimFunc = nimbleFunction(
+    name = 'auxSimFunc',
   contains = auxFuncVirtual,
   setup = function(model, node){},
   methods = list(
@@ -38,6 +40,7 @@ auxSimFunc = nimbleFunction(
 )
 
 auxFStep <- nimbleFunction(
+    name = 'auxFStep',
   contains = auxStepVirtual,
   setup = function(model, mvEWSamples, mvWSamples, nodes, iNode, names,
                    saveAll, smoothing, lookahead, silent = TRUE) {
@@ -223,6 +226,7 @@ return(0)
 #' hist(as.matrix(Cmy_Auxf$mvEWSamples, 'x'))
 #' }
 buildAuxiliaryFilter <- nimbleFunction(
+    name = 'buildAuxiliaryFilter',
   setup = function(model, nodes, control = list()) {
     
    

--- a/packages/nimble/R/filtering_bootstrap.R
+++ b/packages/nimble/R/filtering_bootstrap.R
@@ -13,6 +13,7 @@ bootStepVirtual <- nimbleFunctionVirtual(
 # uses weights from previous time point to calculate likelihood estimate.
 
 bootFStep <- nimbleFunction(
+    name = 'bootFStep',
   contains = bootStepVirtual,
   setup = function(model, mvEWSamples, mvWSamples, nodes, iNode, names, saveAll, smoothing, silent = FALSE) {
     notFirst <- iNode != 1
@@ -179,6 +180,7 @@ bootFStep <- nimbleFunction(
 #' boot_X <- as.matrix(Cmy_BootF$mvEWSamples)
 #' }
 buildBootstrapFilter <- nimbleFunction(
+    name = 'buildBootstrapFilter',
   setup = function(model, nodes, control = list()) {
     
     #control list extraction

--- a/packages/nimble/R/filtering_enkf.R
+++ b/packages/nimble/R/filtering_enkf.R
@@ -24,6 +24,7 @@ ENKFFuncVirtual <- nimbleFunctionVirtual(
 
 #  returns mean and cov matrix for MVN data node
 enkfMultFunc = nimbleFunction(
+    name = 'enkfMultFunc',
   contains = ENKFFuncVirtual,
   setup = function(model, thisData){},
   methods = list(
@@ -40,6 +41,7 @@ enkfMultFunc = nimbleFunction(
 
 #  returns mean (as vector) and var (as matrix) for normal data node  
 enkfScalFunc = nimbleFunction(
+    name = 'enkfScalFunc',
   contains = ENKFFuncVirtual,
   setup = function(model, thisData){},
   methods = list(
@@ -66,6 +68,7 @@ enkfScalFunc = nimbleFunction(
 # Does not check to verify this.
 
 ENKFStep <- nimbleFunction(
+    name = 'ENKFStep',
   contains = ENKFStepVirtual,
   setup = function(model, mvSamples, nodes, iNode, xDim, yDim, saveAll, names, silent = FALSE) {
     notFirst <- iNode != 1
@@ -238,6 +241,7 @@ ENKFStep <- nimbleFunction(
 #' }
 #' @export
 buildEnsembleKF <- nimbleFunction(
+    name = 'buildEnsembleKF',
   setup = function(model, nodes, control = list()) {
 
     #control list extraction

--- a/packages/nimble/R/filtering_liuwest.R
+++ b/packages/nimble/R/filtering_liuwest.R
@@ -21,6 +21,7 @@ LWSetMeanVirtual <- nimbleFunctionVirtual(
 
 # Has a return_mean method which returns the mean of a normally distributed nimble node.
 paramMean <- nimbleFunction(
+    name = 'paramMean',
   contains = LWSetMeanVirtual,
   setup = function(model, node){
     ## check that node has a normal distribution!
@@ -40,6 +41,7 @@ LWSetParVirtual <- nimbleFunctionVirtual(
 )
 
 doPars <- nimbleFunction(
+    name = 'doPars',
   contains = LWSetParVirtual,
   setup = function(parName, mvWSamples, mvEWSamples) {
   },
@@ -104,6 +106,7 @@ doPars <- nimbleFunction(
 
 
 LWStep <- nimbleFunction(
+    name = 'LWStep',
   contains = LWStepVirtual,
   setup = function(model, mvWSamples, mvEWSamples, nodes, paramVarDims, iNode, paramNodes, paramVars, names, saveAll, d, silent = FALSE) {
     notFirst <- iNode != 1
@@ -272,6 +275,7 @@ LWStep <- nimbleFunction(
 # the mean of all particles, and cholesVar, which returns the cholesky 
 # decomposition of the weighted MC covariance matrix
 LWparFunc <- nimbleFunction(
+    name = 'LWparFunc',
   setup = function(d, parDim, prevInd){
     # Calculate h^2 and a using specified discount factor d
     hsq <- 1-((3*d-1)/(2*d))^2 
@@ -371,6 +375,7 @@ LWparFunc <- nimbleFunction(
 #' lw_sigma_x <- as.matrix(Cmy_LWF$mvEWSamples, 'sigma_x')
 #' }
 buildLiuWestFilter <- nimbleFunction(
+    name = 'buildLiuWestFilter',
   setup = function(model, nodes, params = NULL, control = list()){
     
     #control list extraction

--- a/packages/nimble/R/initializeModel.R
+++ b/packages/nimble/R/initializeModel.R
@@ -29,6 +29,7 @@
 #' )
 #' @export
 initializeModel <- nimbleFunction(
+    name = 'initializeModel',
     setup = function(model, silent = FALSE) {
         initFunctionList <- nimbleFunctionList(nodeInit_virtual)
         iter <- 1
@@ -60,6 +61,7 @@ initializeModel <- nimbleFunction(
 nodeInit_virtual <- nimbleFunctionVirtual()
 
 checkRHSonlyInit <- nimbleFunction(
+    name = 'checkRHSonlyInit',
     contains = nodeInit_virtual,
     setup = function(model, nodes) {},
     run = function() {
@@ -69,6 +71,7 @@ checkRHSonlyInit <- nimbleFunction(
 )
 
 stochNodeInit <- nimbleFunction(
+    name = 'stochNodeInit',
     contains = nodeInit_virtual,
     setup = function(model, node, silent) {
         thisDetermNodes <- model$getDependencies(node, determOnly=TRUE)

--- a/packages/nimble/R/miscFunctions.R
+++ b/packages/nimble/R/miscFunctions.R
@@ -1,6 +1,7 @@
 # used in altParams for dmnorm
 # this needs to be sourced after nimbleFunction() is defined, so can't be done in distributions_inputList.R
 calc_dmnormAltParams <- nimbleFunction(
+    name = 'calc_dmnormAltParams',
     run = function(cholesky = double(2), prec_param = double(), return_prec = double()) {
         if(prec_param == return_prec) {
             ans <- t(cholesky) %*% cholesky
@@ -22,6 +23,7 @@ calc_dmnormAltParams <- nimbleFunction(
 ## used in conjugacy definition for dmnorm, to calculate 'contribution' terms;
 ## avoids unnecessary matrix multiplications, when 'coeff' is identity matrix
 calc_dmnormConjugacyContributions <- nimbleFunction(
+    name = 'calc_dmnormConjugacyContributions',
     run = function(coeff = double(2), prec = double(2), vec = double(1), order = double()) {
         if(dim(coeff)[1] == dim(coeff)[2]) {
             d <- dim(coeff)[1]
@@ -48,6 +50,7 @@ calc_dmnormConjugacyContributions <- nimbleFunction(
 # used in altParams for dwish and dinvwish
 # this needs to be sourced after nimbleFunction() is defined, so can't be done in distributions_inputList.R
 calc_dwishAltParams <- nimbleFunction(
+    name = 'calc_dwishAltParams',
     run = function(cholesky = double(2), scale_param = double(), return_scale = double()) {
         if(scale_param == return_scale) {
             ans <- t(cholesky) %*% cholesky


### PR DESCRIPTION
This PR adds a name argument to every `nimbleFunction` defined in the package source code.  The only exception is for conjugate samplers, since even the `nimbleFunction` code for those is code-generated and I did not take the time to ensure a safe name choice.  These names should make generated C++ easier to read.