### PR TITLE
Dynamic indexing fix typos

### DIFF
--- a/packages/nimble/R/BUGS_BUGSdecl.R
+++ b/packages/nimble/R/BUGS_BUGSdecl.R
@@ -425,22 +425,25 @@ getSymbolicParentNodesRecurse <- function(code, constNames = list(), indexNames 
                                 replaceable = FALSE,
                                 hasIndex = any(contentsHasIndex)))
                 } else { ## non-replaceable indices are dynamic indices
-                    if(!nimbleOptions()$allowDynamicIndexing)
+                    if(!nimbleOptions()$allowDynamicIndexing) {
                         warning("It appears you are trying to use dynamic indexing (i.e., the index of a variable is determined by something that is not a constant) in: ", deparse(code), ". This is now allowed in version 0.6-6 as an option, but you need to set 'nimbleOptions(allowDynamicIndexing = TRUE)'.")
                         dynamicIndexParent <- code[[2]]
-                    else {
-                        if(any(sapply(contentsCode, detectNonscalarIndex)))
+                    } else {
+                        if(any(sapply(contentsCode, detectNonscalarIndex))) {
                             stop("getSymbolicParentNodesRecurse: only scalar random indices are allowed; vector random indexing found in ", deparse(code))
+                        }
                         indexedVariable <- deparse(code[[2]])
                         dynamicIndexParent <- addUnknownIndexToVarNameInBracketExpr(code, contextID)
                         dynamicIndexParent[-c(1, 2)][ !contentsReplaceable ] <- as.numeric(NA)
                         cnt <- 1
                         nonNestedContents <- which(!sapply(contentsCode, usedInIndex)) ## nested indexing can introduce contentsCode elements that have already been tagged with dynamic index info
-                        if(sum(!contentsReplaceable) != length(nonNestedContents))
+                        if(sum(!contentsReplaceable) != length(nonNestedContents)) {
                             stop("getSymbolicParentNodesRecurse: bug in indexing of dynamic index parents.")
+                        }
                         for(iC in which(!contentsReplaceable)) {
-                            if(cnt > length(contentsCode)) 
+                            if(cnt > length(contentsCode)) {
                                 stop("getSymbolicParentNodesRecurse: bug in indexing of dynamic index parents.")
+                            }
                             contentsCode[[nonNestedContents[cnt]]] <- addIndexWrapping(
                                 contentsCode[[nonNestedContents[cnt]]], code[[2+iC]],
                                                                     indexedVariable, iC)

--- a/packages/nimble/R/nimbleFunction_nodeFunction.R
+++ b/packages/nimble/R/nimbleFunction_nodeFunction.R
@@ -134,7 +134,7 @@ ndf_createDetermSimulate <- function(LHS, RHS, dynamicIndexLimitsExpr, RHSnonRep
                            list(LHS = LHS,
                                 RHS = RHS,
                                 CONDITION = dynamicIndexLimitsExpr,
-                                TEXT = paste0("dynamic index out of bounds: ", deparse(RHSnonReplaced)))
+                                TEXT = paste0("dynamic index out of bounds: ", deparse(RHSnonReplaced))))
     } else code <- substitute(LHS <<- RHS,
                               list(LHS = LHS,
                                    RHS = RHS))


### PR DESCRIPTION
If tests were quicker, then developers would be more likely to run tests before committing.