### PR TITLE
Add returnESS() method to bootstrap  and auxiliary particle filters

### DIFF
--- a/packages/nimble/NEWS
+++ b/packages/nimble/NEWS
@@ -18,6 +18,8 @@ USER LEVEL CHANGES
 
 -- pi is now handled as a constant or variable in a nimbleFunction (but cannot be used as a constant in model code).
 
+-- returnESS() method added to the bootstrap filter and auxiliary particle filter.
+
 DEVELOPER LEVEL CHANGES
 
 -- Improvements added to testing system, including safeguarding against silent failures, use of gold files, batching of compiler tests, more expected failures, conversion to running all tests using test_package, and parallelization on Travis-CI.

--- a/packages/nimble/R/filtering_auxiliary.R
+++ b/packages/nimble/R/filtering_auxiliary.R
@@ -6,8 +6,14 @@
 ##  Pitt et al., 2012
 
 auxStepVirtual <- nimbleFunctionVirtual(
-  run = function(m = integer()) 
+  run = function(m = integer()) {
     returnType(double())
+  },
+  methods = list(
+    returnESS = function() {
+      returnType(double())
+    }
+  )
 )
 
 auxFuncVirtual <- nimbleFunctionVirtual(
@@ -85,7 +91,8 @@ auxFStep <- nimbleFunction(
     else{
       for(i in 1:numLatentNodes)
         auxFuncList[[i]] <- auxSimFunc(model,  allLatentNodes)
-     }
+    }
+    ess <- 0
   },
   run = function(m = integer()) {
     returnType(double())
@@ -146,6 +153,7 @@ auxFStep <- nimbleFunction(
     }
     
     normWts <- exp(wts)/sum(exp(wts))
+    ess <<- 1/sum(normWts^2) 
     
     for(i in 1:m){
       ##  save weights for use in next timepoint's look-ahead step
@@ -169,7 +177,14 @@ auxFStep <- nimbleFunction(
     }
     return(log(outLL))
 return(0)
-  }, where = getLoadingNamespace()
+  }, 
+  methods = list(
+    returnESS = function() {
+      returnType(double(0))
+      return(ess)
+    }
+  ),
+  where = getLoadingNamespace()
 )
 
 
@@ -210,6 +225,10 @@ return(0)
 #'   The auxiliary particle filter uses a lookahead function to select promising particles before propagation.  This function can eithre be the expected
 #'   value of the latent state at the next time point (\code{lookahead = 'mean'}) or a simulation from the distribution of the latent state at the next time point (\code{lookahead = 'simulate'}), conditioned on the current particle.
 #'   
+#'  @section \code{returnESS()} Method:
+#'  Calling the \code{returnESS()} method of an auxiliary particle filter after that filter has been \code{run()} for a given model will return a vector of ESS (effective
+#'  sample size) values, one value for each time point.
+
 #' @export
 #' 
 #' @family particle filtering methods
@@ -222,7 +241,8 @@ return(0)
 #'    control = list(saveAll = TRUE, lookahead = 'mean'))
 #' Cmodel <- compileNimble(model)
 #' Cmy_AuxF <- compileNimble(my_AuxF, project = model)
-#' logLike <- Cmy_AuxF(m = 100000)
+#' logLike <- Cmy_AuxF$run(m = 100000)
+#' ESS <- Cmy_AuxF$returnESS(m = 100000)
 #' hist(as.matrix(Cmy_Auxf$mvEWSamples, 'x'))
 #' }
 buildAuxiliaryFilter <- nimbleFunction(
@@ -324,6 +344,8 @@ buildAuxiliaryFilter <- nimbleFunction(
     for(iNode in seq_along(nodes))
       auxStepFunctions[[iNode]] <- auxFStep(model, mvEWSamples, mvWSamples, nodes,
                                             iNode, names, saveAll, smoothing, lookahead, silent)
+    
+    essVals <- rep(0, length(nodes))
   },
   run = function(m = integer(default = 10000)) {
     returnType(double())
@@ -334,7 +356,8 @@ buildAuxiliaryFilter <- nimbleFunction(
     logL <- 0
     for(iNode in seq_along(auxStepFunctions)) {
       logL <- logL + auxStepFunctions[[iNode]]$run(m)
-
+      essVals[iNode] <<- auxStepFunctions[[iNode]]$returnESS()
+      
       # when all particles have 0 weight, likelihood becomes NAN
       # this happens if top-level params have bad values - possible
       # during pmcmc for example
@@ -344,6 +367,13 @@ buildAuxiliaryFilter <- nimbleFunction(
     }
   
     return(logL)
-  },  where = getLoadingNamespace()
+  },
+  methods = list(
+    returnESS = function(){
+      returnType(double(1))
+      return(essVals)
+    }
+  ),where = getLoadingNamespace()
 )
+
 

--- a/packages/nimble/R/filtering_bootstrap.R
+++ b/packages/nimble/R/filtering_bootstrap.R
@@ -2,12 +2,16 @@
 ##  We have a build function (buildBootstrapFilter),
 ##  and step function.
 
-
 bootStepVirtual <- nimbleFunctionVirtual(
-  run = function(m = integer(), threshNum=double(), prevSamp = logical()) 
+  run = function(m = integer(), threshNum=double(), prevSamp = logical()) {
     returnType(double(1))
+  },
+  methods = list(
+    returnESS = function() {
+      returnType(double())
+    }
+  )
 )
-
 
 # Bootstrap filter as specified in Doucet & Johnasen '08,
 # uses weights from previous time point to calculate likelihood estimate.
@@ -43,6 +47,7 @@ bootFStep <- nimbleFunction(
       prevInd <- 1 
     }
     isLast <- (iNode == length(nodes))
+    ess <- 0
   },
   run = function(m = integer(), threshNum = double(), prevSamp = logical()) {
     returnType(double(1))
@@ -95,7 +100,7 @@ bootFStep <- nimbleFunction(
     
     # Normalize weights and calculate effective sample size 
     wts <- exp(wts)/sum(exp(wts))
-    ess <- 1/sum(wts^2) 
+    ess <<- 1/sum(wts^2) 
     
     # Determine whether to resample by weights or not
     if(ess < threshNum){
@@ -122,7 +127,13 @@ bootFStep <- nimbleFunction(
       }
     }
     return(out)
-  }, where = getLoadingNamespace()
+  },
+  methods = list(
+    returnESS = function(){
+      returnType(double(0))
+      return(ess)
+    }
+  ), where = getLoadingNamespace()
 )
 
 #' Create a bootstrap particle filter algorithm to estimate log-likelihood.
@@ -166,6 +177,10 @@ bootFStep <- nimbleFunction(
 #'  states in the \code{mvWSamples} modelValues object, with corresponding logged weights in \code{mvWSamples['wts',]}.
 #'  An equally weighted sample from the posterior can be found in the \code{mvEWsamp} \code{modelValues} object.
 #'
+#' @section \code{returnESS()} Method:
+#'  Calling the \code{returnESS()} method of a bootstrap filter after that filter has been \code{run()} for a given model will return a vector of ESS (effective
+#'  sample size) values, one value for each time point.
+#'  
 #' @export
 #' 
 #' @family particle filtering methods
@@ -176,7 +191,8 @@ bootFStep <- nimbleFunction(
 #' my_BootF <- buildBootstrapFilter(model, 'x[1:100]')
 #' Cmodel <- compileNimble(model)
 #' Cmy_BootF <- compileNimble(my_BootF, project = model)
-#' logLike <- Cmy_BootF(m = 100000)
+#' logLike <- Cmy_BootF$run(m = 100000)
+#' ESS <- Cmy_BootF$returnESS()
 #' boot_X <- as.matrix(Cmy_BootF$mvEWSamples)
 #' }
 buildBootstrapFilter <- nimbleFunction(
@@ -270,6 +286,7 @@ buildBootstrapFilter <- nimbleFunction(
       bootStepFunctions[[iNode]] <- bootFStep(model, mvEWSamples, mvWSamples, nodes,
                                               iNode, names, saveAll, smoothing, silent) 
     }
+    essVals <- rep(0, length(nodes))
   },
   run = function(m = integer(default = 10000)) {
     returnType(double())
@@ -285,10 +302,17 @@ buildBootstrapFilter <- nimbleFunction(
       out <- bootStepFunctions[[iNode]]$run(m,threshNum, prevSamp)
       logL <- logL + out[1]
       prevSamp <- out[2]
+      essVals[iNode] <<- bootStepFunctions[[iNode]]$returnESS()
       if(logL == -Inf) return(logL)
       if(is.nan(logL)) return(-Inf)
       if(logL == Inf) return(-Inf) 
     }
     return(logL)
-  }, where = getLoadingNamespace()
+  },
+  methods = list(
+    returnESS = function(){
+      returnType(double(1))
+      return(essVals)
+    }
+  ), where = getLoadingNamespace()
 )


### PR DESCRIPTION
This PR adds a `returnESS()` method to the bootstrap filter and auxiliary particle filter.  If `returnESS()` is called after the `run()` method of a specialized particle filter has been called, a vector of ESS values will be returned - one ESS value for each time point.  An example of the use of `returnESS()` is below:

```
 ssCode <- nimbleCode({
   x0 ~ dnorm(0,1)
   x[1] ~ dnorm(x0, 1)
   y[1] ~ dnorm(x[1], var = 2)
     for(i in 2:3) {
         x[i] ~ dnorm(x[i-1], 1)
         y[i] ~ dnorm(x[i], var = 2)
     }
 })
 ssData = list(y = c(0,1,2))
 ssInits = list(x0 = 0)
ssModel <- nimbleModel(code = ssCode, data = ssData, inits = ssInits)
compileNimble(ssModel)

ssBootFilter <- buildBootstrapFilter(ssModel, nodes = 'x')
CssBootFilter <- compileNimble(ssBootFilter, project = ssModel)
CssBootFilter$run(10000)
ESS <- CssBootFilter$returnESS()
```