### PR TITLE
remove first include of Makeconf in CppCode/GNUmakefile

### DIFF
--- a/packages/nimble/inst/CppCode/GNUmakefile
+++ b/packages/nimble/inst/CppCode/GNUmakefile
@@ -8,7 +8,8 @@ ifndef R_SHARE_DIR
 endif
 
 ## include raw package Makeconf first so that if subsequent removal of -g flags fails locally, raw Makeconf settings will be in place
--include $(R_HOME)/etc$(R_ARCH)/Makeconf
+## Actually, this include makes OS X scream warnings about over-ridden make settings from second include below
+#-include $(R_HOME)/etc$(R_ARCH)/Makeconf
 # Don't have to succeed in including this if we are calling cleanup in the nimble package directory.
 # Following two lines result in much smaller libnimble.a or equivalent by removing -g flags
 $(shell $(R_HOME)/bin$(R_ARCH)/Rscript --vanilla ./customizeMakeconf.R)

--- a/packages/nimble/inst/CppCode/customizeMakeconf.R
+++ b/packages/nimble/inst/CppCode/customizeMakeconf.R
@@ -1,5 +1,5 @@
 try({
-    packageMakeconfFile <- file.path(R.home('etc'), 'Makeconf')
+    packageMakeconfFile <- file.path(R.home('etc'), .Platform$r_arch, 'Makeconf')
     if(file.exists(packageMakeconfFile)) {
         file.copy(packageMakeconfFile, 'Makeconf')
         lines <- readLines('Makeconf')


### PR DESCRIPTION
On OS X a set of ugly warnings are issued from the double use of `include` in `CppCode/GNUmakefile`.  This pull request removes the first one, since it was intended only as a failsafe when the `customizeMakeconf` script was introduced.  It should no longer be necessary.