### PR TITLE
Add xfail arguments to math tests

### DIFF
--- a/packages/nimble/inst/tests/mathTestLists.R
+++ b/packages/nimble/inst/tests/mathTestLists.R
@@ -1,4 +1,4 @@
-1### INSTRUCTIONS:
+### INSTRUCTIONS:
 ## enter each test as a list, with an informative name, NIMBLE expression to evaluate, vector of input dimensions, value of output dimension, and (if NIMBLE expression cannot be directly evaluated in R) the equivalent pure R expression whose result should match the NIMBLE result
 
 testsVaried = list(
@@ -39,7 +39,7 @@ testsBasicMath = list(
   list(name = 'log of vector', expr = quote(out <- log(abs(arg1))), inputDim = 1, outputDim = 1),
   list(name = 'sqrt of vector', expr = quote(out <- sqrt(abs(arg1))), inputDim = 1, outputDim = 1),
   list(name = 'abs of vector', expr = quote(out <- abs(arg1)), inputDim = 1, outputDim = 1),
-##  list(name = 'step of vector', expr = quote(out <- step(arg1)), inputDim = 1, outputDim = 1, Rcode = quote(out <- as.numeric(arg1 > 0))),   ## FAILS on compileNimble(nfR) with Eigen error
+  list(name = 'step of vector', expr = quote(out <- step(arg1)), inputDim = 1, outputDim = 1, Rcode = quote(out <- as.numeric(arg1 > 0)), xfail = 'math.*runs'), ## FAILS on compileNimble(nfR) with Eigen error.
   list(name = 'cube of vector', expr = quote(out <- cube(arg1)), inputDim = 1, outputDim = 1),
   list(name = 'cos of vector', expr = quote(out <- cos(arg1)), inputDim = 1, outputDim = 1),
   list(name = 'acos of cos of vector', expr = quote(out <- acos(cos(arg1))), inputDim = 1, outputDim = 1),
@@ -52,7 +52,7 @@ testsBasicMath = list(
   list(name = 'tanh of vector', expr = quote(out <- tanh(arg1)), inputDim = 1, outputDim = 1),
   list(name = 'acosh of vector', expr = quote(out <- acosh(1 + abs(arg1))), inputDim = 1, outputDim = 1),
   list(name = 'asinh of vector', expr = quote(out <- asinh(arg1)), inputDim = 1, outputDim = 1),
-##  list(name = 'atanh of vector', expr = quote(out <- atanh(arg1%%1)), inputDim = 1, outputDim = 1), ## FAILS - issue here is probably that modulo on vecs doesn't work but need to restrict domain for atanh
+  list(name = 'atanh of vector', expr = quote(out <- atanh(arg1%%1)), inputDim = 1, outputDim = 1, xfail = 'math.*runs'), ## FAILS - issue here is probably that modulo on vecs doesn't work but need to restrict domain for atanh
   ###
   list(name = 'scalar + scalar', expr = quote(out <- arg1 + arg2), inputDim = c(0,0), outputDim = 0),
   list(name = 'diff of scalars', expr = quote(out <- arg1 - arg2), inputDim = c(0,0), outputDim = 0),
@@ -62,7 +62,7 @@ testsBasicMath = list(
   list(name = 'power of scalars via pow', expr = quote(out <- pow(arg1, arg2)), inputDim = c(0,0), outputDim = 0),
   list(name = 'power of scalars via ^ with positive first arg', expr = quote(out <- exp(arg1) ^ arg2), inputDim = c(0,0), outputDim = 0),
   list(name = 'power of scalars via pow with positive first arg', expr = quote(out <- pow(exp(arg1), arg2)), inputDim = c(0,0), outputDim = 0),
-  list(name = 'modulo of scalars', expr = quote(out <- arg1 %% arg2), inputDim = c(0,0), outputDim = 0),
+  list(name = 'modulo of scalars', expr = quote(out <- arg1 %% arg2), inputDim = c(0,0), outputDim = 0),  # FLAKY
   list(name = 'min of scalars', expr = quote(out <- min(arg1, arg2)), inputDim = c(0,0), outputDim = 0),
   list(name = 'max of scalars', expr = quote(out <- max(arg1, arg2)), inputDim = c(0,0), outputDim = 0),
   ###
@@ -70,9 +70,9 @@ testsBasicMath = list(
   list(name = 'diff of vectors', expr = quote(out <- arg1 - arg2), inputDim = c(1,1), outputDim = 1),
   list(name = 'product of vectors', expr = quote(out <- arg1 * arg2), inputDim = c(1,1), outputDim = 1),
   list(name = 'ratio of vectors', expr = quote(out <- arg1 / arg2), inputDim = c(1,1), outputDim = 1),
-##  list(name = 'power of vectors via ^', expr = quote(out <- arg1 ^ arg2), inputDim = c(1,1), outputDim = 1), ## FAILS with Eigen casting
-  ## list(name = 'power of vectors via pow', expr = quote(out <- pow(arg1, arg2)), inputDim = c(1,1), outputDim = 1), ## FAILS with Eigen casting
-  ## list(name = 'modulo of vectors', expr = quote(out <- arg1 %% arg2), inputDim = c(1,1), outputDim = 1), ## FAILS with Eigen casting
+  list(name = 'power of vectors via ^', expr = quote(out <- arg1 ^ arg2), inputDim = c(1,1), outputDim = 1, xfail = 'math.*runs'), ## FAILS with Eigen casting
+  list(name = 'power of vectors via pow', expr = quote(out <- pow(arg1, arg2)), inputDim = c(1,1), outputDim = 1, xfail = 'math.*runs'), ## FAILS with Eigen casting
+  list(name = 'modulo of vectors', expr = quote(out <- arg1 %% arg2), inputDim = c(1,1), outputDim = 1, xfail = 'math.*runs'), ## FAILS with Eigen casting
   list(name = 'pmin of vectors', expr = quote(out <- pmin(arg1, arg2)), inputDim = c(1,1), outputDim = 1),
   list(name = 'pmax of vectors', expr = quote(out <- pmax(arg1, arg2)), inputDim = c(1,1), outputDim = 1),
   ###
@@ -85,8 +85,8 @@ testsBasicMath = list(
   list(name = 'power of vector and constant via ^', expr = quote(out <- arg1 ^ 2), inputDim = c(1,0), outputDim = 1),
   list(name = 'power of vector and constant via pow', expr = quote(out <- pow(arg1, 2)), inputDim = c(1,0), outputDim = 1),
   list(name = 'power of vector and scalar via ^ with positive first arg', expr = quote(out <- exp(arg1) ^ arg2), inputDim = c(1,0), outputDim = 1),
-  list(name = 'power of vector and scalar via pow with positive first arg', expr = quote(out <- pow(exp(arg1), arg2)), inputDim = c(1,0), outputDim = 1)
-  ## list(name = 'modulo of vector and scalar', expr = quote(out <- arg1 %% arg2), inputDim = c(1,0), outputDim = 1) ## FAILS with Eigen casting
+  list(name = 'power of vector and scalar via pow with positive first arg', expr = quote(out <- pow(exp(arg1), arg2)), inputDim = c(1,0), outputDim = 1),
+  list(name = 'modulo of vector and scalar', expr = quote(out <- arg1 %% arg2), inputDim = c(1,0), outputDim = 1, xfail = 'math.*runs') ## FAILS with Eigen casting
   )
 
 testsMoreMath = list(
@@ -142,16 +142,16 @@ testsReduction = list(
   list(name = 'sd of vector', expr = quote(out <- min(arg1)), inputDim = 1, outputDim = 0),
   list(name = 'var of vector', expr = quote(out <- min(arg1)), inputDim = 1, outputDim = 0),
   list(name = 'prod of vector', expr = quote(out <- min(arg1)), inputDim = 1, outputDim = 0),
-  ## list(name = 'norm of vector', expr = quote(out <- norm(arg1)), inputDim = 1, outputDim = 0),  ## norm doesn't work on vector in R
+  list(name = 'norm of vector', expr = quote(out <- norm(arg1)), inputDim = 1, outputDim = 0, xfail = 'math.*runs'),  ## norm doesn't work on vector in R
   ### matrix
   list(name = 'min of matrix', expr = quote(out <- min(arg1)), inputDim = 2, outputDim = 0),
   list(name = 'max of matrix', expr = quote(out <- min(arg1)), inputDim = 2, outputDim = 0),
   list(name = 'sum of matrix', expr = quote(out <- min(arg1)), inputDim = 2, outputDim = 0),
   list(name = 'mean of matrix', expr = quote(out <- min(arg1)), inputDim = 2, outputDim = 0),
-##  list(name = 'sd of matrix', expr = quote(out <- min(arg1)), inputDim = 2, outputDim = 0),
+  list(name = 'sd of matrix', expr = quote(out <- min(arg1)), inputDim = 2, outputDim = 0),
   list(name = 'var of matrix', expr = quote(out <- min(arg1)), inputDim = 2, outputDim = 0),
-  list(name = 'prod of matrix', expr = quote(out <- min(arg1)), inputDim = 2, outputDim = 0)
-##  list(name = 'norm of matrix', expr = quote(out <- norm(arg1)), inputDim = 2, outputDim = 0, Rcode = quote(out <- norm(arg1, "F"))) ## NIMBLE's C norm is apparently Frobenius, so R and C nimble functions differ => FAILS
+  list(name = 'prod of matrix', expr = quote(out <- min(arg1)), inputDim = 2, outputDim = 0),
+  list(name = 'norm of matrix', expr = quote(out <- norm(arg1)), inputDim = 2, outputDim = 0, Rcode = quote(out <- norm(arg1, "F")), xfail = 'math.*runs') ## NIMBLE's C norm is apparently Frobenius, so R and C nimble functions differ => FAILS
   )
 
 testsComparison = list(
@@ -160,9 +160,9 @@ testsComparison = list(
   list(name = 'equals, scalar', expr = quote(out <- arg1 == arg2), inputDim = c(0,0), outputDim = 0),
   list(name = 'not equals, scalar', expr = quote(out <- arg1 != arg2), inputDim = c(0,0), outputDim = 0),
   ## vector
-  ## list(name = 'greater than, vector', expr = quote(out <- arg1 > arg2), inputDim = c(1,1), outputDim = 1), ## FAILS with Eigen issue
-  ## list(name = 'equals, vector', expr = quote(out <- arg1 == arg2), inputDim = c(1,1), outputDim = 1),  ## FAILS with Eigen issue
-  ## list(name = 'not equals, vector', expr = quote(out <- arg1 != arg2), inputDim = c(1,1), outputDim = 1),  ## FAILS with Eigen issue
+  list(name = 'greater than, vector', expr = quote(out <- arg1 > arg2), inputDim = c(1,1), outputDim = 1, xfail = 'math.*runs'), ## FAILS with Eigen issue
+  list(name = 'equals, vector', expr = quote(out <- arg1 == arg2), inputDim = c(1,1), outputDim = 1, xfail = 'math.*runs'),  ## FAILS with Eigen issue
+  list(name = 'not equals, vector', expr = quote(out <- arg1 != arg2), inputDim = c(1,1), outputDim = 1, xfail = 'math.*runs'),  ## FAILS with Eigen issue
   ## logical
   list(name = 'and operator, scalar', expr = quote(out <- arg1 & arg2), inputDim = c(0,0), outputDim = 0, logicalArgs = c(TRUE, TRUE)),
   list(name = 'or operator, scalar', expr = quote(out <- arg1 | arg2), inputDim = c(0,0), outputDim = 0, logicalArgs = c(TRUE, TRUE)),

--- a/packages/nimble/inst/tests/test-math.R
+++ b/packages/nimble/inst/tests/test-math.R
@@ -9,16 +9,16 @@ context("Testing of math functions in NIMBLE code")
 source(system.file(file.path('tests', 'mathTestLists.R'), package = 'nimble'))
 
 set.seed(0)
-ans1 <- sapply(testsVaried, test_math)    ## 12
-ans2 <- sapply(testsBasicMath, test_math) ## 70
+ans1 <- sapply(testsVaried, test_math, 'math')    ## 12
+ans2 <- sapply(testsBasicMath, test_math, 'math') ## 70
 if(.Platform$OS.type == 'windows') {
     message("Since you are running on Windows, tests stopped prior to reaching max DLL limit.  Please use test-math2 to continue")
     stop()
 }
-ans3 <- sapply(testsMoreMath, test_math)  ## 41
-ans4 <- sapply(testsReduction, test_math) ## 13
-ans5 <- sapply(testsComparison, test_math)## 6
-ans6 <- sapply(testsMatrix, test_math)    ## 19
+ans3 <- sapply(testsMoreMath, test_math, 'math')  ## 41
+ans4 <- sapply(testsReduction, test_math, 'math') ## 13
+ans5 <- sapply(testsComparison, test_math, 'math')## 6
+ans6 <- sapply(testsMatrix, test_math, 'math')    ## 19
 
 
 


### PR DESCRIPTION
This adds support for an optional `xfail` field of the parametrized tests for math, and avoids reliance on commenting-out-code in tests.

## Why?

We have a nice bank of math examples in [`mathTestLists.R`](https://github.com/nimble-dev/nimble/blob/devel/packages/nimble/inst/tests/mathTestLists.R) that are currently used in `test-math.R`, and we're starting to use those examples in other branches. A few those fail, and our current practice is to comment-out the failing tests. This is problematic when different examples fail on different branches or files: we would currently have to comment out an example if it fails in any branch or file.

## How?

This PR adds an `xfail` field to the example lists (the name is borrowed from py.test, dejagnu, and php). This field specifies a regular expression of circumstances under which the test can fail, using the convention that `test_math()` will now take a second argument as the context name (currently only 'math'), and can fail in three circumstances:

- general compile error" `xfail = 'math.*runs'`,
- disagreement between R and the Nimble DSL: `xfail = 'math.*DSL'`
- disagreement between R and compiled code: `xfail = 'math.*Cpp`

Regular expressions seem like the simplest way to specify the sparse tensor of expected failures (contexts x expectations). For example we can in the future specify `xfail = '(math|tensorflow).*Cpp'`.