### PR TITLE
Add --parallel option to run_tests.R

### DIFF
--- a/packages/Makefile
+++ b/packages/Makefile
@@ -14,12 +14,17 @@ nimble_$(VERSION).tar.gz: nimble/configure FORCE
 
 build: nimble_$(VERSION).tar.gz
 
+install: nimble_$(VERSION).tar.gz
+	R CMD INSTALL nimble_$(VERSION).tar.gz
+
 check: build FORCE
 	R CMD check --as-cran nimble_$(VERSION).tar.gz
 
 test: FORCE
 	cd .. ; ./run_tests.R --parallel
 
+# We are progressively delegating style to clang-format.
+# Some older C++ files are still styled manually.
 clang-format: FORCE
 	clang-format -style=file \
 	  nimble/inst/include/nimble/NimArrBase.h \
@@ -28,8 +33,12 @@ clang-format: FORCE
 	  nimble/inst/CppCode/predefinedNimbleLists.cpp \
 	  -i
 
+# Keeps .Rproj.user/ and .Rhistory.
 clean: FORCE
-	git clean -dfX
+	git clean -dfx -e .R*
+
+mrproper: FORCE
+	git clean -dfx
 
 FORCE:
 

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -1,14 +1,25 @@
+.PHONY: FORCE
+
 build: nimble/configure
-	@echo "Building nimble package in this directory"
+	@echo "Building nimble package in-place"
 	(R CMD build nimble)
 
 configure: nimble/configure.ac
 	(cd nimble; autoconf)
 
-clang-format:
+clang-format: FORCE
 	clang-format -style=file \
 	  nimble/inst/include/nimble/NimArrBase.h \
 	  nimble/inst/include/nimble/NimArr.h \
 	  nimble/inst/include/nimble/predefinedNimbleLists.h \
 	  nimble/inst/CppCode/predefinedNimbleLists.cpp \
 	  -i
+
+test: FORCE
+	cd .. ; ./run_tests.R --parallel
+
+clean: FORCE
+	git clean -dfX
+
+FORCE:
+

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -21,7 +21,7 @@ check: build FORCE
 	R CMD check --as-cran nimble_$(VERSION).tar.gz
 
 test: FORCE
-	cd .. ; ./run_tests.R --parallel
+	cd .. ; ./run_tests.R
 
 # We are progressively delegating style to clang-format.
 # Some older C++ files are still styled manually.

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -1,11 +1,24 @@
 .PHONY: FORCE
 
-build: nimble/configure
-	@echo "Building nimble package in-place"
-	(R CMD build nimble)
+VERSION=$(shell grep Version: nimble/DESCRIPTION | grep -o '[^ ]*$$')
+
+version: FORCE
+	@echo $(VERSION)
 
 configure: nimble/configure.ac
 	(cd nimble; autoconf)
+
+nimble_$(VERSION).tar.gz: nimble/configure FORCE
+	@echo "Building nimble package in this directory"
+	(R CMD build nimble)
+
+build: nimble_$(VERSION).tar.gz
+
+check: build FORCE
+	R CMD check --as-cran nimble_$(VERSION).tar.gz
+
+test: FORCE
+	cd .. ; ./run_tests.R --parallel
 
 clang-format: FORCE
 	clang-format -style=file \
@@ -14,9 +27,6 @@ clang-format: FORCE
 	  nimble/inst/include/nimble/predefinedNimbleLists.h \
 	  nimble/inst/CppCode/predefinedNimbleLists.cpp \
 	  -i
-
-test: FORCE
-	cd .. ; ./run_tests.R --parallel
 
 clean: FORCE
 	git clean -dfX

--- a/run_tests.R
+++ b/run_tests.R
@@ -83,15 +83,15 @@ runTest <- function(test, logToFile = FALSE, runViaTestthat = TRUE) {
         stderr.log <- file.path(logDir, paste0('test-', name, '.stderr'))
         stdout.log <- file.path(logDir, paste0('test-', name, '.stdout'))
         if (system2(command[1], tail(command, -1), stderr = stderr.log, stdout = stdout.log)) {
-            cat('FAILED', test, 'See', stderr.log, stdout.log, '\n')
+            cat('\x1b[31mFAILED\x1b[0m', test, 'See', stderr.log, stdout.log, '\n')
             return(TRUE)
         }
     } else {
         if (system2(command[1], tail(command, -1))) {
-            stop(paste('FAILED', test))
+            stop(paste('\x1b[31mFAILED\x1b[0m', test))
         }
     }
-    cat('PASSED', test, '\n')
+    cat('\x1b[32mPASSED\x1b[0m', test, '\n')
     return(FALSE)
 }
 

--- a/run_tests.R
+++ b/run_tests.R
@@ -1,8 +1,15 @@
 #!/usr/bin/env Rscript
+
 # This script runs most tests in nimble/inst/tests/ prioritized by duration.
+#
 # To run only some of the tests, define the environment variable NIMBLE_TEST_BATCH=N
 # where N is a number in 1,...,5.
+# To run tests in paralle, pass the argument --parallel, for example
+#
+#   ./run_tests.R --parallel  # Run tests in parallel.
+#
 # To see which tests will be run, pass the argument --dry-run, for example
+#
 #   ./run_tests.R --dry-run                        # Run all tests.                        
 #   $ NIMBLE_TEST_BATCH=1 ./run_tests.R --dry-run  # Run one batch of tests.
 
@@ -60,19 +67,48 @@ if (system2('/usr/bin/time', c('-v', 'echo', 'Running tests under /usr/bin/time 
 }
 
 # Run each test in a separate process to avoid dll garbage overload.
-for (test in allTests) {
-    cat('--------------------------------------------------------------------------------\n')
+runTest <- function(test, logToFile = FALSE, runViaTestthat = TRUE) {
+    if (!logToFile) cat('--------------------------------------------------------------------------------\n')
     cat('TESTING', test, '\n')
-    runViaTestthat <- TRUE
     if (runViaTestthat) {
         name <- gsub('test-(.*)\\.R', '\\1', test)
-        script = paste0('library(methods); library(testthat); library(nimble); test_package("nimble", "^', name, '$")')
+        script <- paste0('library(methods); library(testthat); library(nimble); test_package("nimble", "^', name, '$")')
         command <- c(runner, '-e', shQuote(script))
     } else {
         command <- c(runner, file.path('packages', 'nimble', 'inst', 'tests', test))
     }
-    if(system2(command[1], tail(command, -1))) {
-        stop(paste('FAILED', test))
+    if (logToFile) {
+        logDir <- '/tmp/log/nimble'
+        dir.create(logDir, recursive = TRUE, showWarnings = FALSE)
+        stderr.log <- file.path(logDir, paste0('test-', name, '.stderr'))
+        stdout.log <- file.path(logDir, paste0('test-', name, '.stdout'))
+        if (system2(command[1], tail(command, -1), stderr = stderr.log, stdout = stdout.log)) {
+            cat('FAILED', test, 'See', stderr.log, stdout.log, '\n')
+            return(TRUE)
+        }
+    } else {
+        if (system2(command[1], tail(command, -1))) {
+            stop(paste('FAILED', test))
+        }
     }
     cat('PASSED', test, '\n')
+    return(FALSE)
+}
+
+if ('--parallel' %in% commandArgs(trailingOnly = TRUE)) {
+    if (!require(parallel)) stop('Missing parallel package, required for --parallel')
+    cores <- detectCores()
+    cat('PARALLELIZING OVER', cores, 'CORES\n')
+    failed <- mclapply(allTests, runTest, logToFile = TRUE,
+                       mc.cores = cores, mc.preschedule = FALSE, mc.cleanup = TRUE)
+    numFailed <- sum(unlist(failed))
+    if (numFailed == 0) {
+        cat('PASSED all tests\n')
+    } else {
+        stop(paste('FAILED', numFailed, 'tests'))
+    }
+} else {
+    for (test in allTests) {
+        runTest(test)
+    }
 }


### PR DESCRIPTION
This adds a `--parallel` option to `run_tests.R` and adds a `test` target to the `nimble/packages/Makefile` to run tests in parallel.