### PR TITLE
Move test requirements from .travis.yml to install_requirements.R

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,12 +39,7 @@ addons:
       - time  # For /usr/bin/time profiling.
 
 install:
-  - Rscript -e "install.packages('igraph', repos = 'http://cran.us.r-project.org')"
-  - Rscript -e "install.packages('coda', repos = 'http://cran.us.r-project.org')"
-  - Rscript -e "install.packages('testthat', repos = 'http://cran.us.r-project.org')"
-  - Rscript -e "install.packages('mvtnorm', repos = 'http://cran.us.r-project.org')"  ## needed for test-distributions.R
-  - Rscript -e "install.packages('abind', repos = 'http://cran.us.r-project.org')"    ## needed for test-compareMCMCs.R
-  - Rscript -e "install.packages('covr', repos = 'http://cran.us.r-project.org')"  ## needed for code coverage reports
+  - ./install_requirements.R
   - R CMD build packages/nimble
   - R CMD INSTALL packages/nimble
 

--- a/install_requirements.R
+++ b/install_requirements.R
@@ -1,0 +1,16 @@
+#!/usr/bin/env Rscript
+
+requirements <- c(
+    'igraph',
+    'coda',
+    'testthat',
+    'mvtnorm',  ## needed for test-distributions.R
+    'abind',    ## needed for test-compareMCMCs.R
+    'covr')     ## needed for code coverage reports
+
+for (package in requirements) {
+    if (!suppressPackageStartupMessages(require(package,
+                                                character.only = TRUE))) {
+        install.packages(package, repos = 'http://cran.us.r-project.org')
+    }
+}

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -28,7 +28,8 @@ rhub: build FORCE
 	Rscript -e "library(rhub); check(platform = c('ubuntu-gcc-devel','windows-x86_64-devel','linux-x86_64-rocker-gcc-san','linux-x86_64-centos6-epel','fedora-clang-devel'))"
 
 test: FORCE
-	cd .. ; ./run_tests.R
+	cd .. ; ./install_requirements.R
+	cd .. ; ./run_tests.R --parallel
 
 # We are progressively delegating style to clang-format.
 # Some older C++ files are still styled manually.

--- a/run_tests.R
+++ b/run_tests.R
@@ -81,12 +81,12 @@ runTest <- function(test, logToFile = FALSE, runViaTestthat = TRUE) {
     } else {
         command <- c(runner, file.path('packages', 'nimble', 'inst', 'tests', test))
     }
+    env <- 'MAKEFLAGS=-j1'  # Work around broken job pipe when GNU make is run under mclapply.
     if (logToFile) {
         logDir <- '/tmp/log/nimble'
         dir.create(logDir, recursive = TRUE, showWarnings = FALSE)
         stderr.log <- file.path(logDir, paste0('test-', name, '.stderr'))
         stdout.log <- file.path(logDir, paste0('test-', name, '.stdout'))
-        env <- 'MAKEFLAGS=-j1'  # Work around broken job pipe when GNU make is run under mclapply.
         if (system2(command[1], tail(command, -1),
                     stderr = stderr.log, stdout = stdout.log, env = env)) {
             cat('\x1b[31mFAILED\x1b[0m', test, 'See', stderr.log, stdout.log, '\n')

--- a/run_tests.R
+++ b/run_tests.R
@@ -13,6 +13,10 @@
 #   ./run_tests.R --dry-run                        # Run all tests.                        
 #   $ NIMBLE_TEST_BATCH=1 ./run_tests.R --dry-run  # Run one batch of tests.
 
+# Parse command line options.
+optionDryRun <- ('--dry-run' %in% commandArgs(trailingOnly = TRUE))
+optionParallel <- ('--parallel' %in% commandArgs(trailingOnly = TRUE))
+
 # Avoid running these blacklisted tests, since they take too long.
 blacklist <- c('test-Math2.R', 'test-Mcmc2.R', 'test-Mcmc3.R', 'test-Filtering2.R')
 # Avoid running these tests since they test experimental features.
@@ -53,16 +57,16 @@ if (!is.na(testBatch)) {
         }
     }
 }
-
 cat('PLANNING TO TEST', allTests, sep = '\n  ')
 cat('PREDICTED DURATION =', sum(testTimes[allTests, 'time']), 'sec\n')
-if ('--dry-run' %in% commandArgs(trailingOnly = TRUE)) quit()
+if (optionDryRun) quit()
 
 # Run under /usr/bin/time -v if possible, to gather timing information.
-if (system2('/usr/bin/time', c('-v', 'echo', 'Running tests under /usr/bin/time -v'))) {
-    cat('Warning: Unable to run tests under /usr/bin/time -v\n')
-    runner <- 'Rscript'
+runner <- 'Rscript'
+if (optionParallel || system2('/usr/bin/time', c('-v', 'echo'), stderr=NULL)) {
+    cat('Not running tests under /usr/bin/time -v\n')
 } else {
+    cat('Running tests under /usr/bin/time -v\n')
     runner <- c('/usr/bin/time', '-v', 'Rscript')
 }
 
@@ -82,12 +86,14 @@ runTest <- function(test, logToFile = FALSE, runViaTestthat = TRUE) {
         dir.create(logDir, recursive = TRUE, showWarnings = FALSE)
         stderr.log <- file.path(logDir, paste0('test-', name, '.stderr'))
         stdout.log <- file.path(logDir, paste0('test-', name, '.stdout'))
-        if (system2(command[1], tail(command, -1), stderr = stderr.log, stdout = stdout.log)) {
+        env <- 'MAKEFLAGS=-j1'  # Work around broken job pipe when GNU make is run under mclapply.
+        if (system2(command[1], tail(command, -1),
+                    stderr = stderr.log, stdout = stdout.log, env = env)) {
             cat('\x1b[31mFAILED\x1b[0m', test, 'See', stderr.log, stdout.log, '\n')
             return(TRUE)
         }
     } else {
-        if (system2(command[1], tail(command, -1))) {
+        if (system2(command[1], tail(command, -1), env = env)) {
             stop(paste('\x1b[31mFAILED\x1b[0m', test))
         }
     }
@@ -95,7 +101,7 @@ runTest <- function(test, logToFile = FALSE, runViaTestthat = TRUE) {
     return(FALSE)
 }
 
-if ('--parallel' %in% commandArgs(trailingOnly = TRUE)) {
+if (optionParallel) {
     if (!require(parallel)) stop('Missing parallel package, required for --parallel')
     cores <- detectCores()
     cat('PARALLELIZING OVER', cores, 'CORES\n')


### PR DESCRIPTION
This fixes issues with `run_tests.R --parallel` and enables parallel testing by default.
The two issues were:

1. Missing dependencies.
  This is fixed by moving requirements into a script `install_requirements.R` which is used by both `.travis.yml` and `make test`.
2. Conflict between GNU `make` and R's `parallel::mclapply`.
  This is fixed by setting `MAKEFLAGS=-j1` in child processes that run tests.