### PR TITLE
Cleanup C++ code in nimble/inst/*Utils.*

### DIFF
--- a/packages/Makefile
+++ b/packages/Makefile
@@ -35,10 +35,12 @@ test: FORCE
 # Some older C++ files are still styled manually.
 clang-format: FORCE
 	clang-format -style=file \
-	  nimble/inst/include/nimble/NimArrBase.h \
-	  nimble/inst/include/nimble/NimArr.h \
-	  nimble/inst/include/nimble/predefinedNimbleLists.h \
+	  nimble/inst/CppCode/*Utils.cpp \
 	  nimble/inst/CppCode/predefinedNimbleLists.cpp \
+	  nimble/inst/include/nimble/*Utils.h \
+	  nimble/inst/include/nimble/NimArr.h \
+	  nimble/inst/include/nimble/NimArrBase.h \
+	  nimble/inst/include/nimble/predefinedNimbleLists.h \
 	  -i
 
 # Keeps .Rproj.user/ and .Rhistory.

--- a/packages/nimble/inst/CppCode/ModelClassUtils.cpp
+++ b/packages/nimble/inst/CppCode/ModelClassUtils.cpp
@@ -27,10 +27,9 @@ NimArrType** cGetModelElementPtr(SEXP Sextptr, SEXP Sname) {
   }
   string name = STRSEXP_2_string(Sname, 0);
   ModelBase* m = static_cast<ModelBase*>(R_ExternalPtrAddr(Sextptr));
-  return (static_cast<NimArrType**>(
-      m->getObjectPtr(name)));  // I think this has wrong pointer-depth -Perry.
-                                // getObjectPtr always returns an address, so it
-                                // is a **NimArr<>
+  // I think this has wrong pointer-depth -Perry.
+  // getObjectPtr always returns an address, so it is a **NimArr<>
+  return (static_cast<NimArrType**>(m->getObjectPtr(name)));
 }
 
 SEXP getModelElementPtr(SEXP Sextptr, SEXP Sname) {

--- a/packages/nimble/inst/CppCode/ModelClassUtils.cpp
+++ b/packages/nimble/inst/CppCode/ModelClassUtils.cpp
@@ -1,66 +1,73 @@
 #include "nimble/ModelClassUtils.h"
 
-SEXP getModelValuesPtrFromModel (SEXP rPtr){
-	void* vPtr = R_ExternalPtrAddr(rPtr);
-	if(vPtr == 0){
-		PRINTF("Warning: rPtr points to null!\n");
-		return(R_NilValue);
-	}
-	ModelBase* modelBasePtr = static_cast<ModelBase*> (vPtr);
-	void* cModelValuesPtr = static_cast<void *>((*modelBasePtr).getModelValuesPtr());
-	SEXP rModelValuesPtr;
- 	PROTECT(rModelValuesPtr = R_MakeExternalPtr(cModelValuesPtr, R_NilValue, R_NilValue));
-	UNPROTECT(1);
-	return(rModelValuesPtr) ;
+SEXP getModelValuesPtrFromModel(SEXP rPtr) {
+  void* vPtr = R_ExternalPtrAddr(rPtr);
+  if (vPtr == 0) {
+    PRINTF("Warning: rPtr points to null!\n");
+    return (R_NilValue);
+  }
+  ModelBase* modelBasePtr = static_cast<ModelBase*>(vPtr);
+  void* cModelValuesPtr =
+      static_cast<void*>((*modelBasePtr).getModelValuesPtr());
+  SEXP rModelValuesPtr;
+  PROTECT(rModelValuesPtr =
+              R_MakeExternalPtr(cModelValuesPtr, R_NilValue, R_NilValue));
+  UNPROTECT(1);
+  return (rModelValuesPtr);
 }
 
 NimArrType** cGetModelElementPtr(SEXP Sextptr, SEXP Sname) {
-  if(!isString(Sname)) {
+  if (!isString(Sname)) {
     PRINTF("Error: Sname is not character!\n");
-    return(NULL);
+    return (NULL);
   }
-  if(!R_ExternalPtrAddr(Sextptr)) {
+  if (!R_ExternalPtrAddr(Sextptr)) {
     PRINTF("Error: Sextptr is not a a valid external pointer\n");
-    return(NULL);
+    return (NULL);
   }
   string name = STRSEXP_2_string(Sname, 0);
-  ModelBase *m = static_cast< ModelBase *>(R_ExternalPtrAddr(Sextptr));
-  return( static_cast <NimArrType**> (m->getObjectPtr(name) ) );// I think this has wrong pointer-depth -Perry.  getObjectPtr always returns an address, so it is a **NimArr<>
+  ModelBase* m = static_cast<ModelBase*>(R_ExternalPtrAddr(Sextptr));
+  return (static_cast<NimArrType**>(
+      m->getObjectPtr(name)));  // I think this has wrong pointer-depth -Perry.
+                                // getObjectPtr always returns an address, so it
+                                // is a **NimArr<>
 }
 
-SEXP getModelElementPtr(SEXP Sextptr, SEXP Sname){
-	NimArrType** vPtr = cGetModelElementPtr(Sextptr, Sname) ;
-	SEXP rPtr = R_MakeExternalPtr(vPtr, R_NilValue, R_NilValue);
-	PROTECT(rPtr);
-	UNPROTECT(1);
-	return(rPtr);	
+SEXP getModelElementPtr(SEXP Sextptr, SEXP Sname) {
+  NimArrType** vPtr = cGetModelElementPtr(Sextptr, Sname);
+  SEXP rPtr = R_MakeExternalPtr(vPtr, R_NilValue, R_NilValue);
+  PROTECT(rPtr);
+  UNPROTECT(1);
+  return (rPtr);
 }
 
-
-// This is for the new method of building modelValues. 
+// This is for the new method of building modelValues.
 // Returns a character string rName s.t. in R, .Call(rName)
 // will build our modelValues object and return a pointer
-SEXP getMVBuildName (SEXP rPtr){
-	void* vPtr = R_ExternalPtrAddr(rPtr);
-	if(vPtr == 0){
-		PRINTF("Warning: rPtr points to null!\n");
-		return(R_NilValue);
-	}
-	Values* modelValuesPtr = static_cast<Values*> (vPtr);
-	string mVBuildName = (*modelValuesPtr).getMVBuildName();
-	if (mVBuildName == "missing")
-		PRINTF("Warning: buildName missing in modelValues! \nConstructor must assign the string buildName to the name which call a SEXP that builds modelValues object\n");
-	SEXP rName = allocVector(STRSXP, 1);
-	PROTECT(rName);
-	SEXP mvbn = mkChar(mVBuildName.c_str() );
-	PROTECT(mvbn);
-	SET_STRING_ELT(rName, 0, mvbn );
-	UNPROTECT(2);
-	return(rName);
+SEXP getMVBuildName(SEXP rPtr) {
+  void* vPtr = R_ExternalPtrAddr(rPtr);
+  if (vPtr == 0) {
+    PRINTF("Warning: rPtr points to null!\n");
+    return (R_NilValue);
+  }
+  Values* modelValuesPtr = static_cast<Values*>(vPtr);
+  string mVBuildName = (*modelValuesPtr).getMVBuildName();
+  if (mVBuildName == "missing")
+    PRINTF(
+        "Warning: buildName missing in modelValues! \nConstructor must assign "
+        "the string buildName to the name which call a SEXP that builds "
+        "modelValues object\n");
+  SEXP rName = allocVector(STRSXP, 1);
+  PROTECT(rName);
+  SEXP mvbn = mkChar(mVBuildName.c_str());
+  PROTECT(mvbn);
+  SET_STRING_ELT(rName, 0, mvbn);
+  UNPROTECT(2);
+  return (rName);
 }
 
 SEXP derefPtr(SEXP SmultiPtr) {
-  void **doublePtr = static_cast<void **>(R_ExternalPtrAddr(SmultiPtr));
-  return(R_MakeExternalPtr( static_cast<void *>(*doublePtr), R_NilValue, R_NilValue) );
+  void** doublePtr = static_cast<void**>(R_ExternalPtrAddr(SmultiPtr));
+  return (R_MakeExternalPtr(static_cast<void*>(*doublePtr), R_NilValue,
+                            R_NilValue));
 }
-

--- a/packages/nimble/inst/CppCode/RcppNimbleUtils.cpp
+++ b/packages/nimble/inst/CppCode/RcppNimbleUtils.cpp
@@ -1,823 +1,833 @@
-#include "nimble/NimArrBase.h"
-#include "nimble/NamedObjects.h"
 #include "nimble/RcppNimbleUtils.h"
+#include "nimble/NamedObjects.h"
+#include "nimble/NimArrBase.h"
 #include "nimble/dllFinalizer.h"
 //#include "nimble/RcppUtils.h"
+#include <algorithm>
+#include <iostream>
+#include <sstream>
 #include "nimble/Utils.h"
 #include "nimble/smartPtrs.h"
-#include<iostream>
-#include<sstream>
-#include<algorithm>
 
-
-// This is used when we have a NimArr<>* in a model and a NimArr<>** that needs to point to it.
+// This is used when we have a NimArr<>* in a model and a NimArr<>** that needs
+// to point to it.
 // We assume we have an extptr to each
 SEXP setDoublePtrFromSinglePtr(SEXP SdoublePtr, SEXP SsinglePtr) {
-  void *singlePtr = R_ExternalPtrAddr(SsinglePtr); // this is really a **
-  void **doublePtr = static_cast<void **>(R_ExternalPtrAddr(SdoublePtr)); // this is really a ***.  
+  void *singlePtr = R_ExternalPtrAddr(SsinglePtr);  // this is really a **
+  void **doublePtr = static_cast<void **>(
+      R_ExternalPtrAddr(SdoublePtr));  // this is really a ***.
   *doublePtr = singlePtr;
-  return(R_NilValue);
+  return (R_NilValue);
 }
 
 // probably deprecated
 SEXP setSmartPtrFromSinglePtr(SEXP StoPtr, SEXP SfromPtr) {
-  void *fromPtr = R_ExternalPtrAddr(SfromPtr); 
-  nimSmartPtrBase *toSmartPtr = static_cast<nimSmartPtrBase*>(R_ExternalPtrAddr(StoPtr));  
+  void *fromPtr = R_ExternalPtrAddr(SfromPtr);
+  nimSmartPtrBase *toSmartPtr =
+      static_cast<nimSmartPtrBase *>(R_ExternalPtrAddr(StoPtr));
   toSmartPtr->setPtrFromVoidPtr(fromPtr);
-  return(R_NilValue);
+  return (R_NilValue);
 }
 
 SEXP setSmartPtrFromDoublePtr(SEXP StoPtr, SEXP SfromPtr) {
-  void *fromPtr = *static_cast<void**>(R_ExternalPtrAddr(SfromPtr)); 
-  nimSmartPtrBase *toSmartPtr = static_cast<nimSmartPtrBase*>(R_ExternalPtrAddr(StoPtr));  
+  void *fromPtr = *static_cast<void **>(R_ExternalPtrAddr(SfromPtr));
+  nimSmartPtrBase *toSmartPtr =
+      static_cast<nimSmartPtrBase *>(R_ExternalPtrAddr(StoPtr));
   toSmartPtr->setPtrFromVoidPtr(fromPtr);
-  return(R_NilValue);
+  return (R_NilValue);
 }
 
 SEXP setPtrVectorOfPtrs(SEXP SaccessorPtr, SEXP ScontentsPtr, SEXP Ssize) {
-  vectorOfPtrsAccessBase *accessorPtr = static_cast<vectorOfPtrsAccessBase *>(R_ExternalPtrAddr(SaccessorPtr)); 
+  vectorOfPtrsAccessBase *accessorPtr =
+      static_cast<vectorOfPtrsAccessBase *>(R_ExternalPtrAddr(SaccessorPtr));
   void *contentsPtr = static_cast<void *>(R_ExternalPtrAddr(ScontentsPtr));
   int size = INTEGER(Ssize)[0];
   accessorPtr->setTheVec(contentsPtr, size);
-  return(R_NilValue);
+  return (R_NilValue);
 }
 
 SEXP setOnePtrVectorOfPtrs(SEXP SaccessorPtr, SEXP Si, SEXP ScontentsPtr) {
-  vectorOfPtrsAccessBase *accessorPtr = static_cast<vectorOfPtrsAccessBase *>(R_ExternalPtrAddr(SaccessorPtr)); 
+  vectorOfPtrsAccessBase *accessorPtr =
+      static_cast<vectorOfPtrsAccessBase *>(R_ExternalPtrAddr(SaccessorPtr));
   void *contentsPtr = static_cast<void *>(R_ExternalPtrAddr(ScontentsPtr));
   int i = INTEGER(Si)[0];
   accessorPtr->setVecPtr(i, contentsPtr);
-  return(R_NilValue);
+  return (R_NilValue);
 }
 
 /*This function was created so we can report the status of different operations
-from C++ to R. I found that Rbreak does not stop the R function from which the C++
-function was called. This can cause an excessive number (e.g. nrow) of printed 
-error reports if the user makes a common mistake. Instead, this function is used to 
-return the status to R. If it is false, we use the R function "stop" which will break
+from C++ to R. I found that Rbreak does not stop the R function from which the
+C++
+function was called. This can cause an excessive number (e.g. nrow) of printed
+error reports if the user makes a common mistake. Instead, this function is used
+to
+return the status to R. If it is false, we use the R function "stop" which will
+break
 for loops, etc. */
- 
-SEXP returnStatus(bool OK)
-	{
-	SEXP ans;
-    PROTECT(ans = allocVector(LGLSXP, 1) );
-    LOGICAL(ans)[0] = OK;
-    UNPROTECT(1);
-    return(ans);
-	}
 
-bool all(bool x) {return(x);}
-bool any(bool x) {return(x);}
-int t(int x) {return(x);}
-double t(double x) {return(x);}
-int prod(int x) {return(x);}
-double prod(double x) {return(x);}
+SEXP returnStatus(bool OK) {
+  SEXP ans;
+  PROTECT(ans = allocVector(LGLSXP, 1));
+  LOGICAL(ans)[0] = OK;
+  UNPROTECT(1);
+  return (ans);
+}
+
+bool all(bool x) { return (x); }
+bool any(bool x) { return (x); }
+int t(int x) { return (x); }
+double t(double x) { return (x); }
+int prod(int x) { return (x); }
+double prod(double x) { return (x); }
 
 NimArr<1, double> vectorDouble_2_NimArr(vector<double> input) {
   NimArr<1, double> output;
   output.setSize(input.size(), false, false);
   std::copy(input.begin(), input.end(), output.getPtr());
-  return(output);
+  return (output);
 }
 
-SEXP setVecNimArrRows(SEXP Sextptr, SEXP nRows, SEXP setSize2row1){
-    NimVecType *typePtr = static_cast< NimVecType* >(R_ExternalPtrAddr(Sextptr));
-    nimType vecType = (*typePtr).getNimType();
-    if(vecType == DOUBLE){
-    	VecNimArrBase<double> *matPtr = static_cast< VecNimArrBase<double>* >(R_ExternalPtrAddr(Sextptr));
-    	int nrowCpp = matPtr->size();
-	    int new_size = INTEGER(nRows)[0];
-    	matPtr->resize(new_size);
-    	if(new_size <= nrowCpp)
-    		return(returnStatus(true));
-    	if(LOGICAL(setSize2row1)[0]	== TRUE){
-		    	NimArrBase<double> *thisRow;
-    			thisRow = matPtr->getBasePtr(0);
-    			int numDims = thisRow->numDims();
-		     	vector<int> Dims(numDims);
- 				for(int i = 0; i < numDims; i++)
-    	  			Dims[i] = thisRow->dimSize(i);
-   		   		for(int i = nrowCpp; i < new_size; i++){
-   		   			thisRow = matPtr->getBasePtr(i);
-    	  			thisRow->setSize(Dims);
-    	  		}
-    	return(returnStatus(true) );
-    	}
+SEXP setVecNimArrRows(SEXP Sextptr, SEXP nRows, SEXP setSize2row1) {
+  NimVecType *typePtr = static_cast<NimVecType *>(R_ExternalPtrAddr(Sextptr));
+  nimType vecType = (*typePtr).getNimType();
+  if (vecType == DOUBLE) {
+    VecNimArrBase<double> *matPtr =
+        static_cast<VecNimArrBase<double> *>(R_ExternalPtrAddr(Sextptr));
+    int nrowCpp = matPtr->size();
+    int new_size = INTEGER(nRows)[0];
+    matPtr->resize(new_size);
+    if (new_size <= nrowCpp) return (returnStatus(true));
+    if (LOGICAL(setSize2row1)[0] == TRUE) {
+      NimArrBase<double> *thisRow;
+      thisRow = matPtr->getBasePtr(0);
+      int numDims = thisRow->numDims();
+      vector<int> Dims(numDims);
+      for (int i = 0; i < numDims; i++) Dims[i] = thisRow->dimSize(i);
+      for (int i = nrowCpp; i < new_size; i++) {
+        thisRow = matPtr->getBasePtr(i);
+        thisRow->setSize(Dims);
+      }
+      return (returnStatus(true));
     }
-    else if(vecType == INT){
-    	VecNimArrBase<int> *matPtr = static_cast< VecNimArrBase<int>* >(R_ExternalPtrAddr(Sextptr));
-    	int nrowCpp = matPtr->size();
-    	  int new_size = INTEGER(nRows)[0];
-	  	matPtr->resize(new_size);
-	  	if(new_size <= nrowCpp)
-    		return(returnStatus(true));
+  } else if (vecType == INT) {
+    VecNimArrBase<int> *matPtr =
+        static_cast<VecNimArrBase<int> *>(R_ExternalPtrAddr(Sextptr));
+    int nrowCpp = matPtr->size();
+    int new_size = INTEGER(nRows)[0];
+    matPtr->resize(new_size);
+    if (new_size <= nrowCpp) return (returnStatus(true));
 
-    	if(LOGICAL(setSize2row1)[0]	== TRUE){
-    		NimArrBase<int> *thisRow;
-    		thisRow = matPtr->getBasePtr(0);
-    		int numDims = thisRow->numDims();
-  	    	vector<int> Dims(numDims);
-			for(int i = 0; i < numDims; i++)
-      			Dims[i] = thisRow->dimSize(i);
-      		for(int i = nrowCpp; i < new_size; i++){
-      			thisRow = matPtr->getBasePtr(i);
-      			thisRow->setSize(Dims);
-      		}
-      	}
-    return(returnStatus(true) );
+    if (LOGICAL(setSize2row1)[0] == TRUE) {
+      NimArrBase<int> *thisRow;
+      thisRow = matPtr->getBasePtr(0);
+      int numDims = thisRow->numDims();
+      vector<int> Dims(numDims);
+      for (int i = 0; i < numDims; i++) Dims[i] = thisRow->dimSize(i);
+      for (int i = nrowCpp; i < new_size; i++) {
+        thisRow = matPtr->getBasePtr(i);
+        thisRow->setSize(Dims);
+      }
     }
- 	
- 	PRINTF("Data type for VecNimArr not currently supported\n");
- 	return(returnStatus(false) ) ;
+    return (returnStatus(true));
+  }
+
+  PRINTF("Data type for VecNimArr not currently supported\n");
+  return (returnStatus(false));
 }
 
 /* Add blank rows to C model values */
-SEXP addBlankModelValueRows(SEXP Sextptr, SEXP numAdded){
-    if(!isInteger(numAdded)) {
-        PRINTF("Error: numAdded is not an integer!\n");
-        return(returnStatus(false) );
+SEXP addBlankModelValueRows(SEXP Sextptr, SEXP numAdded) {
+  if (!isInteger(numAdded)) {
+    PRINTF("Error: numAdded is not an integer!\n");
+    return (returnStatus(false));
+  }
+
+  if (!R_ExternalPtrAddr(Sextptr)) {
+    PRINTF("Error: Sextptr is not a valid external pointer\n");
+    return (returnStatus(false));
+  }
+  NimVecType *typePtr = static_cast<NimVecType *>(R_ExternalPtrAddr(Sextptr));
+  nimType vecType = (*typePtr).getNimType();
+  if (vecType == DOUBLE) {
+    VecNimArrBase<double> *matPtr =
+        static_cast<VecNimArrBase<double> *>(R_ExternalPtrAddr(Sextptr));
+    int nrowCpp = matPtr->size();
+    int new_size = INTEGER(numAdded)[0] + nrowCpp;
+    matPtr->resize(new_size);
+    NimArrBase<double> *thisRow;
+    thisRow = matPtr->getBasePtr(0);
+    int numDims = thisRow->numDims();
+    vector<int> Dims(numDims);
+    for (int i = 0; i < numDims; i++) Dims[i] = thisRow->dimSize(i);
+    for (int i = nrowCpp; i < INTEGER(numAdded)[0] + nrowCpp; i++) {
+      thisRow = matPtr->getBasePtr(i);
+      thisRow->setSize(Dims);
     }
-    
-    if(!R_ExternalPtrAddr(Sextptr)) {
-        PRINTF("Error: Sextptr is not a valid external pointer\n");
-        return(returnStatus(false) );
+    return (returnStatus(true));
+  }
+
+  else if (vecType == INT) {
+    VecNimArrBase<int> *matPtr =
+        static_cast<VecNimArrBase<int> *>(R_ExternalPtrAddr(Sextptr));
+    int nrowCpp = matPtr->size();
+    int new_size = INTEGER(numAdded)[0] + nrowCpp;
+    matPtr->resize(new_size);
+    NimArrBase<int> *thisRow;
+    thisRow = matPtr->getBasePtr(0);
+    int numDims = thisRow->numDims();
+    vector<int> Dims(numDims);
+    for (int i = 0; i < numDims; i++) Dims[i] = thisRow->dimSize(i);
+    for (int i = nrowCpp; i < INTEGER(numAdded)[0] + nrowCpp; i++) {
+      thisRow = matPtr->getBasePtr(i);
+      thisRow->setSize(Dims);
     }
-    NimVecType *typePtr = static_cast< NimVecType* >(R_ExternalPtrAddr(Sextptr));
-    nimType vecType = (*typePtr).getNimType();
-    if(vecType == DOUBLE){
-    	VecNimArrBase<double> *matPtr = static_cast< VecNimArrBase<double>* >(R_ExternalPtrAddr(Sextptr));
-    	int nrowCpp = matPtr->size();
-	    int new_size = INTEGER(numAdded)[0] + nrowCpp;
-    	matPtr->resize(new_size);
-    	NimArrBase<double> *thisRow;
-    	thisRow = matPtr->getBasePtr(0);
-    	int numDims = thisRow->numDims();
-	     vector<int> Dims(numDims);
- 		for(int i = 0; i < numDims; i++)
-      		Dims[i] = thisRow->dimSize(i);
-    	for(int i = nrowCpp; i < INTEGER(numAdded)[0] + nrowCpp; i++){
-      		thisRow = matPtr->getBasePtr(i); 
-      		thisRow->setSize(Dims);
-    	}
-    return(returnStatus(true) );
-    }
-    
-    else if(vecType == INT){
-    	VecNimArrBase<int> *matPtr = static_cast< VecNimArrBase<int>* >(R_ExternalPtrAddr(Sextptr));
-    	int nrowCpp = matPtr->size();
-    	  int new_size = INTEGER(numAdded)[0] + nrowCpp;
-	  	matPtr->resize(new_size);
-    	NimArrBase<int> *thisRow;
-    	thisRow = matPtr->getBasePtr(0);
-    	int numDims = thisRow->numDims();
-  	    vector<int> Dims(numDims);
-		for(int i = 0; i < numDims; i++)
-      		Dims[i] = thisRow->dimSize(i);
-    	for(int i = nrowCpp; i < INTEGER(numAdded)[0] + nrowCpp; i++){
-      		thisRow = matPtr->getBasePtr(i); 
-      		thisRow->setSize(Dims);
-    	}
-    return(returnStatus(true) );
-    }
- 	
- 	PRINTF("Data type for VecNimArr not currently supported\n");
- 	return(returnStatus(false) ) ;
+    return (returnStatus(true));
+  }
+
+  PRINTF("Data type for VecNimArr not currently supported\n");
+  return (returnStatus(false));
 }
 
 /* Cliff's new function for retreiving nrow from CmodelValues object */
-SEXP getNRow(SEXP Sextptr){
-    if(!R_ExternalPtrAddr(Sextptr)) {
-        PRINTF("Error: Sextptr is not a valid external pointer\n");
-        return(R_NilValue);
-    }
-    int nRow = 0;
-    NimVecType *typePtr = static_cast< NimVecType* >(R_ExternalPtrAddr(Sextptr));
-    nimType vecType = (*typePtr).getNimType();
-    if(vecType == DOUBLE){
-    	VecNimArrBase<double>* matPtr = static_cast<VecNimArrBase<double>* > (typePtr);
-	    nRow = matPtr->size();
-	}
-	else if(vecType == INT)	{
-    	VecNimArrBase<int>* matPtr = static_cast<VecNimArrBase<int>* > (typePtr);
-	    nRow = matPtr->size();
-	}
-	else{
-		PRINTF("Data type of VecNimArr not currently supported\n");
-		_nimble_global_output<< "vecType = " << vecType << "\n"; nimble_print_to_R(_nimble_global_output);
-		}
-	SEXP rNRow;
-	PROTECT(rNRow = allocVector(INTSXP, 1) ); 
-	INTEGER(rNRow)[0] = nRow;
-	UNPROTECT(1);
-    return(rNRow);
+SEXP getNRow(SEXP Sextptr) {
+  if (!R_ExternalPtrAddr(Sextptr)) {
+    PRINTF("Error: Sextptr is not a valid external pointer\n");
+    return (R_NilValue);
+  }
+  int nRow = 0;
+  NimVecType *typePtr = static_cast<NimVecType *>(R_ExternalPtrAddr(Sextptr));
+  nimType vecType = (*typePtr).getNimType();
+  if (vecType == DOUBLE) {
+    VecNimArrBase<double> *matPtr =
+        static_cast<VecNimArrBase<double> *>(typePtr);
+    nRow = matPtr->size();
+  } else if (vecType == INT) {
+    VecNimArrBase<int> *matPtr = static_cast<VecNimArrBase<int> *>(typePtr);
+    nRow = matPtr->size();
+  } else {
+    PRINTF("Data type of VecNimArr not currently supported\n");
+    _nimble_global_output << "vecType = " << vecType << "\n";
+    nimble_print_to_R(_nimble_global_output);
+  }
+  SEXP rNRow;
+  PROTECT(rNRow = allocVector(INTSXP, 1));
+  INTEGER(rNRow)[0] = nRow;
+  UNPROTECT(1);
+  return (rNRow);
 }
 
-
-/* Cliff's new function for copying variables of given rows from one CModelValues object to another */
-/* This copies the values from SextptrFrom into SextptrTo. It takes values from rowsFrom and copies
+/* Cliff's new function for copying variables of given rows from one
+ * CModelValues object to another */
+/* This copies the values from SextptrFrom into SextptrTo. It takes values from
+rowsFrom and copies
 into rowsTo */
-SEXP copyModelValuesElements(SEXP SextptrFrom, SEXP SextptrTo, SEXP rowsFrom, SEXP rowsTo){
-    if(!R_ExternalPtrAddr(SextptrFrom) | !R_ExternalPtrAddr(SextptrFrom)) {
-        PRINTF("Error: Sextptr is not a valid external pointer\n");
-        return(returnStatus(false));
-    }
-    if(LENGTH(rowsFrom) != LENGTH(rowsTo) ){
-        PRINTF("Error: length of rowsFrom != rowsTo");
-        return(returnStatus(false) );
-    }
-    if(LENGTH(rowsFrom) == 0){
-        return(returnStatus(true) );
-    }
-  
-  NimVecType *typePtrFrom = static_cast< NimVecType* >(R_ExternalPtrAddr(SextptrFrom));
+SEXP copyModelValuesElements(SEXP SextptrFrom, SEXP SextptrTo, SEXP rowsFrom,
+                             SEXP rowsTo) {
+  if (!R_ExternalPtrAddr(SextptrFrom) | !R_ExternalPtrAddr(SextptrFrom)) {
+    PRINTF("Error: Sextptr is not a valid external pointer\n");
+    return (returnStatus(false));
+  }
+  if (LENGTH(rowsFrom) != LENGTH(rowsTo)) {
+    PRINTF("Error: length of rowsFrom != rowsTo");
+    return (returnStatus(false));
+  }
+  if (LENGTH(rowsFrom) == 0) {
+    return (returnStatus(true));
+  }
+
+  NimVecType *typePtrFrom =
+      static_cast<NimVecType *>(R_ExternalPtrAddr(SextptrFrom));
   nimType vecTypeFrom = (*typePtrFrom).getNimType();
-  NimVecType *typePtrTo = static_cast< NimVecType* >(R_ExternalPtrAddr(SextptrTo));
+  NimVecType *typePtrTo =
+      static_cast<NimVecType *>(R_ExternalPtrAddr(SextptrTo));
   nimType vecTypeTo = (*typePtrTo).getNimType();
 
-  if((vecTypeFrom == DOUBLE) & (vecTypeTo == DOUBLE)){
-	  VecNimArrBase<double> *matPtrFrom = static_cast< VecNimArrBase<double>* >(typePtrFrom);
-	  VecNimArrBase<double> *matPtrTo = static_cast< VecNimArrBase<double>* >(typePtrTo );
-	  int k = LENGTH(rowsFrom);
-	  int sizeFrom = matPtrFrom->size();
-	  int sizeTo = matPtrTo->size();
-	  int *indexFrom = INTEGER(rowsFrom);
-	  int *indexTo = INTEGER(rowsTo);
-	  NimArrBase<double> *thisRowFrom;
-	  NimArrBase<double> *thisRowTo;
-	  int ncFrom = 0;
-	  int ncTo = 0;
-    
-	  for(int i = 0; i < k; i++){
-	  if((indexFrom[i] > sizeFrom) | (indexFrom[i] <= 0))
-	    {
-	    _nimble_global_output<<"Warning: invalid index to copy from. Index = " << indexFrom[i] << " sizeFrom = " << sizeFrom << "\n";
-	    nimble_print_to_R(_nimble_global_output);
-	    if(i > 0)
-	      PRINTF("Warning: partial copy completed before error discovered!\n");
-	    return(returnStatus(false) );
-    	}
-  	if((indexTo[i] > sizeTo) | (indexTo[i] <=0))
-  	  {
-	    _nimble_global_output<<"Warning: invalid index to copy from. Index = " << indexTo[i] << " sizeTo = "<< sizeTo << "\n";
-	    nimble_print_to_R(_nimble_global_output);
-  	  if(i > 0)
-  	    PRINTF("Warning: partial copy completed before error discovered!\n");
-  	  return(returnStatus(false) );
-  	  }
-  	thisRowFrom = matPtrFrom->getBasePtr(indexFrom[i] - 1);  
-  	thisRowTo = matPtrTo->getBasePtr(indexTo[i] - 1);  
-  
-  	ncFrom = thisRowFrom->size();
-  	ncTo = thisRowTo->size();
-  
-  	if(ncFrom != ncTo){
-  	  PRINTF("Error: ncFrom != ncTo\n");
-  	  if(i > 0)
-  	    PRINTF("Warning: partial copy completed before error discovered!\n");
-  	  return(returnStatus(false) );
-  	  }
-  	for(int j = 0; j < ncFrom; j++)
-  		    (*thisRowTo)[j] = (*thisRowFrom)[j];
-  	}
-  	return(returnStatus(true) );
+  if ((vecTypeFrom == DOUBLE) & (vecTypeTo == DOUBLE)) {
+    VecNimArrBase<double> *matPtrFrom =
+        static_cast<VecNimArrBase<double> *>(typePtrFrom);
+    VecNimArrBase<double> *matPtrTo =
+        static_cast<VecNimArrBase<double> *>(typePtrTo);
+    int k = LENGTH(rowsFrom);
+    int sizeFrom = matPtrFrom->size();
+    int sizeTo = matPtrTo->size();
+    int *indexFrom = INTEGER(rowsFrom);
+    int *indexTo = INTEGER(rowsTo);
+    NimArrBase<double> *thisRowFrom;
+    NimArrBase<double> *thisRowTo;
+    int ncFrom = 0;
+    int ncTo = 0;
+
+    for (int i = 0; i < k; i++) {
+      if ((indexFrom[i] > sizeFrom) | (indexFrom[i] <= 0)) {
+        _nimble_global_output
+            << "Warning: invalid index to copy from. Index = " << indexFrom[i]
+            << " sizeFrom = " << sizeFrom << "\n";
+        nimble_print_to_R(_nimble_global_output);
+        if (i > 0)
+          PRINTF("Warning: partial copy completed before error discovered!\n");
+        return (returnStatus(false));
+      }
+      if ((indexTo[i] > sizeTo) | (indexTo[i] <= 0)) {
+        _nimble_global_output
+            << "Warning: invalid index to copy from. Index = " << indexTo[i]
+            << " sizeTo = " << sizeTo << "\n";
+        nimble_print_to_R(_nimble_global_output);
+        if (i > 0)
+          PRINTF("Warning: partial copy completed before error discovered!\n");
+        return (returnStatus(false));
+      }
+      thisRowFrom = matPtrFrom->getBasePtr(indexFrom[i] - 1);
+      thisRowTo = matPtrTo->getBasePtr(indexTo[i] - 1);
+
+      ncFrom = thisRowFrom->size();
+      ncTo = thisRowTo->size();
+
+      if (ncFrom != ncTo) {
+        PRINTF("Error: ncFrom != ncTo\n");
+        if (i > 0)
+          PRINTF("Warning: partial copy completed before error discovered!\n");
+        return (returnStatus(false));
+      }
+      for (int j = 0; j < ncFrom; j++) (*thisRowTo)[j] = (*thisRowFrom)[j];
+    }
+    return (returnStatus(true));
   }
 
-  if((vecTypeFrom == INT) & (vecTypeTo == INT)){
-	  VecNimArrBase<int> *matPtrFrom = static_cast< VecNimArrBase<int>* >(typePtrFrom);
-	  VecNimArrBase<int> *matPtrTo = static_cast< VecNimArrBase<int>* >(typePtrTo );
-	  int k = LENGTH(rowsFrom);
-	  int sizeFrom = matPtrFrom->size();
-	  int sizeTo = matPtrTo->size();
-	  int *indexFrom = INTEGER(rowsFrom);
-	  int *indexTo = INTEGER(rowsTo);
-	  NimArrBase<int> *thisRowFrom;
-	  NimArrBase<int> *thisRowTo;
-	  int ncFrom = 0;
-	  int ncTo = 0;
-    
-	  for(int i = 0; i < k; i++){
-	  if((indexFrom[i] > sizeFrom) | (indexFrom[i] <= 0))
-	    {
-	    _nimble_global_output<<"Warning: invalid index to copy from. Index = " << indexFrom[i] << " sizeFrom = " << sizeFrom << "\n";
-	    nimble_print_to_R(_nimble_global_output);
-	    if(i > 0)
-	      PRINTF("Warning: partial copy completed before error discovered!\n");
-	    return(returnStatus(false) );
-    	}
-  	if((indexTo[i] > sizeTo) | (indexTo[i] <=0))
-  	  {
-  	  _nimble_global_output<<"Warning: invalid index to copy from. Index = " << indexTo[i] << " sizeTo = "<< sizeTo << "\n";
-	  nimble_print_to_R(_nimble_global_output);
-	  if(i > 0)
-  	    PRINTF("Warning: partial copy completed before error discovered!\n");
-  	  return(returnStatus(false) );
-  	  }
-  	thisRowFrom = matPtrFrom->getBasePtr(indexFrom[i] - 1);  
-  	thisRowTo = matPtrTo->getBasePtr(indexTo[i] - 1);  
-  
-  	ncFrom = thisRowFrom->size();
-  	ncTo = thisRowTo->size();
-  
-  	if(ncFrom != ncTo){
-  	  PRINTF("Error: ncFrom != ncTo\n");
-  	  if(i > 0)
-  	    PRINTF("Warning: partial copy completed before error discovered!\n");
-  	  return(returnStatus(false) );
-  	  }
-  	for(int j = 0; j < ncFrom; j++)
-  		    (*thisRowTo)[j] = (*thisRowFrom)[j];
-  	}
-  	return(returnStatus(true) );
+  if ((vecTypeFrom == INT) & (vecTypeTo == INT)) {
+    VecNimArrBase<int> *matPtrFrom =
+        static_cast<VecNimArrBase<int> *>(typePtrFrom);
+    VecNimArrBase<int> *matPtrTo = static_cast<VecNimArrBase<int> *>(typePtrTo);
+    int k = LENGTH(rowsFrom);
+    int sizeFrom = matPtrFrom->size();
+    int sizeTo = matPtrTo->size();
+    int *indexFrom = INTEGER(rowsFrom);
+    int *indexTo = INTEGER(rowsTo);
+    NimArrBase<int> *thisRowFrom;
+    NimArrBase<int> *thisRowTo;
+    int ncFrom = 0;
+    int ncTo = 0;
+
+    for (int i = 0; i < k; i++) {
+      if ((indexFrom[i] > sizeFrom) | (indexFrom[i] <= 0)) {
+        _nimble_global_output
+            << "Warning: invalid index to copy from. Index = " << indexFrom[i]
+            << " sizeFrom = " << sizeFrom << "\n";
+        nimble_print_to_R(_nimble_global_output);
+        if (i > 0)
+          PRINTF("Warning: partial copy completed before error discovered!\n");
+        return (returnStatus(false));
+      }
+      if ((indexTo[i] > sizeTo) | (indexTo[i] <= 0)) {
+        _nimble_global_output
+            << "Warning: invalid index to copy from. Index = " << indexTo[i]
+            << " sizeTo = " << sizeTo << "\n";
+        nimble_print_to_R(_nimble_global_output);
+        if (i > 0)
+          PRINTF("Warning: partial copy completed before error discovered!\n");
+        return (returnStatus(false));
+      }
+      thisRowFrom = matPtrFrom->getBasePtr(indexFrom[i] - 1);
+      thisRowTo = matPtrTo->getBasePtr(indexTo[i] - 1);
+
+      ncFrom = thisRowFrom->size();
+      ncTo = thisRowTo->size();
+
+      if (ncFrom != ncTo) {
+        PRINTF("Error: ncFrom != ncTo\n");
+        if (i > 0)
+          PRINTF("Warning: partial copy completed before error discovered!\n");
+        return (returnStatus(false));
+      }
+      for (int j = 0; j < ncFrom; j++) (*thisRowTo)[j] = (*thisRowFrom)[j];
+    }
+    return (returnStatus(true));
   }
 
-  PRINTF("Data type not currently supported for VecNimArr. Copy MV elements failed\n");
-  return(returnStatus(false) );
-
-}	
-
-SEXP getMVElement(SEXP Sextptr, SEXP Sindex){
-	if(!isInteger(Sindex)) {
-    	PRINTF("Error: Sindex is not an integer!\n");
-    	return(returnStatus(false) ) ;
-	}
-  	if(!R_ExternalPtrAddr(Sextptr)) {
-  	  PRINTF("Error: Sextptr is not a valid external pointer\n");
-  	  return(returnStatus(false) ) ;
-  	}
-	NimVecType *typePtr = static_cast< NimVecType* >(R_ExternalPtrAddr(Sextptr));
-	nimType vecType = (*typePtr).getNimType();
-	int nrowCpp = typePtr->size();
-	int index = INTEGER(Sindex)[0];
-	if(index > nrowCpp){
-		PRINTF("Error: index too large\n");
-		return(returnStatus(false) ) ;
-	  }
-  	if(index < 1){
-		PRINTF("Error: index < 1\n");
-		return(returnStatus(false) ) ;
-  	}
-  return(cGetMVElementOneRow(typePtr, vecType, index) ) ;	
-}  	
-
-// This is not called directly from R.  It is called from getMVElement
-SEXP cGetMVElementOneRow(NimVecType* typePtr, nimType vecType, int index) 	{  	
-    if(vecType == DOUBLE){
-		VecNimArrBase<double> *matPtr = static_cast< VecNimArrBase<double>* >(typePtr);
-		NimArrBase<double> *thisRow;
-  		thisRow = matPtr->getBasePtr(index - 1);		//Converting R index to C index
-		int outputLength = thisRow->size();
-  		SEXP Sans;
-  		PROTECT(Sans = allocVector(REALSXP, outputLength));
-		double *value = REAL(Sans);
-  		std::copy(thisRow->getPtr(), thisRow->getPtr() + outputLength, value); /* copy should work now */
-  		if(thisRow->numDims() > 1) { // using first row as representative
-    		SEXP Sdim;
-    		PROTECT(Sdim = allocVector(INTSXP, thisRow->numDims()));
-    		for(int idim = 0; idim < thisRow->numDims(); ++idim) INTEGER(Sdim)[idim] = thisRow->dimSize(idim);
-    			setAttrib(Sans, R_DimSymbol, Sdim);
-    		UNPROTECT(2);
-  		}
-  		else {
-    UNPROTECT(1);
-  		}
-  	 	return(Sans);
-  	}
-    else if(vecType == INT){
-		VecNimArrBase<int> *matPtr = static_cast< VecNimArrBase<int>* >(typePtr);
-		NimArrBase<int> *thisRow;
-  		thisRow = matPtr->getBasePtr(index - 1);		//Converting R index to C index
-		int outputLength = thisRow->size();
-  		SEXP Sans;
-  		PROTECT(Sans = allocVector(INTSXP, outputLength));
-		int *value = INTEGER(Sans);
-  		std::copy(thisRow->getPtr(), thisRow->getPtr() + outputLength, value); /* copy should work now */
-  		if(thisRow->numDims() > 1) { // using first row as representative
-    		SEXP Sdim;
-    		PROTECT(Sdim = allocVector(INTSXP, thisRow->numDims()));
-    		for(int idim = 0; idim < thisRow->numDims(); ++idim) INTEGER(Sdim)[idim] = thisRow->dimSize(idim);
-    			setAttrib(Sans, R_DimSymbol, Sdim);
-    		UNPROTECT(2);
-  		}
-  		else {
-    UNPROTECT(1);
-  		}
-  	  	return(Sans);	
-  	}
-  	else
-  		PRINTF("VecNimArr datatype not supported\n");
-	return(R_NilValue);
+  PRINTF(
+      "Data type not currently supported for VecNimArr. Copy MV elements "
+      "failed\n");
+  return (returnStatus(false));
 }
 
-SEXP setMVElementFromList(SEXP vNimPtr, SEXP rList, SEXP Sindices){
+SEXP getMVElement(SEXP Sextptr, SEXP Sindex) {
+  if (!isInteger(Sindex)) {
+    PRINTF("Error: Sindex is not an integer!\n");
+    return (returnStatus(false));
+  }
+  if (!R_ExternalPtrAddr(Sextptr)) {
+    PRINTF("Error: Sextptr is not a valid external pointer\n");
+    return (returnStatus(false));
+  }
+  NimVecType *typePtr = static_cast<NimVecType *>(R_ExternalPtrAddr(Sextptr));
+  nimType vecType = (*typePtr).getNimType();
+  int nrowCpp = typePtr->size();
+  int index = INTEGER(Sindex)[0];
+  if (index > nrowCpp) {
+    PRINTF("Error: index too large\n");
+    return (returnStatus(false));
+  }
+  if (index < 1) {
+    PRINTF("Error: index < 1\n");
+    return (returnStatus(false));
+  }
+  return (cGetMVElementOneRow(typePtr, vecType, index));
+}
+
+// This is not called directly from R.  It is called from getMVElement
+SEXP cGetMVElementOneRow(NimVecType *typePtr, nimType vecType, int index) {
+  if (vecType == DOUBLE) {
+    VecNimArrBase<double> *matPtr =
+        static_cast<VecNimArrBase<double> *>(typePtr);
+    NimArrBase<double> *thisRow;
+    thisRow = matPtr->getBasePtr(index - 1);  // Converting R index to C index
+    int outputLength = thisRow->size();
+    SEXP Sans;
+    PROTECT(Sans = allocVector(REALSXP, outputLength));
+    double *value = REAL(Sans);
+    std::copy(thisRow->getPtr(), thisRow->getPtr() + outputLength,
+              value);              /* copy should work now */
+    if (thisRow->numDims() > 1) {  // using first row as representative
+      SEXP Sdim;
+      PROTECT(Sdim = allocVector(INTSXP, thisRow->numDims()));
+      for (int idim = 0; idim < thisRow->numDims(); ++idim)
+        INTEGER(Sdim)[idim] = thisRow->dimSize(idim);
+      setAttrib(Sans, R_DimSymbol, Sdim);
+      UNPROTECT(2);
+    } else {
+      UNPROTECT(1);
+    }
+    return (Sans);
+  } else if (vecType == INT) {
+    VecNimArrBase<int> *matPtr = static_cast<VecNimArrBase<int> *>(typePtr);
+    NimArrBase<int> *thisRow;
+    thisRow = matPtr->getBasePtr(index - 1);  // Converting R index to C index
+    int outputLength = thisRow->size();
+    SEXP Sans;
+    PROTECT(Sans = allocVector(INTSXP, outputLength));
+    int *value = INTEGER(Sans);
+    std::copy(thisRow->getPtr(), thisRow->getPtr() + outputLength,
+              value);              /* copy should work now */
+    if (thisRow->numDims() > 1) {  // using first row as representative
+      SEXP Sdim;
+      PROTECT(Sdim = allocVector(INTSXP, thisRow->numDims()));
+      for (int idim = 0; idim < thisRow->numDims(); ++idim)
+        INTEGER(Sdim)[idim] = thisRow->dimSize(idim);
+      setAttrib(Sans, R_DimSymbol, Sdim);
+      UNPROTECT(2);
+    } else {
+      UNPROTECT(1);
+    }
+    return (Sans);
+  } else
+    PRINTF("VecNimArr datatype not supported\n");
+  return (R_NilValue);
+}
+
+SEXP setMVElementFromList(SEXP vNimPtr, SEXP rList, SEXP Sindices) {
   // This function needs to get the length of rList
-  // Once it has this length, it marches down the length of rList and sets all the values of
+  // Once it has this length, it marches down the length of rList and sets all
+  // the values of
   // of vNimPtr
   int listLength = LENGTH(rList);
   int checkLength = LENGTH(Sindices);
-  if(listLength != checkLength){
+  if (listLength != checkLength) {
     PRINTF("Number of indices copying to does not match length of list\n");
-    return(R_NilValue);
+    return (R_NilValue);
   }
   SEXP listElement;
-  NimVecType *typePtr = static_cast<NimVecType*>(R_ExternalPtrAddr(vNimPtr) );
+  NimVecType *typePtr = static_cast<NimVecType *>(R_ExternalPtrAddr(vNimPtr));
   nimType vecType = (*typePtr).getNimType();
   int index;
-  for(int i = 0; i < listLength ; i++){
+  for (int i = 0; i < listLength; i++) {
     listElement = VECTOR_ELT(rList, i);
     index = INTEGER(Sindices)[i];
     cSetMVElementSingle(typePtr, vecType, index, listElement);
   }
-  return(R_NilValue);
+  return (R_NilValue);
 }
 
-
- void cSetMVElementSingle(NimVecType* typePtr, nimType vecType,  int index, SEXP Svalue) {
-    if(vecType == DOUBLE){
-		VecNimArrBase<double> *matPtr = static_cast< VecNimArrBase<double>* >(typePtr);
-  		NimArrBase<double> *thisRow;
-  		thisRow = matPtr->getBasePtr(index - 1);		//Converting from R index to C index
-  		int nc = thisRow->size();
-  		double *value = REAL(Svalue);
-  		int new_nc = LENGTH(Svalue);
-  		if(new_nc != nc){
-  			PRINTF("Error: size of values assigned not the same! If this is during compiling, could be from improperly sized r modelValues variable (see user manual section on modelValues)\n");
-		return;
-  		}
-  for(int i = 0; i < nc; i++)
-    (*thisRow)[i] = value[i];
-	return;
-	}
-
-	else if(vecType == INT){
-		VecNimArrBase<int> *matPtr = static_cast< VecNimArrBase<int>* >(typePtr);
-  		NimArrBase<int> *thisRow;
-  		thisRow = matPtr->getBasePtr(index - 1);		//Converting from R index to C index
-  		int nc = thisRow->size();
-  		double *value = REAL(Svalue);
-  		int new_nc = LENGTH(Svalue);
-  		if(new_nc != nc){
-  			PRINTF("Error: size of values assigned not the same!\n");
-		return;
-  		}
-  	for(int i = 0; i < nc; i++)
-    	(*thisRow)[i] = value[i];
-	return;
-	}
-	PRINTF("VecNimArr data type not currently supported\n");
-	return;
-}
-
-
-
- SEXP getMVElementAsList(SEXP SextPtr, SEXP Sindices){
- 	int nIndice = LENGTH(Sindices);
- 	SEXP sList;
- 	PROTECT(sList = allocVector(VECSXP, nIndice) );
- 	NimVecType *typePtr = static_cast< NimVecType* >(R_ExternalPtrAddr(SextPtr));
-	nimType vecType = (*typePtr).getNimType();
-	for(int i = 0; i < nIndice; i++)
-		SET_VECTOR_ELT(sList, i, cGetMVElementOneRow(typePtr, vecType, INTEGER(Sindices)[i]) );
-	UNPROTECT(1);
-	return(sList);
- }
-
-SEXP setMVElement(SEXP Sextptr, SEXP Sindex, SEXP Svalue){
-    if(!isInteger(Sindex)) {
-    PRINTF("Error: Sindex is not an integer!\n");
-	return(returnStatus(false) ) ;
-  }
-  if(!R_ExternalPtrAddr(Sextptr)) {
-    PRINTF("Error: Sextptr is not a valid external pointer\n");
-	return(returnStatus(false) ) ;
-  }
-  int index = INTEGER(Sindex)[0];
-  if(index < 1){ 
-    PRINTF("Error: index < 1\n");   	
-	return(returnStatus(false) ) ;
-  }
-
-   NimVecType *typePtr = static_cast< NimVecType* >(R_ExternalPtrAddr(Sextptr));
-   nimType vecType = (*typePtr).getNimType();
-  int nrowCpp = typePtr->size();
-  if(index > nrowCpp){
-	PRINTF("Error: index too large\n");
-	return(returnStatus(false) ) ;
-  }
-  cSetMVElementSingle( typePtr, vecType, index, Svalue );
-  return(returnStatus(true) );
- } 
- 
- 
- SEXP getMVsize(SEXP Sextptr){
-	NimVecType	*nimVecPtr = static_cast<NimVecType*>(R_ExternalPtrAddr(Sextptr) ); 
- 	vector<int> cDims = (*nimVecPtr).getRowDims(0);
-	int nDims = cDims.size();
- 	SEXP Sans;
- 	PROTECT(Sans = allocVector(INTSXP, nDims) );
- 	for(int i = 0; i < nDims; i++)
- 		INTEGER(Sans)[i] = cDims[i];
- 	UNPROTECT(1);
- 	return(Sans);
- 	}
-
-SEXP NimArrDouble_2_SEXP(NimArrBase<double> &nimArrDbl){
-		int len = nimArrDbl.size();
-		SEXP Sans;  
-		PROTECT(Sans = allocVector(REALSXP, len));
-		std::copy(nimArrDbl.v, nimArrDbl.v + len , REAL(Sans) );  
-  		int numDims = nimArrDbl.numDims();
-  		if(numDims > 1) {
-		  SEXP Sdim;
-		  PROTECT(Sdim = allocVector(INTSXP, numDims));
-		  for(int idim = 0; idim < numDims; ++idim) INTEGER(Sdim)[idim] = nimArrDbl.dimSize(idim);
-		  setAttrib(Sans, R_DimSymbol, Sdim);
-		  UNPROTECT(2);
-  		}
-  		else {
-    		UNPROTECT(1);
-  		} 
-	return(Sans);
- }
-
-SEXP NimArrInt_2_SEXP(NimArrBase<int> &nimArrInt){
-		int len = nimArrInt.size();
-		SEXP Sans;  
-		PROTECT(Sans = allocVector(INTSXP, len));
-		std::copy(nimArrInt.v, nimArrInt.v + len , INTEGER(Sans) );  
-  		int numDims = nimArrInt.numDims();
-  		if(numDims > 1) {
-    		SEXP Sdim;
-    		PROTECT(Sdim = allocVector(INTSXP, numDims));
-    		for(int idim = 0; idim < numDims; ++idim) INTEGER(Sdim)[idim] = nimArrInt.dimSize(idim);
-			setAttrib(Sans, R_DimSymbol, Sdim);
-		    UNPROTECT(2);
-  		}
-  		else {
-    		UNPROTECT(1);
-  		} 
-	return(Sans);
- }
-
-SEXP NimArrBool_2_SEXP(NimArrBase<bool> &nimArrBl){
-  int len = nimArrBl.size();
-  SEXP Sans;  
-  PROTECT(Sans = allocVector(LGLSXP, len));
-  std::copy(nimArrBl.v, nimArrBl.v + len , LOGICAL(Sans) );  
-  int numDims = nimArrBl.numDims();
-  if(numDims > 1) {
-    SEXP Sdim;
-    PROTECT(Sdim = allocVector(INTSXP, numDims));
-    for(int idim = 0; idim < numDims; ++idim) INTEGER(Sdim)[idim] = nimArrBl.dimSize(idim);
-    setAttrib(Sans, R_DimSymbol, Sdim);
-    UNPROTECT(2);
-  }
-  else {
-    UNPROTECT(1);
-  } 
-  return(Sans);
- }
-
-
-NimArrType* getNimTypePtr(SEXP &rPtr, SEXP &refNum)
-{
-	NimArrType* nimTypePtr;
-	int cRefNum = INTEGER(refNum)[0];
-	if(cRefNum == 1){
-		nimTypePtr = static_cast<NimArrType*>(R_ExternalPtrAddr(rPtr) );
-		return(nimTypePtr); 
-		}
-	if(cRefNum == 2){
-		nimTypePtr = (*static_cast<NimArrType**> (R_ExternalPtrAddr(rPtr) ) );
-		return(nimTypePtr);
-		}
-	PRINTF("Warning: number of dereferences not currently supported, returning null pointer\n");
-	nimTypePtr = NULL;
-	return(nimTypePtr);
-}
-
-void SEXP_2_NimArrDouble (SEXP rValues, NimArrBase<double> &NimArrDbl){
-  int rLength = LENGTH(rValues);
-  if(rLength != NimArrDbl.size() ) {
-    PRINTF("Warning: R object of different size than NimArrDouble. R obj has size %i but NimArrDbl has size %i.\n", rLength, NimArrDbl.size());
+void cSetMVElementSingle(NimVecType *typePtr, nimType vecType, int index,
+                         SEXP Svalue) {
+  if (vecType == DOUBLE) {
+    VecNimArrBase<double> *matPtr =
+        static_cast<VecNimArrBase<double> *>(typePtr);
+    NimArrBase<double> *thisRow;
+    thisRow =
+        matPtr->getBasePtr(index - 1);  // Converting from R index to C index
+    int nc = thisRow->size();
+    double *value = REAL(Svalue);
+    int new_nc = LENGTH(Svalue);
+    if (new_nc != nc) {
+      PRINTF(
+          "Error: size of values assigned not the same! If this is during "
+          "compiling, could be from improperly sized r modelValues variable "
+          "(see user manual section on modelValues)\n");
+      return;
+    }
+    for (int i = 0; i < nc; i++) (*thisRow)[i] = value[i];
     return;
   }
-  if(isReal(rValues) ) {
-    for(int i = 0; i < rLength; i++)
-      NimArrDbl[i] = REAL(rValues)[i];
+
+  else if (vecType == INT) {
+    VecNimArrBase<int> *matPtr = static_cast<VecNimArrBase<int> *>(typePtr);
+    NimArrBase<int> *thisRow;
+    thisRow =
+        matPtr->getBasePtr(index - 1);  // Converting from R index to C index
+    int nc = thisRow->size();
+    double *value = REAL(Svalue);
+    int new_nc = LENGTH(Svalue);
+    if (new_nc != nc) {
+      PRINTF("Error: size of values assigned not the same!\n");
+      return;
+    }
+    for (int i = 0; i < nc; i++) (*thisRow)[i] = value[i];
+    return;
   }
-  else if(isInteger(rValues) | isLogical(rValues) ) {
-    for(int i = 0; i < rLength; i++)
-      NimArrDbl[i] = INTEGER(rValues)[i];
-  }
-  
-  else
-    PRINTF("WARNING: class of R object not recognized. Should be numeric or integer\n");
+  PRINTF("VecNimArr data type not currently supported\n");
   return;
 }
 
-void SEXP_2_NimArrInt (SEXP rValues, NimArrBase<int> &NimArrInt){
+SEXP getMVElementAsList(SEXP SextPtr, SEXP Sindices) {
+  int nIndice = LENGTH(Sindices);
+  SEXP sList;
+  PROTECT(sList = allocVector(VECSXP, nIndice));
+  NimVecType *typePtr = static_cast<NimVecType *>(R_ExternalPtrAddr(SextPtr));
+  nimType vecType = (*typePtr).getNimType();
+  for (int i = 0; i < nIndice; i++)
+    SET_VECTOR_ELT(sList, i,
+                   cGetMVElementOneRow(typePtr, vecType, INTEGER(Sindices)[i]));
+  UNPROTECT(1);
+  return (sList);
+}
+
+SEXP setMVElement(SEXP Sextptr, SEXP Sindex, SEXP Svalue) {
+  if (!isInteger(Sindex)) {
+    PRINTF("Error: Sindex is not an integer!\n");
+    return (returnStatus(false));
+  }
+  if (!R_ExternalPtrAddr(Sextptr)) {
+    PRINTF("Error: Sextptr is not a valid external pointer\n");
+    return (returnStatus(false));
+  }
+  int index = INTEGER(Sindex)[0];
+  if (index < 1) {
+    PRINTF("Error: index < 1\n");
+    return (returnStatus(false));
+  }
+
+  NimVecType *typePtr = static_cast<NimVecType *>(R_ExternalPtrAddr(Sextptr));
+  nimType vecType = (*typePtr).getNimType();
+  int nrowCpp = typePtr->size();
+  if (index > nrowCpp) {
+    PRINTF("Error: index too large\n");
+    return (returnStatus(false));
+  }
+  cSetMVElementSingle(typePtr, vecType, index, Svalue);
+  return (returnStatus(true));
+}
+
+SEXP getMVsize(SEXP Sextptr) {
+  NimVecType *nimVecPtr = static_cast<NimVecType *>(R_ExternalPtrAddr(Sextptr));
+  vector<int> cDims = (*nimVecPtr).getRowDims(0);
+  int nDims = cDims.size();
+  SEXP Sans;
+  PROTECT(Sans = allocVector(INTSXP, nDims));
+  for (int i = 0; i < nDims; i++) INTEGER(Sans)[i] = cDims[i];
+  UNPROTECT(1);
+  return (Sans);
+}
+
+SEXP NimArrDouble_2_SEXP(NimArrBase<double> &nimArrDbl) {
+  int len = nimArrDbl.size();
+  SEXP Sans;
+  PROTECT(Sans = allocVector(REALSXP, len));
+  std::copy(nimArrDbl.v, nimArrDbl.v + len, REAL(Sans));
+  int numDims = nimArrDbl.numDims();
+  if (numDims > 1) {
+    SEXP Sdim;
+    PROTECT(Sdim = allocVector(INTSXP, numDims));
+    for (int idim = 0; idim < numDims; ++idim)
+      INTEGER(Sdim)[idim] = nimArrDbl.dimSize(idim);
+    setAttrib(Sans, R_DimSymbol, Sdim);
+    UNPROTECT(2);
+  } else {
+    UNPROTECT(1);
+  }
+  return (Sans);
+}
+
+SEXP NimArrInt_2_SEXP(NimArrBase<int> &nimArrInt) {
+  int len = nimArrInt.size();
+  SEXP Sans;
+  PROTECT(Sans = allocVector(INTSXP, len));
+  std::copy(nimArrInt.v, nimArrInt.v + len, INTEGER(Sans));
+  int numDims = nimArrInt.numDims();
+  if (numDims > 1) {
+    SEXP Sdim;
+    PROTECT(Sdim = allocVector(INTSXP, numDims));
+    for (int idim = 0; idim < numDims; ++idim)
+      INTEGER(Sdim)[idim] = nimArrInt.dimSize(idim);
+    setAttrib(Sans, R_DimSymbol, Sdim);
+    UNPROTECT(2);
+  } else {
+    UNPROTECT(1);
+  }
+  return (Sans);
+}
+
+SEXP NimArrBool_2_SEXP(NimArrBase<bool> &nimArrBl) {
+  int len = nimArrBl.size();
+  SEXP Sans;
+  PROTECT(Sans = allocVector(LGLSXP, len));
+  std::copy(nimArrBl.v, nimArrBl.v + len, LOGICAL(Sans));
+  int numDims = nimArrBl.numDims();
+  if (numDims > 1) {
+    SEXP Sdim;
+    PROTECT(Sdim = allocVector(INTSXP, numDims));
+    for (int idim = 0; idim < numDims; ++idim)
+      INTEGER(Sdim)[idim] = nimArrBl.dimSize(idim);
+    setAttrib(Sans, R_DimSymbol, Sdim);
+    UNPROTECT(2);
+  } else {
+    UNPROTECT(1);
+  }
+  return (Sans);
+}
+
+NimArrType *getNimTypePtr(SEXP &rPtr, SEXP &refNum) {
+  NimArrType *nimTypePtr;
+  int cRefNum = INTEGER(refNum)[0];
+  if (cRefNum == 1) {
+    nimTypePtr = static_cast<NimArrType *>(R_ExternalPtrAddr(rPtr));
+    return (nimTypePtr);
+  }
+  if (cRefNum == 2) {
+    nimTypePtr = (*static_cast<NimArrType **>(R_ExternalPtrAddr(rPtr)));
+    return (nimTypePtr);
+  }
+  PRINTF(
+      "Warning: number of dereferences not currently supported, returning null "
+      "pointer\n");
+  nimTypePtr = NULL;
+  return (nimTypePtr);
+}
+
+void SEXP_2_NimArrDouble(SEXP rValues, NimArrBase<double> &NimArrDbl) {
   int rLength = LENGTH(rValues);
-  if(rLength != NimArrInt.size() ) {
+  if (rLength != NimArrDbl.size()) {
+    PRINTF(
+        "Warning: R object of different size than NimArrDouble. R obj has size "
+        "%i but NimArrDbl has size %i.\n",
+        rLength, NimArrDbl.size());
+    return;
+  }
+  if (isReal(rValues)) {
+    for (int i = 0; i < rLength; i++) NimArrDbl[i] = REAL(rValues)[i];
+  } else if (isInteger(rValues) | isLogical(rValues)) {
+    for (int i = 0; i < rLength; i++) NimArrDbl[i] = INTEGER(rValues)[i];
+  }
+
+  else
+    PRINTF(
+        "WARNING: class of R object not recognized. Should be numeric or "
+        "integer\n");
+  return;
+}
+
+void SEXP_2_NimArrInt(SEXP rValues, NimArrBase<int> &NimArrInt) {
+  int rLength = LENGTH(rValues);
+  if (rLength != NimArrInt.size()) {
     PRINTF("Warning: R object of different size than NimArrInt!\n");
-    return;		
+    return;
   }
-  
-  if(isInteger(rValues) | isLogical(rValues) ) {
-    for(int i = 0; i < rLength; i++)
-      NimArrInt[i] = INTEGER(rValues)[i];
+
+  if (isInteger(rValues) | isLogical(rValues)) {
+    for (int i = 0; i < rLength; i++) NimArrInt[i] = INTEGER(rValues)[i];
+  } else if (isReal(rValues)) {
+    for (int i = 0; i < rLength; i++) NimArrInt[i] = REAL(rValues)[i];
   }
-  else if(isReal(rValues) ) {
-    for(int i = 0; i < rLength; i++)
-      NimArrInt[i] = REAL(rValues)[i];
-  }
-  
+
   else
-    PRINTF("WARNING: class of R object not recognized. Should be numeric or integer\n");    
+    PRINTF(
+        "WARNING: class of R object not recognized. Should be numeric or "
+        "integer\n");
   return;
 }
 
-void SEXP_2_NimArrBool (SEXP rValues, NimArrBase<bool> &NimArrBl){
+void SEXP_2_NimArrBool(SEXP rValues, NimArrBase<bool> &NimArrBl) {
   int rLength = LENGTH(rValues);
-  if(rLength != NimArrBl.size() ) {
+  if (rLength != NimArrBl.size()) {
     PRINTF("Warning: R object of different size than NimArrBl!\n");
-    return;		
+    return;
   }
 
   // In R, Logical is represented as integer
-  if(isInteger(rValues) | isLogical(rValues)) {
-    for(int i = 0; i < rLength; i++)
-      NimArrBl[i] = INTEGER(rValues)[i];
+  if (isInteger(rValues) | isLogical(rValues)) {
+    for (int i = 0; i < rLength; i++) NimArrBl[i] = INTEGER(rValues)[i];
+  } else if (isReal(rValues)) {
+    for (int i = 0; i < rLength; i++) NimArrBl[i] = REAL(rValues)[i];
   }
-  else if(isReal(rValues) ) {
-    for(int i = 0; i < rLength; i++)
-      NimArrBl[i] = REAL(rValues)[i];
-  }
-  
+
   else
-    PRINTF("WARNING: class of R object not recognized. Should be numeric or integer\n");    
+    PRINTF(
+        "WARNING: class of R object not recognized. Should be numeric or "
+        "integer\n");
   return;
 }
 
+SEXP Nim_2_SEXP(SEXP rPtr, SEXP NumRefers) {
+  NimArrType *nimTypePtr = getNimTypePtr(rPtr, NumRefers);
+  if (!nimTypePtr) return (R_NilValue);
+  if ((*nimTypePtr).getNimType() == INT) {
+    NimArrBase<int> *nimBase = static_cast<NimArrBase<int> *>(nimTypePtr);
+    return (NimArrInt_2_SEXP((*nimBase)));
+  }
+  if ((*nimTypePtr).getNimType() == DOUBLE) {
+    NimArrBase<double> *nimBase = static_cast<NimArrBase<double> *>(nimTypePtr);
+    return (NimArrDouble_2_SEXP((*nimBase)));
+  }
+  if ((*nimTypePtr).getNimType() == BOOL) {
+    NimArrBase<bool> *nimBase = static_cast<NimArrBase<bool> *>(nimTypePtr);
+    return (NimArrBool_2_SEXP((*nimBase)));
+  }
 
-SEXP Nim_2_SEXP(SEXP rPtr, SEXP NumRefers){
-	NimArrType* nimTypePtr = getNimTypePtr(rPtr, NumRefers);
-	if(!nimTypePtr)
-		return(R_NilValue);
-	if(	(*nimTypePtr).getNimType() == INT){
-		NimArrBase<int>* nimBase = static_cast<NimArrBase<int> *>(nimTypePtr);
-		return(NimArrInt_2_SEXP( (*nimBase) ) ) ;
-	}
-	if(	(*nimTypePtr).getNimType() == DOUBLE){
-		NimArrBase<double>* nimBase = static_cast<NimArrBase<double> *>(nimTypePtr);
-		return(NimArrDouble_2_SEXP( (*nimBase) ) );
-	}
-	if(	(*nimTypePtr).getNimType() == BOOL){
-	  NimArrBase<bool>* nimBase = static_cast<NimArrBase<bool> *>(nimTypePtr);
-	  return(NimArrBool_2_SEXP( (*nimBase) ) );
-	}
-
-	PRINTF("Datatype of NimArr not found\n");
-	return(R_NilValue);
+  PRINTF("Datatype of NimArr not found\n");
+  return (R_NilValue);
 }
 
-SEXP SEXP_2_Nim(SEXP rPtr, SEXP NumRefers, SEXP rValues, SEXP allowResize){
-    vector<int> sexpDims = getSEXPdims( rValues );
-    int sexpNumDims = sexpDims.size();
-    bool resize = (LOGICAL(allowResize)[0] == TRUE);
+SEXP SEXP_2_Nim(SEXP rPtr, SEXP NumRefers, SEXP rValues, SEXP allowResize) {
+  vector<int> sexpDims = getSEXPdims(rValues);
+  int sexpNumDims = sexpDims.size();
+  bool resize = (LOGICAL(allowResize)[0] == TRUE);
 
-	NimArrType* nimTypePtr = getNimTypePtr(rPtr, NumRefers);
-	if(!nimTypePtr)
-		return(R_NilValue);
-	if((*nimTypePtr).getNimType() == INT){
-	  NimArrBase<int>* nimBase = static_cast<NimArrBase<int> *>(nimTypePtr);
-	  int nimNumDims = (*nimBase).numDims();
-	  if(nimNumDims != sexpNumDims){
-            if((LENGTH(rValues) != (*nimBase).size()) & (sexpNumDims != 1)){
-	      PRINTF("Incorrect number of dimensions in copying\n");
-	      return(R_NilValue);
-            }
-	  }
-	  if(resize == true)
-            (*nimBase).setSize(sexpDims);
-	  SEXP_2_NimArrInt(rValues,  (*nimBase) ) ;
-	}
-	if((*nimTypePtr).getNimType() == DOUBLE){
-	  
-	  NimArrBase<double>* nimBase = static_cast<NimArrBase<double> *>(nimTypePtr);
-	  int nimNumDims = (*nimBase).numDims();
-	  
-	  if(nimNumDims != sexpNumDims){
-            if((LENGTH(rValues) != (*nimBase).size()) & (sexpNumDims != 1)){
-	      PRINTF("Incorrect number of dimensions in copying\n");
-	      return(R_NilValue);
-            }
-	  }
-	  if((resize == true) & (nimNumDims == sexpNumDims))
-            (*nimBase).setSize(sexpDims);
-	  SEXP_2_NimArrDouble( rValues, (*nimBase) ) ;
-	}
-	if((*nimTypePtr).getNimType() == BOOL){
-	  NimArrBase<bool>* nimBase = static_cast<NimArrBase<bool> *>(nimTypePtr);
-	  int nimNumDims = (*nimBase).numDims();
-	  if(nimNumDims != sexpNumDims){
-            if((LENGTH(rValues) != (*nimBase).size()) & (sexpNumDims != 1)){
-	      PRINTF("Incorrect number of dimensions in copying\n");
-	      return(R_NilValue);
-            }
-	  }
-	  if(resize == true)
-            (*nimBase).setSize(sexpDims);
-	  SEXP_2_NimArrBool(rValues,  (*nimBase) ) ;
-	}
-	return(R_NilValue);
+  NimArrType *nimTypePtr = getNimTypePtr(rPtr, NumRefers);
+  if (!nimTypePtr) return (R_NilValue);
+  if ((*nimTypePtr).getNimType() == INT) {
+    NimArrBase<int> *nimBase = static_cast<NimArrBase<int> *>(nimTypePtr);
+    int nimNumDims = (*nimBase).numDims();
+    if (nimNumDims != sexpNumDims) {
+      if ((LENGTH(rValues) != (*nimBase).size()) & (sexpNumDims != 1)) {
+        PRINTF("Incorrect number of dimensions in copying\n");
+        return (R_NilValue);
+      }
+    }
+    if (resize == true) (*nimBase).setSize(sexpDims);
+    SEXP_2_NimArrInt(rValues, (*nimBase));
+  }
+  if ((*nimTypePtr).getNimType() == DOUBLE) {
+    NimArrBase<double> *nimBase = static_cast<NimArrBase<double> *>(nimTypePtr);
+    int nimNumDims = (*nimBase).numDims();
+
+    if (nimNumDims != sexpNumDims) {
+      if ((LENGTH(rValues) != (*nimBase).size()) & (sexpNumDims != 1)) {
+        PRINTF("Incorrect number of dimensions in copying\n");
+        return (R_NilValue);
+      }
+    }
+    if ((resize == true) & (nimNumDims == sexpNumDims))
+      (*nimBase).setSize(sexpDims);
+    SEXP_2_NimArrDouble(rValues, (*nimBase));
+  }
+  if ((*nimTypePtr).getNimType() == BOOL) {
+    NimArrBase<bool> *nimBase = static_cast<NimArrBase<bool> *>(nimTypePtr);
+    int nimNumDims = (*nimBase).numDims();
+    if (nimNumDims != sexpNumDims) {
+      if ((LENGTH(rValues) != (*nimBase).size()) & (sexpNumDims != 1)) {
+        PRINTF("Incorrect number of dimensions in copying\n");
+        return (R_NilValue);
+      }
+    }
+    if (resize == true) (*nimBase).setSize(sexpDims);
+    SEXP_2_NimArrBool(rValues, (*nimBase));
+  }
+  return (R_NilValue);
 }
 
 void VecNimArr_Finalizer(SEXP Sp) {
-  NimVecType* np = static_cast<NimVecType*>(R_ExternalPtrAddr(Sp));
-  if(np) delete np;
+  NimVecType *np = static_cast<NimVecType *>(R_ExternalPtrAddr(Sp));
+  if (np) delete np;
   R_ClearExternalPtr(Sp);
-
 }
 
 SEXP register_VecNimArr_Finalizer(SEXP Sp, SEXP Dll) {
   RegisterNimbleFinalizer(Sp, Dll, &VecNimArr_Finalizer, R_NilValue);
-  return(Sp);
+  return (Sp);
 }
 
-double nimMod(double a, double b) {
-  return(fmod(a, b));
-}
+double nimMod(double a, double b) { return (fmod(a, b)); }
 
 void rankSample(NimArr<1, double> &weights, int &n, NimArr<1, int> &output) {
   bool silent = false;
   rankSample(weights, n, output, silent);
 }
 
-void rankSample(NimArr<1, double> &weights, int &n, NimArr<1, int> &output, bool& silent) {
+void rankSample(NimArr<1, double> &weights, int &n, NimArr<1, int> &output,
+                bool &silent) {
   output.setSize(n);
   int N = weights.size();
   rawSample(weights.getPtr(), n, N, output.getPtr(), false, silent);
 }
 
-
-
-
-void row2NimArr(SEXP matrix, NimArrBase<double>* nimPtr, int startPoint, int len, int nRows){
-	for(int i = 0; i < len; i++)
-		(*nimPtr)[i] = REAL(matrix)[startPoint + i * nRows];
+void row2NimArr(SEXP matrix, NimArrBase<double> *nimPtr, int startPoint,
+                int len, int nRows) {
+  for (int i = 0; i < len; i++)
+    (*nimPtr)[i] = REAL(matrix)[startPoint + i * nRows];
 }
 
-void row2NimArr(SEXP matrix, NimArrBase<int>* nimPtr, int startPoint, int len, int nRows){
-	for(int i = 0; i < len; i++)
-		(*nimPtr)[i] = INTEGER(matrix)[startPoint + i * nRows];	
+void row2NimArr(SEXP matrix, NimArrBase<int> *nimPtr, int startPoint, int len,
+                int nRows) {
+  for (int i = 0; i < len; i++)
+    (*nimPtr)[i] = INTEGER(matrix)[startPoint + i * nRows];
 }
 
-
-
-SEXP matrix2VecNimArr(SEXP RvecNimPtr, SEXP matrix, SEXP rowStart, SEXP rowEnd){
-	int cRowStart = INTEGER(rowStart)[0] - 1;
-	int cRowEnd = INTEGER(rowEnd)[0] - 1;
-	NimVecType* vecTypePtr = static_cast<NimVecType*>(R_ExternalPtrAddr(RvecNimPtr) );
-	vector<int> rowDims = vecTypePtr->getRowDims(0);
-	int len = 0;
-	for(unsigned int i = 0; i < rowDims.size(); i++)
-		len = len + rowDims[i];		
-	int nRows = LENGTH(matrix) / len;
-	nimType varType = vecTypePtr->getNimType();
-	if(varType == DOUBLE){
-		VecNimArrBase<double>* vecPtr = static_cast<VecNimArrBase<double>*>(vecTypePtr);
-		for(int i = cRowStart; i <= cRowEnd; i++)
-			row2NimArr(matrix, static_cast<NimArrBase<double>*>(vecPtr->getRowTypePtr(i) ), cRowStart + i , len, nRows);
-	}
-	if(varType == INT){
-		VecNimArrBase<int>* vecPtr = static_cast<VecNimArrBase<int>*>(vecTypePtr);
-		for(int i = cRowStart; i <= cRowEnd; i++)
-			row2NimArr(matrix, static_cast<NimArrBase<int>*>(vecPtr->getRowTypePtr(i) ), cRowStart + i , len, nRows);
-	}
-	return(R_NilValue);
-}
-
-
-SEXP getEnvVar_Sindex(SEXP sString, SEXP sEnv, SEXP sIndex){
-	SEXP ans;
-	int cIndex = INTEGER(sIndex)[0] - 1;
-	ans = findVar(install(CHAR(STRING_ELT(sString, cIndex ))), sEnv);
-	PROTECT(ans);
-	UNPROTECT(1);
-	return(ans);
-	}
-
-SEXP getEnvVar(SEXP sString, SEXP sEnv){
-  	return(getEnvVar_Sindex(sString, sEnv, ScalarInteger(1)));
-}
-
-SEXP setEnvVar_Sindex(SEXP sString, SEXP sEnv, SEXP sVal, SEXP sIndex){
-	int cIndex = INTEGER(sIndex)[0] - 1;
-	setVar(install(CHAR(STRING_ELT(sString, cIndex ))), sVal, sEnv);
-	return(R_NilValue);
-}
-
- SEXP setEnvVar(SEXP sString, SEXP sEnv, SEXP sVal){						
-  	return(setEnvVar_Sindex(sString, sEnv, sVal, ScalarInteger(1)));
+SEXP matrix2VecNimArr(SEXP RvecNimPtr, SEXP matrix, SEXP rowStart,
+                      SEXP rowEnd) {
+  int cRowStart = INTEGER(rowStart)[0] - 1;
+  int cRowEnd = INTEGER(rowEnd)[0] - 1;
+  NimVecType *vecTypePtr =
+      static_cast<NimVecType *>(R_ExternalPtrAddr(RvecNimPtr));
+  vector<int> rowDims = vecTypePtr->getRowDims(0);
+  int len = 0;
+  for (unsigned int i = 0; i < rowDims.size(); i++) len = len + rowDims[i];
+  int nRows = LENGTH(matrix) / len;
+  nimType varType = vecTypePtr->getNimType();
+  if (varType == DOUBLE) {
+    VecNimArrBase<double> *vecPtr =
+        static_cast<VecNimArrBase<double> *>(vecTypePtr);
+    for (int i = cRowStart; i <= cRowEnd; i++)
+      row2NimArr(matrix,
+                 static_cast<NimArrBase<double> *>(vecPtr->getRowTypePtr(i)),
+                 cRowStart + i, len, nRows);
   }
-  
+  if (varType == INT) {
+    VecNimArrBase<int> *vecPtr = static_cast<VecNimArrBase<int> *>(vecTypePtr);
+    for (int i = cRowStart; i <= cRowEnd; i++)
+      row2NimArr(matrix,
+                 static_cast<NimArrBase<int> *>(vecPtr->getRowTypePtr(i)),
+                 cRowStart + i, len, nRows);
+  }
+  return (R_NilValue);
+}
+
+SEXP getEnvVar_Sindex(SEXP sString, SEXP sEnv, SEXP sIndex) {
+  SEXP ans;
+  int cIndex = INTEGER(sIndex)[0] - 1;
+  ans = findVar(install(CHAR(STRING_ELT(sString, cIndex))), sEnv);
+  PROTECT(ans);
+  UNPROTECT(1);
+  return (ans);
+}
+
+SEXP getEnvVar(SEXP sString, SEXP sEnv) {
+  return (getEnvVar_Sindex(sString, sEnv, ScalarInteger(1)));
+}
+
+SEXP setEnvVar_Sindex(SEXP sString, SEXP sEnv, SEXP sVal, SEXP sIndex) {
+  int cIndex = INTEGER(sIndex)[0] - 1;
+  setVar(install(CHAR(STRING_ELT(sString, cIndex))), sVal, sEnv);
+  return (R_NilValue);
+}
+
+SEXP setEnvVar(SEXP sString, SEXP sEnv, SEXP sVal) {
+  return (setEnvVar_Sindex(sString, sEnv, sVal, ScalarInteger(1)));
+}

--- a/packages/nimble/inst/CppCode/RcppNimbleUtils.cpp
+++ b/packages/nimble/inst/CppCode/RcppNimbleUtils.cpp
@@ -204,7 +204,6 @@ SEXP getNRow(SEXP Sextptr){
 	else{
 		PRINTF("Data type of VecNimArr not currently supported\n");
 		_nimble_global_output<< "vecType = " << vecType << "\n"; nimble_print_to_R(_nimble_global_output);
-//		cout << "vecType DOUBLE = " << DOUBLE << "\n";
 		}
 	SEXP rNRow;
 	PROTECT(rNRow = allocVector(INTSXP, 1) ); 
@@ -385,7 +384,6 @@ SEXP cGetMVElementOneRow(NimVecType* typePtr, nimType vecType, int index) 	{
   	}
     else if(vecType == INT){
 		VecNimArrBase<int> *matPtr = static_cast< VecNimArrBase<int>* >(typePtr);
-//		int nrowCpp = matPtr->size();
 		NimArrBase<int> *thisRow;
   		thisRow = matPtr->getBasePtr(index - 1);		//Converting R index to C index
 		int outputLength = thisRow->size();
@@ -506,7 +504,6 @@ SEXP setMVElement(SEXP Sextptr, SEXP Sindex, SEXP Svalue){
 	return(returnStatus(false) ) ;
   }
   cSetMVElementSingle( typePtr, vecType, index, Svalue );
-  //SEXP SEXP_2_int(SEXP rPtr, SEXP refNum, SEXP rScalar);
   return(returnStatus(true) );
  } 
  
@@ -527,7 +524,6 @@ SEXP NimArrDouble_2_SEXP(NimArrBase<double> &nimArrDbl){
 		int len = nimArrDbl.size();
 		SEXP Sans;  
 		PROTECT(Sans = allocVector(REALSXP, len));
-		//		std::copy(nimArrDbl.v.begin(), nimArrDbl.v.end() , REAL(Sans) );
 		std::copy(nimArrDbl.v, nimArrDbl.v + len , REAL(Sans) );  
   		int numDims = nimArrDbl.numDims();
   		if(numDims > 1) {
@@ -547,7 +543,6 @@ SEXP NimArrInt_2_SEXP(NimArrBase<int> &nimArrInt){
 		int len = nimArrInt.size();
 		SEXP Sans;  
 		PROTECT(Sans = allocVector(INTSXP, len));
-		//		std::copy(nimArrInt.v.begin(), nimArrInt.v.end() , INTEGER(Sans) );
 		std::copy(nimArrInt.v, nimArrInt.v + len , INTEGER(Sans) );  
   		int numDims = nimArrInt.numDims();
   		if(numDims > 1) {
@@ -567,7 +562,6 @@ SEXP NimArrBool_2_SEXP(NimArrBase<bool> &nimArrBl){
   int len = nimArrBl.size();
   SEXP Sans;  
   PROTECT(Sans = allocVector(LGLSXP, len));
-  //		std::copy(nimArrInt.v.begin(), nimArrInt.v.end() , INTEGER(Sans) );
   std::copy(nimArrBl.v, nimArrBl.v + len , LOGICAL(Sans) );  
   int numDims = nimArrBl.numDims();
   if(numDims > 1) {
@@ -739,7 +733,6 @@ SEXP SEXP_2_Nim(SEXP rPtr, SEXP NumRefers, SEXP rValues, SEXP allowResize){
 }
 
 void VecNimArr_Finalizer(SEXP Sp) {
-  //  std::cout<< "In VecNimArr_Finalizer\n";
   NimVecType* np = static_cast<NimVecType*>(R_ExternalPtrAddr(Sp));
   if(np) delete np;
   R_ClearExternalPtr(Sp);
@@ -747,8 +740,6 @@ void VecNimArr_Finalizer(SEXP Sp) {
 }
 
 SEXP register_VecNimArr_Finalizer(SEXP Sp, SEXP Dll) {
-  //  std::cout<< "In register_VecNimArr_Finalizer\n";
-  //  R_RegisterCFinalizerEx(Sp, &VecNimArr_Finalizer, TRUE);
   RegisterNimbleFinalizer(Sp, Dll, &VecNimArr_Finalizer, R_NilValue);
   return(Sp);
 }
@@ -757,22 +748,15 @@ double nimMod(double a, double b) {
   return(fmod(a, b));
 }
 
-// bool compareOrderedPair(orderedPair a, orderedPair b) {  //function called for sort 
-//   return(a.value < b.value);
-// }
-
 void rankSample(NimArr<1, double> &weights, int &n, NimArr<1, int> &output) {
   bool silent = false;
   rankSample(weights, n, output, silent);
 }
 
 void rankSample(NimArr<1, double> &weights, int &n, NimArr<1, int> &output, bool& silent) {
-  //PRINTF("in VOID rankSample\n");
   output.setSize(n);
   int N = weights.size();
-  //GetRNGstate();
   rawSample(weights.getPtr(), n, N, output.getPtr(), false, silent);
-  //PutRNGstate();
 }
 
 

--- a/packages/nimble/inst/CppCode/RcppNimbleUtils.cpp
+++ b/packages/nimble/inst/CppCode/RcppNimbleUtils.cpp
@@ -384,8 +384,8 @@ SEXP cGetMVElementOneRow(NimVecType *typePtr, nimType vecType, int index) {
     SEXP Sans;
     PROTECT(Sans = allocVector(REALSXP, outputLength));
     double *value = REAL(Sans);
-    std::copy(thisRow->getPtr(), thisRow->getPtr() + outputLength,
-              value);              /* copy should work now */
+    /* copy should work now */
+    std::copy(thisRow->getPtr(), thisRow->getPtr() + outputLength, value);
     if (thisRow->numDims() > 1) {  // using first row as representative
       SEXP Sdim;
       PROTECT(Sdim = allocVector(INTSXP, thisRow->numDims()));
@@ -405,8 +405,8 @@ SEXP cGetMVElementOneRow(NimVecType *typePtr, nimType vecType, int index) {
     SEXP Sans;
     PROTECT(Sans = allocVector(INTSXP, outputLength));
     int *value = INTEGER(Sans);
-    std::copy(thisRow->getPtr(), thisRow->getPtr() + outputLength,
-              value);              /* copy should work now */
+    /* copy should work now */
+    std::copy(thisRow->getPtr(), thisRow->getPtr() + outputLength, value);
     if (thisRow->numDims() > 1) {  // using first row as representative
       SEXP Sdim;
       PROTECT(Sdim = allocVector(INTSXP, thisRow->numDims()));

--- a/packages/nimble/inst/CppCode/RcppUtils.cpp
+++ b/packages/nimble/inst/CppCode/RcppUtils.cpp
@@ -268,104 +268,6 @@ bool SEXP_2_bool(SEXP Sn, int i) {
   return(false);
 }
 
-// bool checkString(SEXP Ss, int len) {
-//   if(!isString(Ss)) {
-//     PRINTF("Error: something that was supposed to be a string is not\n"); 
-//     return(false);
-//   }
-//   if(LENGTH(Ss) < len) {
-//     PRINTF("Error: A string vector that was supposed to have length at least %i does not\n", len);
-//     return(false);
-//   }
-//   return(true);
-// }
-
-// bool checkNumeric(SEXP Sval, int len) {
-//   if(!isNumeric(Sval)) return(false);
-//   if(LENGTH(Sval) != len) return(false);
-//   return(true);
-// }
-
-// SEXP setVec(SEXP Sextptr, SEXP Svalue) {
-//   if(!isNumeric(Svalue)) {
-//     PRINTF("Error: Svalue is not a numeric!\n");
-//     return(R_NilValue);
-//   }
-//   if(!R_ExternalPtrAddr(Sextptr)) {
-//      RBREAK("Error: Sextptr is not a valid external pointer\n");
-//   }
-//   //  vector<double> *vecPtr = *static_cast< vector<double>** >(R_ExternalPtrAddr(Sextptr));
-//   NimArrBase<double> *vecPtr = *static_cast< NimArrBase<double>** >(R_ExternalPtrAddr(Sextptr));
-
-//  int nn = LENGTH(Svalue);
-//   int lengthCpp = vecPtr->size();
-//   if(nn != lengthCpp) {
-//     PRINTF("Error: length of Svalues does not match C++ vector length.  Using smaller.\n");
-//     if(nn > lengthCpp) nn = lengthCpp;
-//   }
-//   double *value = REAL(Svalue);
-//   std::copy(value, value + nn, &(vecPtr->v[0]) );	
-//   return(R_NilValue);
-// }
-  
-// SEXP getVec(SEXP Sextptr) {
-//   if(!R_ExternalPtrAddr(Sextptr)) {
-//     PRINTF("Error: Sextptr is not a valid external pointer\n");
-//     return(R_NilValue);
-//   }
-
-//   NimArrBase<double> *vecPtr = static_cast< NimArrBase<double> * >(R_ExternalPtrAddr(Sextptr));
-
-//   int len = vecPtr->size();
-//   SEXP Sans;  
-  
-//   PROTECT(Sans = allocVector(REALSXP, len));
-//   //std::copy(vecPtr->v.begin(), vecPtr->v.end() , REAL(Sans) );
-//   std::copy(vecPtr->v, vecPtr->v + len , REAL(Sans) );
-  
-//   int numDims = vecPtr->numDims();
-//   if(numDims > 1) {
-//     SEXP Sdim;
-//     PROTECT(Sdim = allocVector(INTSXP, numDims));
-//     for(int idim = 0; idim < numDims; ++idim) INTEGER(Sdim)[idim] = vecPtr->dimSize(idim);
-//     setAttrib(Sans, R_DimSymbol, Sdim);
-//     UNPROTECT(2);
-//   } else {
-//     UNPROTECT(1);
-//   } 
-//  return(Sans);
-// }
-
-// SEXP getVec_Integer(SEXP Sextptr) {
-//   if(!R_ExternalPtrAddr(Sextptr)) {
-//     PRINTF("Error: Sextptr is not a valid external pointer\n");
-//     return(R_NilValue);
-//   }
-//   NimArrBase<int> *vecPtr = *static_cast< NimArrBase<int> ** >(R_ExternalPtrAddr(Sextptr));
-//   SEXP Sans;
-//   int len = vecPtr->size();
-  
-//   PROTECT(Sans = allocVector(REALSXP, len));
-//   //  std::copy(vecPtr->v.begin(), vecPtr->v.end(), INTEGER(Sans) );
-//   std::copy(vecPtr->v, vecPtr->v + len, INTEGER(Sans) );  
-  
-//   int numDims = vecPtr->numDims();
-//   if(numDims > 1) {
-//     SEXP Sdim;
-//     PROTECT(Sdim = allocVector(INTSXP, numDims));
-//     for(int idim = 0; idim < numDims; ++idim) INTEGER(Sdim)[idim] = vecPtr->dimSize(idim);
-//     setAttrib(Sans, R_DimSymbol, Sdim);
-//     UNPROTECT(2);
-//   } else {
-//     UNPROTECT(1);
-//   } 
-//  return(Sans);
-// }
-
-// void dontDeleteFinalizer(SEXP ptr){
-// 	return;
-// }
-
 SEXP populate_SEXP_2_double(SEXP rPtr, SEXP refNum, SEXP rScalar){
     void* vPtr = R_ExternalPtrAddr(rPtr);
     if(vPtr == NULL){
@@ -575,7 +477,6 @@ SEXP fastMatrixInsert(SEXP matrixInto, SEXP matrix, SEXP rowStart, SEXP colStart
 }
 
 SEXP matrix2ListDouble(SEXP matrix, SEXP list, SEXP listStartIndex, SEXP RnRows,  SEXP dims){
-  //int cStart = INTEGER(listStartIndex)[0] - 1;
 	int cNRows = INTEGER(RnRows)[0];
 	int len = 1;
 	for(int i = 0; i < LENGTH(dims); i++)
@@ -593,7 +494,6 @@ SEXP matrix2ListDouble(SEXP matrix, SEXP list, SEXP listStartIndex, SEXP RnRows,
 }
 
 SEXP matrix2ListInt(SEXP matrix, SEXP list, SEXP listStartIndex, SEXP RnRows,  SEXP dims){
-  //	int cStart = INTEGER(listStartIndex)[0] - 1;
 	int cNRows = INTEGER(RnRows)[0];
 	int len = 1;
 	for(int i = 0; i < LENGTH(dims); i++)
@@ -677,7 +577,6 @@ void rawSample(double* p, int c_samps, int N, int* ans, bool unsort, bool silent
 }
 
 SEXP C_rankSample(SEXP p, SEXP n, SEXP not_used, SEXP s) {
-  //PRINTF("in SEXP C_rankSample\n");
   int N = LENGTH(p);
   int c_samps = INTEGER(n)[0];
   bool silent = LOGICAL(s)[0];
@@ -701,10 +600,6 @@ void parseVar(const vector<string> &input, vector<string> &output) {
       output[i].assign( input[i].substr(iBegin, iEnd - iBegin) );
     else
       output[i].assign( string("") );
-    //    if(iBracket != std::string::npos)
-
-    //    else
-    //   output[i].assign( input[i] );
   }
 }
 

--- a/packages/nimble/inst/CppCode/RcppUtils.cpp
+++ b/packages/nimble/inst/CppCode/RcppUtils.cpp
@@ -331,6 +331,9 @@ SEXP populate_SEXP_2_double(SEXP rPtr, SEXP refNum, SEXP rScalar) {
   return (R_NilValue);
 }
 
+// Note: this is identical to above and one should be removed (ie. just
+// SEXP_2_scalar)
+// But our generated code calls both
 SEXP populate_SEXP_2_int(SEXP rPtr, SEXP refNum, SEXP rScalar) {
   void* vPtr = R_ExternalPtrAddr(rPtr);
   if (vPtr == NULL) {
@@ -353,9 +356,7 @@ SEXP populate_SEXP_2_int(SEXP rPtr, SEXP refNum, SEXP rScalar) {
     PRINTF(
         "R class not identified. Currently numeric and integers supported\n");
   return (R_NilValue);
-}  // Note: this is identical to above and one should be removed (ie. just
-   // SEXP_2_scalar)
-// But our generated code calls both
+}
 
 SEXP populate_SEXP_2_bool(SEXP rPtr, SEXP refNum, SEXP rScalar) {
   void* vPtr = R_ExternalPtrAddr(rPtr);
@@ -580,8 +581,8 @@ void rawSample(double* p, int c_samps, int N, int* ans, bool unsort,
   }
   if (badVals) {
     for (int i = 1; i <= c_samps; i++)
-      ans[i - 1] = ((i - 1) % N) +
-                   1;  // generates a cyclic uniform sample (DT, May 2015)
+      // generates a cyclic uniform sample (DT, May 2015)
+      ans[i - 1] = ((i - 1) % N) + 1;
     return;
   }
   cdf[N] = sum + 1;

--- a/packages/nimble/inst/CppCode/Utils.cpp
+++ b/packages/nimble/inst/CppCode/Utils.cpp
@@ -14,14 +14,13 @@ int floorOrEquivalent(double x) {
   double roundX = round(x);
   double sqrtEpsilon = sqrt(std::numeric_limits<double>::epsilon());
   bool shouldBeExactInteger(false);
-  if (fabs(x) > sqrtEpsilon) {  // This algorithm for numerical equivalence
-                                // imitates what happens in all.equal.numeric in
-                                // R
+  // This algorithm for numerical equivalence imitates what happens in
+  // all.equal.numeric in R
+  if (fabs(x) > sqrtEpsilon) {
     if (fabs(x - roundX) / fabs(x) < sqrtEpsilon) shouldBeExactInteger = true;
   } else {
-    if (fabs(x - roundX) < sqrtEpsilon)  // in the present context, this would
-                                         // mean length should be zero anyway
-      shouldBeExactInteger = true;
+    // in the present context, this would mean length should be zero anyway
+    if (fabs(x - roundX) < sqrtEpsilon) shouldBeExactInteger = true;
   }
   if (shouldBeExactInteger) return (static_cast<int>(roundX));
   return (floor(x));
@@ -33,8 +32,8 @@ int rFunLength(double Arg) { return Arg; }
 
 int rFunLength(bool Arg) { return Arg; }
 
-bool decide(double lMHr) {  // simple function accept or reject based on log
-                            // Metropolis-Hastings ratio
+// simple function accept or reject based on log Metropolis-Hastings ratio
+bool decide(double lMHr) {
   if (ISNAN(lMHr)) return (false);
   if (lMHr > 0) return (true);
   if (runif(0, 1) < exp(lMHr)) return (true);
@@ -58,10 +57,12 @@ int nimEquals(double x1, double x2) { return (x1 == x2 ? 1 : 0); }
 double nimbleIfElse(bool condition, double x1, double x2) {
   return (condition ? x1 : x2);
 }
-double lfactorial(double x) {
-  return (lgammafn(x + 1));
-}  //{return(lgamma1p(x));} not numerically equivalent to lgamma(x+1), which is
-   // what is done from R. lgamma seems to clean up numerical zeros
+
+// Note that {return(lgamma1p(x));} is not numerically equivalent to
+// lgamma(x+1), which is what is done from R. lgamma seems to clean up
+// numerical zeros
+double lfactorial(double x) { return (lgammafn(x + 1)); }
+
 double factorial(double x) { return (gammafn(1 + x)); }
 double logit(double x) { return (log(x / (1. - x))); }
 double nimRound(double x) { return (fround(x, 0.)); }

--- a/packages/nimble/inst/CppCode/Utils.cpp
+++ b/packages/nimble/inst/CppCode/Utils.cpp
@@ -52,18 +52,15 @@ double icloglog(double x) {return(1.-exp(-exp(x)));}
 double iprobit(double x) {return(pnorm(x, 0., 1., 1, 0));}
 
 double probit(double x) {return(qnorm(x, 0., 1., 1, 0));}
-//double abs(double x) {return(fabs(x));}
 double cloglog(double x) {return(log(-log(1.-x)));}
 int nimEquals(double x1, double x2) {return(x1 == x2 ? 1 : 0);}
 double nimbleIfElse(bool condition, double x1, double x2) {return(condition ? x1 : x2);}
 double lfactorial(double x) {return(lgammafn(x + 1));} //{return(lgamma1p(x));} not numerically equivalent to lgamma(x+1), which is what is done from R. lgamma seems to clean up numerical zeros
 double factorial(double x) {return(gammafn(1+x));}
-//double loggam(double x) {return(lgammafn(x));}
 double logit(double x) {return(log(x / (1.-x)));}
 double nimRound(double x) {return(fround(x, 0.));}
 double pairmax(double x1, double x2) {return(x1 > x2 ? x1 : x2);}
 double pairmin(double x1, double x2) {return(x1 < x2 ? x1 : x2);}
-//double phi(double x) {return(pnorm(x, 0., 1., 1, 0));}
 int nimStep(double x) { return(x >= 0 ? 1 : 0);}
 double cube(double x) {return(x*x*x);}
 double inprod(double v1, double v2) {return(v1*v2);}

--- a/packages/nimble/inst/CppCode/Utils.cpp
+++ b/packages/nimble/inst/CppCode/Utils.cpp
@@ -1,66 +1,72 @@
-#include<limits>
 #include "nimble/Utils.h"
+#include <limits>
 #define PRINTF Rprintf
 #define NIMERROR error
-#define RBREAK(msg) {PRINTF(msg); return(R_NilValue);}
+#define RBREAK(msg)      \
+  {                      \
+    PRINTF(msg);         \
+    return (R_NilValue); \
+  }
 
-// A utility function that will return floor(x) unless x is within numerical imprecision of an integer, in which case it will return round(x)
+// A utility function that will return floor(x) unless x is within numerical
+// imprecision of an integer, in which case it will return round(x)
 int floorOrEquivalent(double x) {
   double roundX = round(x);
   double sqrtEpsilon = sqrt(std::numeric_limits<double>::epsilon());
   bool shouldBeExactInteger(false);
-  if(fabs(x) > sqrtEpsilon) { // This algorithm for numerical equivalence imitates what happens in all.equal.numeric in R
-    if(fabs(x - roundX) / fabs(x) < sqrtEpsilon)
-      shouldBeExactInteger = true;
+  if (fabs(x) > sqrtEpsilon) {  // This algorithm for numerical equivalence
+                                // imitates what happens in all.equal.numeric in
+                                // R
+    if (fabs(x - roundX) / fabs(x) < sqrtEpsilon) shouldBeExactInteger = true;
   } else {
-    if(fabs(x - roundX) < sqrtEpsilon) // in the present context, this would mean length should be zero anyway
+    if (fabs(x - roundX) < sqrtEpsilon)  // in the present context, this would
+                                         // mean length should be zero anyway
       shouldBeExactInteger = true;
   }
-  if(shouldBeExactInteger)
-    return(static_cast<int>(roundX));
-  return(floor(x));
+  if (shouldBeExactInteger) return (static_cast<int>(roundX));
+  return (floor(x));
 }
 
-int rFunLength(int Arg) {
-  return Arg;
+int rFunLength(int Arg) { return Arg; }
+
+int rFunLength(double Arg) { return Arg; }
+
+int rFunLength(bool Arg) { return Arg; }
+
+bool decide(double lMHr) {  // simple function accept or reject based on log
+                            // Metropolis-Hastings ratio
+  if (ISNAN(lMHr)) return (false);
+  if (lMHr > 0) return (true);
+  if (runif(0, 1) < exp(lMHr)) return (true);
+  return (false);
 }
 
-int rFunLength(double Arg) {
-  return Arg;
+void nimStop(string msg) { NIMERROR(msg.c_str()); }
+void nimStop() { NIMERROR(""); }
+
+bool nimNot(bool x) { return (!x); }
+
+double ilogit(double x) { return (1. / (1. + exp(-x))); }
+
+double icloglog(double x) { return (1. - exp(-exp(x))); }
+
+double iprobit(double x) { return (pnorm(x, 0., 1., 1, 0)); }
+
+double probit(double x) { return (qnorm(x, 0., 1., 1, 0)); }
+double cloglog(double x) { return (log(-log(1. - x))); }
+int nimEquals(double x1, double x2) { return (x1 == x2 ? 1 : 0); }
+double nimbleIfElse(bool condition, double x1, double x2) {
+  return (condition ? x1 : x2);
 }
-
-int rFunLength(bool Arg) {
-  return Arg;
-}
-
-bool decide(double lMHr) { // simple function accept or reject based on log Metropolis-Hastings ratio
-  if(ISNAN(lMHr)) return(false);
-  if(lMHr > 0) return(true);
-  if(runif(0,1) < exp(lMHr)) return(true);
-  return(false);
-}
-
-void nimStop(string msg) {NIMERROR(msg.c_str());}
-void nimStop() {NIMERROR("");}
-
-bool nimNot(bool x) {return(!x);}
-
-double ilogit(double x) {return(1./(1. + exp(-x)));}
-
-double icloglog(double x) {return(1.-exp(-exp(x)));}
-
-double iprobit(double x) {return(pnorm(x, 0., 1., 1, 0));}
-
-double probit(double x) {return(qnorm(x, 0., 1., 1, 0));}
-double cloglog(double x) {return(log(-log(1.-x)));}
-int nimEquals(double x1, double x2) {return(x1 == x2 ? 1 : 0);}
-double nimbleIfElse(bool condition, double x1, double x2) {return(condition ? x1 : x2);}
-double lfactorial(double x) {return(lgammafn(x + 1));} //{return(lgamma1p(x));} not numerically equivalent to lgamma(x+1), which is what is done from R. lgamma seems to clean up numerical zeros
-double factorial(double x) {return(gammafn(1+x));}
-double logit(double x) {return(log(x / (1.-x)));}
-double nimRound(double x) {return(fround(x, 0.));}
-double pairmax(double x1, double x2) {return(x1 > x2 ? x1 : x2);}
-double pairmin(double x1, double x2) {return(x1 < x2 ? x1 : x2);}
-int nimStep(double x) { return(x >= 0 ? 1 : 0);}
-double cube(double x) {return(x*x*x);}
-double inprod(double v1, double v2) {return(v1*v2);}
+double lfactorial(double x) {
+  return (lgammafn(x + 1));
+}  //{return(lgamma1p(x));} not numerically equivalent to lgamma(x+1), which is
+   // what is done from R. lgamma seems to clean up numerical zeros
+double factorial(double x) { return (gammafn(1 + x)); }
+double logit(double x) { return (log(x / (1. - x))); }
+double nimRound(double x) { return (fround(x, 0.)); }
+double pairmax(double x1, double x2) { return (x1 > x2 ? x1 : x2); }
+double pairmin(double x1, double x2) { return (x1 < x2 ? x1 : x2); }
+int nimStep(double x) { return (x >= 0 ? 1 : 0); }
+double cube(double x) { return (x * x * x); }
+double inprod(double v1, double v2) { return (v1 * v2); }

--- a/packages/nimble/inst/include/nimble/ModelClassUtils.h
+++ b/packages/nimble/inst/include/nimble/ModelClassUtils.h
@@ -12,21 +12,22 @@ class ModelBase : public NamedObjects {
 };
 
 extern "C" {
-SEXP getModelValuesPtrFromModel(
-    SEXP rPtr);  // gets pointer to modelvalues object in model
-SEXP getModelElementPtr(
-    SEXP Sextptr, SEXP Sname);  // Gets the ptr to an element of name Sname from
+// gets pointer to modelvalues object in model
+SEXP getModelValuesPtrFromModel(SEXP rPtr);
+// Gets the ptr to an element of name Sname from
 // the ModelValues object pointed to by Sextptr
+SEXP getModelElementPtr(SEXP Sextptr, SEXP Sname);
 
-SEXP getMVBuildName(SEXP rPtr);  // gets character string to feed to .Call
+// gets character string to feed to .Call
 // that builds a new ModelValue of the same type as
 // is pointed to by rPtr
+SEXP getMVBuildName(SEXP rPtr);
 
 SEXP derefPtr(SEXP SmultiPtr);
 }
 
-NimArrType** cGetModelElementPtr(
-    SEXP Sextptr, SEXP Sname);  // Gets the ptr to an element of name Sname from
+// Gets the ptr to an element of name Sname from
 // the ModelValues object pointed to by Sextptr
+NimArrType** cGetModelElementPtr(SEXP Sextptr, SEXP Sname);
 
 #endif

--- a/packages/nimble/inst/include/nimble/ModelClassUtils.h
+++ b/packages/nimble/inst/include/nimble/ModelClassUtils.h
@@ -5,26 +5,28 @@
 #include "RcppNimbleUtils.h"
 #include "Values.h"
 
-class ModelBase : public NamedObjects{
-	public:
-	Values* modelValues_;
-	virtual Values* getModelValuesPtr(){ return modelValues_; }
-	};
+class ModelBase : public NamedObjects {
+ public:
+  Values* modelValues_;
+  virtual Values* getModelValuesPtr() { return modelValues_; }
+};
 
 extern "C" {
-  SEXP getModelValuesPtrFromModel (SEXP rPtr); // gets pointer to modelvalues object in model
-  SEXP getModelElementPtr(SEXP Sextptr, SEXP Sname); // Gets the ptr to an element of name Sname from
-  // the ModelValues object pointed to by Sextptr
-  
-  SEXP getMVBuildName(SEXP rPtr);			// gets character string to feed to .Call 
-  // that builds a new ModelValue of the same type as
-  // is pointed to by rPtr
-  
-  SEXP derefPtr(SEXP SmultiPtr);
- }
+SEXP getModelValuesPtrFromModel(
+    SEXP rPtr);  // gets pointer to modelvalues object in model
+SEXP getModelElementPtr(
+    SEXP Sextptr, SEXP Sname);  // Gets the ptr to an element of name Sname from
+// the ModelValues object pointed to by Sextptr
 
+SEXP getMVBuildName(SEXP rPtr);  // gets character string to feed to .Call
+// that builds a new ModelValue of the same type as
+// is pointed to by rPtr
 
-NimArrType** cGetModelElementPtr(SEXP Sextptr, SEXP Sname);	// Gets the ptr to an element of name Sname from
+SEXP derefPtr(SEXP SmultiPtr);
+}
+
+NimArrType** cGetModelElementPtr(
+    SEXP Sextptr, SEXP Sname);  // Gets the ptr to an element of name Sname from
 // the ModelValues object pointed to by Sextptr
 
 #endif

--- a/packages/nimble/inst/include/nimble/RcppNimbleUtils.h
+++ b/packages/nimble/inst/include/nimble/RcppNimbleUtils.h
@@ -51,49 +51,46 @@ SEXP matrix2VecNimArr(SEXP RvecNimPtr, SEXP matrix, SEXP rowStart, SEXP rowEnd);
 
 SEXP setMVElement(SEXP Sextptr, SEXP Sindex, SEXP Svalue);
 
-SEXP newSampObject();  //  Creates our new object from sampleClass (will be
-                       //  generated automatically later)
-                       //	Just for use in demos
-                       // 	To get a pointer to an element from sampleClass, use
-                       //	getModelObjectPtr (from the NamedObjects.cpp file)
+// Creates our new object from sampleClass (will be generated automatically
+// later).
+// Just for use in demos.
+// To get a pointer to an element from sampleClass, use
+// getModelObjectPtr (from the NamedObjects.cpp file).
+SEXP newSampObject();
 
-SEXP Nim_2_SEXP(SEXP rPtr, SEXP NumRefers);  //	Returns SEXP object with correct
-                                             //data type and dimensions.
-                                             //NumRefers
-//  should be an integer with the number of dereferencing required for rPtr
-//	So if rPtr is a pointer to a NimArr, NumRefers = 1
-//	If rPtr is a pointer to a pointer to a NimArr, NumRefers = 2
-//	Currently only NumRefers = 1 and 2 are allowed, but easily updated
-//	by extending "getNimTypePtr" function
+// Returns SEXP object with correct data type and dimensions.  NumRefers
+// should be an integer with the number of dereferencing required for rPtr
+// So if rPtr is a pointer to a NimArr, NumRefers = 1
+// If rPtr is a pointer to a pointer to a NimArr, NumRefers = 2
+// Currently only NumRefers = 1 and 2 are allowed, but easily updated
+// by extending "getNimTypePtr" function
+SEXP Nim_2_SEXP(SEXP rPtr, SEXP NumRefers);
 
-SEXP SEXP_2_Nim(SEXP rPtr, SEXP NumRefers, SEXP rValues,
-                SEXP allowResize);  //	Copies values from rValues to NimArr.
-                                    //Same behavior
-// 	with NumRefers as above. Also, type checking is done
-// 	by R.internals functions INTEGER and REAL
+//	Copies values from rValues to NimArr.
+// Same behavior with NumRefers as above. Also, type checking is done by
+// R.internals functions INTEGER and REAL
+SEXP SEXP_2_Nim(SEXP rPtr, SEXP NumRefers, SEXP rValues, SEXP allowResize);
 
 SEXP setPtrVectorOfPtrs(SEXP SaccessorPtr, SEXP ScontentsPtr, SEXP Ssize);
 SEXP setOnePtrVectorOfPtrs(SEXP SaccessorPtr, SEXP Si, SEXP ScontentsPtr);
 
-SEXP getEnvVar_Sindex(
-    SEXP sString, SEXP sEnv,
-    SEXP sIndex);  // This is a utility for looking up a field of an environment
-                   // sString is a character vector with the field name we want
-                   // sEnv is the environment
-                   // sIndex is the index of the sString that contains the name
-                   // we actually want to use.
-//	Look up by sString[sIndex] is done to allow for easy looping
+// This is a utility for looking up a field of an environment sString is a
+// character vector with the field name we want sEnv is the environment sIndex
+// is the index of the sString that contains the name we actually want to use.
+// Look up by sString[sIndex] is done to allow for easy looping
 // Important Note: sIndex = 1 looks up the first name (i.e. use R indexing, not
-// C)
-SEXP getEnvVar(SEXP sString, SEXP sEnv);  // Same as above, but uses sIndex = 1
-                                          // (i.e. sString is a single character
-                                          // string)
+// C).
+SEXP getEnvVar_Sindex(SEXP sString, SEXP sEnv, SEXP sIndex);
 
-SEXP setEnvVar_Sindex(SEXP sString, SEXP sEnv, SEXP sVal,
-                      SEXP sIndex);  // Same as getEnvVar_Sindex, but this
-                                     // function sets rather than gets
-SEXP setEnvVar(SEXP sString, SEXP sEnv,
-               SEXP sVal);  // Same as above but uses sIndex = 1
+// Same as above, but uses sIndex = 1 (i.e. sString is a single character
+// string)
+SEXP getEnvVar(SEXP sString, SEXP sEnv);
+
+// Same as getEnvVar_Sindex, but this function sets rather than gets
+SEXP setEnvVar_Sindex(SEXP sString, SEXP sEnv, SEXP sVal, SEXP sIndex);
+
+// Same as above but uses sIndex = 1
+SEXP setEnvVar(SEXP sString, SEXP sEnv, SEXP sVal);
 
 SEXP register_VecNimArr_Finalizer(SEXP Sp, SEXP Dll);
 }
@@ -124,8 +121,7 @@ NimArr<1, double> vectorDouble_2_NimArr(vector<double> input);
 /*
   Apparently partial specialization of function templates is not allowed.
   So these are witten for doubles, and when we get to integers and logicals we
-  can
-  use overlaoding or different names.
+  can use overlaoding or different names.
  */
 template <int ndim>
 void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, double> &ans);

--- a/packages/nimble/inst/include/nimble/RcppNimbleUtils.h
+++ b/packages/nimble/inst/include/nimble/RcppNimbleUtils.h
@@ -4,9 +4,6 @@
 #include "NimArr.h"
 #include "RcppUtils.h"
 
-//#include "RcppUtils.h"
-
-
 // all of this is in RcppUtils.h
 /* #include "R.h" */
 /* #include "Utils.h" */
@@ -31,19 +28,12 @@ double prod(double x);
 
 SEXP cGetMVElementOneRow(NimVecType* typePtr, nimType vecType, int index);
 void cSetMVElementSingle(NimVecType* typePtr, nimType vecType,  int index, SEXP Svalue);
- 
-//bool checkString(SEXP Ss, int len);
-//bool checkNumeric(SEXP Sval, int len);
 
 
 extern "C" {
   SEXP setDoublePtrFromSinglePtr(SEXP SdoublePtr, SEXP SsinglePtr);
   SEXP setSmartPtrFromSinglePtr(SEXP SdoublePtr, SEXP SsinglePtr);
   SEXP setSmartPtrFromDoublePtr(SEXP SdoublePtr, SEXP SsinglePtr);
-
-  //  SEXP setVec(SEXP Sextptr, SEXP Svalue);
-  //  SEXP getVec(SEXP Sextptr);
-  //  SEXP getVec_Integer(SEXP Sextptr);
   
   SEXP setVecNimArrRows(SEXP Sextptr, SEXP nRows, SEXP setSize2row1);
   SEXP addBlankModelValueRows(SEXP Sextptr, SEXP numAdded);
@@ -74,11 +64,6 @@ extern "C" {
   SEXP SEXP_2_Nim(SEXP rPtr, SEXP NumRefers, SEXP rValues, SEXP allowResize); //	Copies values from rValues to NimArr. Same behavior
 															  // 	with NumRefers as above. Also, type checking is done
 															  // 	by R.internals functions INTEGER and REAL
-															  
-  //  SEXP Nim_2_Nim(SEXP rPtrFrom, SEXP numRefFrom, SEXP rPtrTo, SEXP numRefTo);	
-												//  Copies from one NimArr to another. Type checks
-												//	For now, both NimArr's must be either double or int. We can add other
-												//  types or allow conversion by extending Nim_2_Nim and the cNim_2_Nim options 
 
   SEXP setPtrVectorOfPtrs(SEXP SaccessorPtr, SEXP ScontentsPtr, SEXP Ssize);
   SEXP setOnePtrVectorOfPtrs(SEXP SaccessorPtr, SEXP Si, SEXP ScontentsPtr);
@@ -149,7 +134,6 @@ void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, double> &ans) {
   NIM_ASSERT4(inputDims.size() == ndim,
     "Wrong number of input dimensions in SEXP_2_NimArr<%d, double> called for SEXP that is not a numeric: expected %d, actual %d\n",
     ndim, ndim, inputDims.size());
-  // NIM_ASSERT(ans.size() == 0, "trying to reset a NimArr that was already sized\n");
   ans.setSize(inputDims);
   int nn = LENGTH(Sn);
   if(isReal(Sn)) {
@@ -159,7 +143,7 @@ void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, double> &ans) {
       "could not handle input of type %s to SEXP_2_NimArr<%d, double>\n",
       type2str(TYPEOF(Sn)), ndim);
     int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
-    std::copy(iSn, iSn + nn, ans.getPtr()); //v);
+    std::copy(iSn, iSn + nn, ans.getPtr());
   }
 }
 
@@ -173,7 +157,6 @@ void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, int> &ans) {
   NIM_ASSERT4(inputDims.size() == ndim,
     "Wrong number of input dimensions in SEXP_2_NimArr<%d, int> called for SEXP that is not a numeric: expected %d, actual %d\n",
     ndim, ndim, inputDims.size());
-  // NIM_ASSERT(ans.size() == 0, "trying to reset a NimArr that was already sized\n");
   ans.setSize(inputDims);
   int nn = LENGTH(Sn);
   if(isReal(Sn)) {
@@ -183,7 +166,7 @@ void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, int> &ans) {
       "could not handle input type %s to SEXP_2_NimArr<%d, int>\n",
       type2str(TYPEOF(Sn)), ndim);
     int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
-    std::copy(iSn, iSn + nn, ans.getPtr()); //v);
+    std::copy(iSn, iSn + nn, ans.getPtr());
   }
 }
 
@@ -196,7 +179,6 @@ void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, bool> &ans) {
   NIM_ASSERT4(inputDims.size() == ndim,
     "Wrong number of input dimensions in SEXP_2_NimArr<%d, bool> called for SEXP that is not a numeric: expected %d, actual %d\n",
     ndim, ndim, inputDims.size());
-  // NIM_ASSERT(ans.size() == 0, "trying to reset a NimArr that was already sized\n");
   ans.setSize(inputDims);
   int nn = LENGTH(Sn);
   if(isReal(Sn)) {
@@ -206,7 +188,7 @@ void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, bool> &ans) {
       "could not handle input type %s to SEXP_2_NimArr<%d, bool>\n",
       type2str(TYPEOF(Sn)), ndim);
     int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
-    std::copy(iSn, iSn + nn, ans.getPtr()); //v);
+    std::copy(iSn, iSn + nn, ans.getPtr());
   }
 }
 
@@ -281,8 +263,6 @@ void cNimArr_2_NimArr(NimArrBase<T> &nimFrom, NimArrBase<T> &nimTo);
 template <class T1, class T2>
 void cNimArr_2_NimArr_Index(NimArrBase<T1> &nimFrom, int fromBegin, NimArrBase<T2> &nimTo, int toBegin, int length);
 
-//void trashNamedObjectsPtr(SEXP rPtr);
-//void trashElementPtr(SEXP rPtr);
 void sampleFinalizer(SEXP ptr);
 template<int nDim, class T>
 void VecNimArrFinalizer(SEXP ptr);
@@ -294,16 +274,6 @@ int length(vector<T> vec)
 	{
 	return(vec.size());
 	}
-	
-/* class orderedPair	//simple class which is used to be sorted by value, but remember what the original order was. used in rawSample */
-/* 	{ */
-/* 	public: */
-/* 	double value; */
-/* 	int rank; */
-/* 	}; */
-
-/* bool compareOrderedPair(orderedPair a, orderedPair b);	 //function called for sort  */
-
 
 void rankSample(NimArr<1, double>& weights, int& n, NimArr<1, int>& output);
 void rankSample(NimArr<1, double>& weights, int& n, NimArr<1, int>& output, bool& silent);

--- a/packages/nimble/inst/include/nimble/RcppNimbleUtils.h
+++ b/packages/nimble/inst/include/nimble/RcppNimbleUtils.h
@@ -1,7 +1,7 @@
 #ifndef __RCPPNIMBLEUTILS
 #define __RCPPNIMBLEUTILS
-#include "NimArrBase.h"
 #include "NimArr.h"
+#include "NimArrBase.h"
 #include "RcppUtils.h"
 
 // all of this is in RcppUtils.h
@@ -15,7 +15,8 @@
 /* #include <Rinternals.h> */
 
 /* #include <R_ext/Applic.h>	/\* this is required for optim *\/ */
-/* #include <stdarg.h> 		/\* this is required for variable number of arguments *\/ */
+/* #include <stdarg.h> 		/\* this is required for variable number of
+ * arguments *\/ */
 
 using namespace std;
 
@@ -26,174 +27,197 @@ double t(double x);
 int prod(int x);
 double prod(double x);
 
-SEXP cGetMVElementOneRow(NimVecType* typePtr, nimType vecType, int index);
-void cSetMVElementSingle(NimVecType* typePtr, nimType vecType,  int index, SEXP Svalue);
-
+SEXP cGetMVElementOneRow(NimVecType *typePtr, nimType vecType, int index);
+void cSetMVElementSingle(NimVecType *typePtr, nimType vecType, int index,
+                         SEXP Svalue);
 
 extern "C" {
-  SEXP setDoublePtrFromSinglePtr(SEXP SdoublePtr, SEXP SsinglePtr);
-  SEXP setSmartPtrFromSinglePtr(SEXP SdoublePtr, SEXP SsinglePtr);
-  SEXP setSmartPtrFromDoublePtr(SEXP SdoublePtr, SEXP SsinglePtr);
-  
-  SEXP setVecNimArrRows(SEXP Sextptr, SEXP nRows, SEXP setSize2row1);
-  SEXP addBlankModelValueRows(SEXP Sextptr, SEXP numAdded);
-  SEXP getNRow(SEXP Sextptr);
-  SEXP copyModelValuesElements(SEXP SextptrFrom, SEXP SextptrTo, SEXP rowsFrom, SEXP rowsTo);
-  SEXP getMVElement(SEXP Sextptr, SEXP Sindex);
-  SEXP getMVsize(SEXP Sextptr);
+SEXP setDoublePtrFromSinglePtr(SEXP SdoublePtr, SEXP SsinglePtr);
+SEXP setSmartPtrFromSinglePtr(SEXP SdoublePtr, SEXP SsinglePtr);
+SEXP setSmartPtrFromDoublePtr(SEXP SdoublePtr, SEXP SsinglePtr);
 
-  SEXP getMVElementAsList(SEXP SextPtr, SEXP Sindices);
-  SEXP setMVElementFromList(SEXP vNimPtr, SEXP rList, SEXP Sindices);
+SEXP setVecNimArrRows(SEXP Sextptr, SEXP nRows, SEXP setSize2row1);
+SEXP addBlankModelValueRows(SEXP Sextptr, SEXP numAdded);
+SEXP getNRow(SEXP Sextptr);
+SEXP copyModelValuesElements(SEXP SextptrFrom, SEXP SextptrTo, SEXP rowsFrom,
+                             SEXP rowsTo);
+SEXP getMVElement(SEXP Sextptr, SEXP Sindex);
+SEXP getMVsize(SEXP Sextptr);
 
-  SEXP matrix2VecNimArr(SEXP RvecNimPtr, SEXP matrix, SEXP rowStart, SEXP rowEnd);
+SEXP getMVElementAsList(SEXP SextPtr, SEXP Sindices);
+SEXP setMVElementFromList(SEXP vNimPtr, SEXP rList, SEXP Sindices);
 
-  SEXP setMVElement(SEXP Sextptr, SEXP Sindex, SEXP Svalue);
+SEXP matrix2VecNimArr(SEXP RvecNimPtr, SEXP matrix, SEXP rowStart, SEXP rowEnd);
 
-  SEXP newSampObject();	//  Creates our new object from sampleClass (will be generated automatically later)
-							//	Just for use in demos
-							// 	To get a pointer to an element from sampleClass, use
-							//	getModelObjectPtr (from the NamedObjects.cpp file)
-					
-  SEXP Nim_2_SEXP(SEXP rPtr, SEXP NumRefers);	//	Returns SEXP object with correct data type and dimensions. NumRefers
-												//  should be an integer with the number of dereferencing required for rPtr
-												//	So if rPtr is a pointer to a NimArr, NumRefers = 1
-												//	If rPtr is a pointer to a pointer to a NimArr, NumRefers = 2
-												//	Currently only NumRefers = 1 and 2 are allowed, but easily updated
-												//	by extending "getNimTypePtr" function
-	
-  SEXP SEXP_2_Nim(SEXP rPtr, SEXP NumRefers, SEXP rValues, SEXP allowResize); //	Copies values from rValues to NimArr. Same behavior
-															  // 	with NumRefers as above. Also, type checking is done
-															  // 	by R.internals functions INTEGER and REAL
+SEXP setMVElement(SEXP Sextptr, SEXP Sindex, SEXP Svalue);
 
-  SEXP setPtrVectorOfPtrs(SEXP SaccessorPtr, SEXP ScontentsPtr, SEXP Ssize);
-  SEXP setOnePtrVectorOfPtrs(SEXP SaccessorPtr, SEXP Si, SEXP ScontentsPtr);
-  
-  SEXP getEnvVar_Sindex(SEXP sString, SEXP sEnv, SEXP sIndex);// This is a utility for looking up a field of an environment
-  														 // sString is a character vector with the field name we want
-  														 // sEnv is the environment
-  														 // sIndex is the index of the sString that contains the name
-  														 // we actually want to use. 
-  														 //	Look up by sString[sIndex] is done to allow for easy looping
-  														 //Important Note: sIndex = 1 looks up the first name (i.e. use R indexing, not C) 
-  SEXP getEnvVar(SEXP sString, SEXP sEnv);	// Same as above, but uses sIndex = 1 (i.e. sString is a single character string)
-  														 
-  SEXP setEnvVar_Sindex(SEXP sString, SEXP sEnv, SEXP sVal, SEXP sIndex);	//Same as getEnvVar_Sindex, but this function sets rather than gets														
-  SEXP setEnvVar(SEXP sString, SEXP sEnv, SEXP sVal);						//Same as above but uses sIndex = 1
+SEXP newSampObject();  //  Creates our new object from sampleClass (will be
+                       //  generated automatically later)
+                       //	Just for use in demos
+                       // 	To get a pointer to an element from sampleClass, use
+                       //	getModelObjectPtr (from the NamedObjects.cpp file)
 
-  SEXP register_VecNimArr_Finalizer(SEXP Sp, SEXP Dll);
+SEXP Nim_2_SEXP(SEXP rPtr, SEXP NumRefers);  //	Returns SEXP object with correct
+                                             //data type and dimensions.
+                                             //NumRefers
+//  should be an integer with the number of dereferencing required for rPtr
+//	So if rPtr is a pointer to a NimArr, NumRefers = 1
+//	If rPtr is a pointer to a pointer to a NimArr, NumRefers = 2
+//	Currently only NumRefers = 1 and 2 are allowed, but easily updated
+//	by extending "getNimTypePtr" function
+
+SEXP SEXP_2_Nim(SEXP rPtr, SEXP NumRefers, SEXP rValues,
+                SEXP allowResize);  //	Copies values from rValues to NimArr.
+                                    //Same behavior
+// 	with NumRefers as above. Also, type checking is done
+// 	by R.internals functions INTEGER and REAL
+
+SEXP setPtrVectorOfPtrs(SEXP SaccessorPtr, SEXP ScontentsPtr, SEXP Ssize);
+SEXP setOnePtrVectorOfPtrs(SEXP SaccessorPtr, SEXP Si, SEXP ScontentsPtr);
+
+SEXP getEnvVar_Sindex(
+    SEXP sString, SEXP sEnv,
+    SEXP sIndex);  // This is a utility for looking up a field of an environment
+                   // sString is a character vector with the field name we want
+                   // sEnv is the environment
+                   // sIndex is the index of the sString that contains the name
+                   // we actually want to use.
+//	Look up by sString[sIndex] is done to allow for easy looping
+// Important Note: sIndex = 1 looks up the first name (i.e. use R indexing, not
+// C)
+SEXP getEnvVar(SEXP sString, SEXP sEnv);  // Same as above, but uses sIndex = 1
+                                          // (i.e. sString is a single character
+                                          // string)
+
+SEXP setEnvVar_Sindex(SEXP sString, SEXP sEnv, SEXP sVal,
+                      SEXP sIndex);  // Same as getEnvVar_Sindex, but this
+                                     // function sets rather than gets
+SEXP setEnvVar(SEXP sString, SEXP sEnv,
+               SEXP sVal);  // Same as above but uses sIndex = 1
+
+SEXP register_VecNimArr_Finalizer(SEXP Sp, SEXP Dll);
 }
 
 void VecNimArr_Finalizer(SEXP Sp);
 
 class vectorOfPtrsAccessBase {
  public:
-  virtual void setTheVec(void *tV, int size)=0;
-  virtual void setVecPtr(int i, void *v)=0;
-  virtual void *getVecPtr(int i)=0;
+  virtual void setTheVec(void *tV, int size) = 0;
+  virtual void setVecPtr(int i, void *v) = 0;
+  virtual void *getVecPtr(int i) = 0;
 };
 
-template<class T>
+template <class T>
 class vectorOfPtrsAccess : public vectorOfPtrsAccessBase {
  public:
-  vector<T*> *theVec;
-  void setTheVec(void* v, int size) {theVec = static_cast<vector<T*>*>(v); theVec->resize(size);}
-  void setVecPtr(int i, void *v) {
-    (*theVec)[i] = static_cast<T*>(v);
+  vector<T *> *theVec;
+  void setTheVec(void *v, int size) {
+    theVec = static_cast<vector<T *> *>(v);
+    theVec->resize(size);
   }
-  void *getVecPtr(int i) {return(static_cast<void *>( (*theVec)[i] ) ); }
+  void setVecPtr(int i, void *v) { (*theVec)[i] = static_cast<T *>(v); }
+  void *getVecPtr(int i) { return (static_cast<void *>((*theVec)[i])); }
 };
 
 NimArr<1, double> vectorDouble_2_NimArr(vector<double> input);
 
 /*
   Apparently partial specialization of function templates is not allowed.
-  So these are witten for doubles, and when we get to integers and logicals we can 
+  So these are witten for doubles, and when we get to integers and logicals we
+  can
   use overlaoding or different names.
  */
-template<int ndim>
-void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, double> &ans );
-template<int ndim>
-void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, int> &ans );
+template <int ndim>
+void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, double> &ans);
+template <int ndim>
+void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, int> &ans);
 
-template<int ndim>
+template <int ndim>
 SEXP NimArr_2_SEXP(const NimArr<ndim, double> &val);
-template<int ndim>
+template <int ndim>
 SEXP NimArr_2_SEXP(const NimArr<ndim, int> &val);
 
-template<>
-void SEXP_2_NimArr<1>(SEXP Sn, NimArr<1, double> &ans); 
-template<>
-void SEXP_2_NimArr<1>(SEXP Sn, NimArr<1, int> &ans); 
+template <>
+void SEXP_2_NimArr<1>(SEXP Sn, NimArr<1, double> &ans);
+template <>
+void SEXP_2_NimArr<1>(SEXP Sn, NimArr<1, int> &ans);
 
-template<int ndim>
+template <int ndim>
 void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, double> &ans) {
   NIM_ASSERT3(isNumeric(Sn) || isLogical(Sn),
-    "SEXP_2_NimArr<%d, double> called for SEXP that is not a numeric or logical: actual type %s\n",
-    ndim, type2str(TYPEOF(Sn)));
+              "SEXP_2_NimArr<%d, double> called for SEXP that is not a numeric "
+              "or logical: actual type %s\n",
+              ndim, type2str(TYPEOF(Sn)));
   vector<int> inputDims(getSEXPdims(Sn));
   NIM_ASSERT4(inputDims.size() == ndim,
-    "Wrong number of input dimensions in SEXP_2_NimArr<%d, double> called for SEXP that is not a numeric: expected %d, actual %d\n",
-    ndim, ndim, inputDims.size());
+              "Wrong number of input dimensions in SEXP_2_NimArr<%d, double> "
+              "called for SEXP that is not a numeric: expected %d, actual %d\n",
+              ndim, ndim, inputDims.size());
   ans.setSize(inputDims);
   int nn = LENGTH(Sn);
-  if(isReal(Sn)) {
-    std::copy(REAL(Sn), REAL(Sn) + nn, ans.getPtr() );
+  if (isReal(Sn)) {
+    std::copy(REAL(Sn), REAL(Sn) + nn, ans.getPtr());
   } else {
-    NIM_ASSERT3(isInteger(Sn) || isLogical(Sn),
-      "could not handle input of type %s to SEXP_2_NimArr<%d, double>\n",
-      type2str(TYPEOF(Sn)), ndim);
+    NIM_ASSERT3(
+        isInteger(Sn) || isLogical(Sn),
+        "could not handle input of type %s to SEXP_2_NimArr<%d, double>\n",
+        type2str(TYPEOF(Sn)), ndim);
     int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
     std::copy(iSn, iSn + nn, ans.getPtr());
   }
 }
 
-// ACTUALLY THIS IS IDENTICAL CODE TO ABOVE, SO THEY COULD BE COMBINED WITHOUT TEMPLATE SPECIALIZATION
-template<int ndim>
+// ACTUALLY THIS IS IDENTICAL CODE TO ABOVE, SO THEY COULD BE COMBINED WITHOUT
+// TEMPLATE SPECIALIZATION
+template <int ndim>
 void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, int> &ans) {
   NIM_ASSERT3(isNumeric(Sn) || isLogical(Sn),
-    "SEXP_2_NimArr<%d, int> called for SEXP that is not a numeric or logical: actual type %s\n",
-    ndim, type2str(TYPEOF(Sn)));
+              "SEXP_2_NimArr<%d, int> called for SEXP that is not a numeric or "
+              "logical: actual type %s\n",
+              ndim, type2str(TYPEOF(Sn)));
   vector<int> inputDims(getSEXPdims(Sn));
   NIM_ASSERT4(inputDims.size() == ndim,
-    "Wrong number of input dimensions in SEXP_2_NimArr<%d, int> called for SEXP that is not a numeric: expected %d, actual %d\n",
-    ndim, ndim, inputDims.size());
+              "Wrong number of input dimensions in SEXP_2_NimArr<%d, int> "
+              "called for SEXP that is not a numeric: expected %d, actual %d\n",
+              ndim, ndim, inputDims.size());
   ans.setSize(inputDims);
   int nn = LENGTH(Sn);
-  if(isReal(Sn)) {
-    std::copy(REAL(Sn), REAL(Sn) + nn, ans.getPtr() );
+  if (isReal(Sn)) {
+    std::copy(REAL(Sn), REAL(Sn) + nn, ans.getPtr());
   } else {
     NIM_ASSERT3(isInteger(Sn) || isLogical(Sn),
-      "could not handle input type %s to SEXP_2_NimArr<%d, int>\n",
-      type2str(TYPEOF(Sn)), ndim);
+                "could not handle input type %s to SEXP_2_NimArr<%d, int>\n",
+                type2str(TYPEOF(Sn)), ndim);
     int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
     std::copy(iSn, iSn + nn, ans.getPtr());
   }
 }
 
-template<int ndim>
+template <int ndim>
 void SEXP_2_NimArr(SEXP Sn, NimArr<ndim, bool> &ans) {
   NIM_ASSERT3(isNumeric(Sn) || isLogical(Sn),
-    "SEXP_2_NimArr<%d, bool> called for SEXP that is not a numeric or logical: actual type %s\n",
-    ndim, type2str(TYPEOF(Sn)));
+              "SEXP_2_NimArr<%d, bool> called for SEXP that is not a numeric "
+              "or logical: actual type %s\n",
+              ndim, type2str(TYPEOF(Sn)));
   vector<int> inputDims(getSEXPdims(Sn));
   NIM_ASSERT4(inputDims.size() == ndim,
-    "Wrong number of input dimensions in SEXP_2_NimArr<%d, bool> called for SEXP that is not a numeric: expected %d, actual %d\n",
-    ndim, ndim, inputDims.size());
+              "Wrong number of input dimensions in SEXP_2_NimArr<%d, bool> "
+              "called for SEXP that is not a numeric: expected %d, actual %d\n",
+              ndim, ndim, inputDims.size());
   ans.setSize(inputDims);
   int nn = LENGTH(Sn);
-  if(isReal(Sn)) {
-    std::copy(REAL(Sn), REAL(Sn) + nn, ans.getPtr() );
+  if (isReal(Sn)) {
+    std::copy(REAL(Sn), REAL(Sn) + nn, ans.getPtr());
   } else {
     NIM_ASSERT3(isInteger(Sn) || isLogical(Sn),
-      "could not handle input type %s to SEXP_2_NimArr<%d, bool>\n",
-      type2str(TYPEOF(Sn)), ndim);
+                "could not handle input type %s to SEXP_2_NimArr<%d, bool>\n",
+                type2str(TYPEOF(Sn)), ndim);
     int *iSn = isInteger(Sn) ? INTEGER(Sn) : LOGICAL(Sn);
     std::copy(iSn, iSn + nn, ans.getPtr());
   }
 }
 
-
-template<int ndim>
+template <int ndim>
 SEXP NimArr_2_SEXP(NimArr<ndim, double> &val) {
   SEXP Sans;
   int outputLength = val.size();
@@ -201,19 +225,20 @@ SEXP NimArr_2_SEXP(NimArr<ndim, double> &val) {
   double *ans = REAL(Sans);
 
   std::copy(val.getPtr(), val.getPtr() + outputLength, ans);
-  if(val.numDims() > 1) {
+  if (val.numDims() > 1) {
     SEXP Sdim;
-    PROTECT(Sdim = allocVector(INTSXP, val.numDims() ) );
-    for(int idim = 0; idim < val.numDims(); ++idim) INTEGER(Sdim)[idim] = val.dimSize(idim);
+    PROTECT(Sdim = allocVector(INTSXP, val.numDims()));
+    for (int idim = 0; idim < val.numDims(); ++idim)
+      INTEGER(Sdim)[idim] = val.dimSize(idim);
     setAttrib(Sans, R_DimSymbol, Sdim);
     UNPROTECT(2);
   } else {
     UNPROTECT(1);
   }
-  return(Sans);
+  return (Sans);
 }
 
-template<int ndim>
+template <int ndim>
 SEXP NimArr_2_SEXP(NimArr<ndim, int> &val) {
   SEXP Sans;
   int outputLength = val.size();
@@ -221,19 +246,20 @@ SEXP NimArr_2_SEXP(NimArr<ndim, int> &val) {
   int *ans = INTEGER(Sans);
 
   std::copy(val.getPtr(), val.getPtr() + outputLength, ans);
-  if(val.numDims() > 1) {
+  if (val.numDims() > 1) {
     SEXP Sdim;
-    PROTECT(Sdim = allocVector(INTSXP, val.numDims() ) );
-    for(int idim = 0; idim < val.numDims(); ++idim) INTEGER(Sdim)[idim] = val.dimSize(idim);
+    PROTECT(Sdim = allocVector(INTSXP, val.numDims()));
+    for (int idim = 0; idim < val.numDims(); ++idim)
+      INTEGER(Sdim)[idim] = val.dimSize(idim);
     setAttrib(Sans, R_DimSymbol, Sdim);
     UNPROTECT(2);
   } else {
     UNPROTECT(1);
   }
-  return(Sans);
+  return (Sans);
 }
 
-template<int ndim>
+template <int ndim>
 SEXP NimArr_2_SEXP(NimArr<ndim, bool> &val) {
   SEXP Sans;
   int outputLength = val.size();
@@ -241,41 +267,44 @@ SEXP NimArr_2_SEXP(NimArr<ndim, bool> &val) {
   int *ans = LOGICAL(Sans);
 
   std::copy(val.getPtr(), val.getPtr() + outputLength, ans);
-  if(val.numDims() > 1) {
+  if (val.numDims() > 1) {
     SEXP Sdim;
-    PROTECT(Sdim = allocVector(LGLSXP, val.numDims() ) );
-    for(int idim = 0; idim < val.numDims(); ++idim) LOGICAL(Sdim)[idim] = val.dimSize(idim);
+    PROTECT(Sdim = allocVector(LGLSXP, val.numDims()));
+    for (int idim = 0; idim < val.numDims(); ++idim)
+      LOGICAL(Sdim)[idim] = val.dimSize(idim);
     setAttrib(Sans, R_DimSymbol, Sdim);
     UNPROTECT(2);
   } else {
     UNPROTECT(1);
   }
-  return(Sans);
+  return (Sans);
 }
 
-
- void row2NimArr(SEXP &matrix, NimArrBase<double> &nimPtr, int startPoint, int len, int nRows);
-void row2NimArr(SEXP &matrix, NimArrBase<int> &nimPtr, int startPoint, int len, int nRows);
+void row2NimArr(SEXP &matrix, NimArrBase<double> &nimPtr, int startPoint,
+                int len, int nRows);
+void row2NimArr(SEXP &matrix, NimArrBase<int> &nimPtr, int startPoint, int len,
+                int nRows);
 
 template <class T>
 void cNimArr_2_NimArr(NimArrBase<T> &nimFrom, NimArrBase<T> &nimTo);
 
 template <class T1, class T2>
-void cNimArr_2_NimArr_Index(NimArrBase<T1> &nimFrom, int fromBegin, NimArrBase<T2> &nimTo, int toBegin, int length);
+void cNimArr_2_NimArr_Index(NimArrBase<T1> &nimFrom, int fromBegin,
+                            NimArrBase<T2> &nimTo, int toBegin, int length);
 
 void sampleFinalizer(SEXP ptr);
-template<int nDim, class T>
+template <int nDim, class T>
 void VecNimArrFinalizer(SEXP ptr);
 
 double nimMod(double a, double b);
 
-template<class T>
-int length(vector<T> vec)
-	{
-	return(vec.size());
-	}
+template <class T>
+int length(vector<T> vec) {
+  return (vec.size());
+}
 
-void rankSample(NimArr<1, double>& weights, int& n, NimArr<1, int>& output);
-void rankSample(NimArr<1, double>& weights, int& n, NimArr<1, int>& output, bool& silent);
+void rankSample(NimArr<1, double> &weights, int &n, NimArr<1, int> &output);
+void rankSample(NimArr<1, double> &weights, int &n, NimArr<1, int> &output,
+                bool &silent);
 
 #endif

--- a/packages/nimble/inst/include/nimble/RcppUtils.h
+++ b/packages/nimble/inst/include/nimble/RcppUtils.h
@@ -31,20 +31,20 @@ SEXP string_2_STRSEXP(string v);
 void STRSEXP_2_vectorString(SEXP Ss, vector<string> &ans);
 SEXP vectorString_2_STRSEXP(const vector<string> &v);
 
-vector<double> SEXP_2_vectorDouble(
-    SEXP Sn); /* Sn can be numeric or integer from R*/
+/* Sn can be numeric or integer from R*/
+vector<double> SEXP_2_vectorDouble(SEXP Sn);
 double SEXP_2_double(SEXP Sn, int i = 0); /* Ditto */
 SEXP double_2_SEXP(double v);
 SEXP vectorDouble_2_SEXP(const vector<double> &v);
 SEXP vectorInt_2_SEXP(const vector<int> &v);
 SEXP vectorInt_2_SEXP(const vector<int> &v, int offset);
 
-vector<int> SEXP_2_vectorInt(
-    SEXP Sn, int offset = 0); /* Sn can be numeric or integer from R */
-/* Offset is added to every value, so if the vectors are indices, offset = -1 is
- * useful */
-/* If Sn is numeric but not integer, a warning is issued if it contains
- * non-integers */
+// Sn can be numeric or integer from R.
+// Offset is added to every value, so if the vectors are indices,
+// offset = -1 is useful.
+// If Sn is numeric but not integer, a warning is issued if it contains
+// non-integers.
+vector<int> SEXP_2_vectorInt(SEXP Sn, int offset = 0);
 int SEXP_2_int(SEXP Sn, int i = 0, int offset = 0);
 SEXP int_2_SEXP(int i);
 bool SEXP_2_bool(SEXP Sn, int i = 0);

--- a/packages/nimble/inst/include/nimble/RcppUtils.h
+++ b/packages/nimble/inst/include/nimble/RcppUtils.h
@@ -75,8 +75,6 @@ void rawSample(double* p, int c_samps, int N, int* ans, bool unsort, bool silent
 
 SEXP makeNewNimbleList(SEXP S_listName);
 
-//void dontDeleteFinalizer(SEXP ptr);
-
 #endif
 
 

--- a/packages/nimble/inst/include/nimble/RcppUtils.h
+++ b/packages/nimble/inst/include/nimble/RcppUtils.h
@@ -1,20 +1,18 @@
 #ifndef __RCPPUTILS
 #define __RCPPUTILS
 
-
+#include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
-#include<iostream>
-#include<sstream>
 #include "R.h"
-#include "Utils.h"
 #include "Rdefines.h"
-
+#include "Utils.h"
 
 #include <Rinternals.h>
 
-#include <R_ext/Applic.h>	/* this is required for optim */
-#include <stdarg.h> 		/* this is required for variable number of arguments */
+#include <R_ext/Applic.h> /* this is required for optim */
+#include <stdarg.h> /* this is required for variable number of arguments */
 
 extern std::ostringstream _nimble_global_output;
 
@@ -24,57 +22,62 @@ using namespace std;
 
 void nimble_print_to_R(std::ostringstream &input);
 
-
 void multivarTestCall(double *x, int n);
 
 vector<int> getSEXPdims(SEXP Sx);
 
 string STRSEXP_2_string(SEXP Ss, int i = 0);
-SEXP   string_2_STRSEXP(string v);
-void   STRSEXP_2_vectorString(SEXP Ss, vector<string> &ans);
-SEXP   vectorString_2_STRSEXP(const vector<string> &v);
+SEXP string_2_STRSEXP(string v);
+void STRSEXP_2_vectorString(SEXP Ss, vector<string> &ans);
+SEXP vectorString_2_STRSEXP(const vector<string> &v);
 
-vector<double> SEXP_2_vectorDouble( SEXP Sn ); /* Sn can be numeric or integer from R*/
+vector<double> SEXP_2_vectorDouble(
+    SEXP Sn); /* Sn can be numeric or integer from R*/
 double SEXP_2_double(SEXP Sn, int i = 0); /* Ditto */
 SEXP double_2_SEXP(double v);
 SEXP vectorDouble_2_SEXP(const vector<double> &v);
 SEXP vectorInt_2_SEXP(const vector<int> &v);
 SEXP vectorInt_2_SEXP(const vector<int> &v, int offset);
 
-vector<int> SEXP_2_vectorInt(SEXP Sn, int offset = 0); /* Sn can be numeric or integer from R */ 
-/* Offset is added to every value, so if the vectors are indices, offset = -1 is useful */
-/* If Sn is numeric but not integer, a warning is issued if it contains non-integers */
+vector<int> SEXP_2_vectorInt(
+    SEXP Sn, int offset = 0); /* Sn can be numeric or integer from R */
+/* Offset is added to every value, so if the vectors are indices, offset = -1 is
+ * useful */
+/* If Sn is numeric but not integer, a warning is issued if it contains
+ * non-integers */
 int SEXP_2_int(SEXP Sn, int i = 0, int offset = 0);
 SEXP int_2_SEXP(int i);
 bool SEXP_2_bool(SEXP Sn, int i = 0);
 SEXP bool_2_SEXP(bool ind);
 
 extern "C" {
-  SEXP populate_SEXP_2_double(SEXP rPtr, SEXP refNum, SEXP rScalar);
-  SEXP extract_double_2_SEXP(SEXP rPtr, SEXP refNum);
-  SEXP populate_SEXP_2_bool(SEXP rPtr, SEXP refNum, SEXP rScalar);
-  SEXP extract_bool_2_SEXP(SEXP rPtr, SEXP refNum);
-  SEXP populate_SEXP_2_int(SEXP rPtr, SEXP refNum, SEXP rScalar);
-  SEXP extract_int_2_SEXP(SEXP rPtr, SEXP refNum);
+SEXP populate_SEXP_2_double(SEXP rPtr, SEXP refNum, SEXP rScalar);
+SEXP extract_double_2_SEXP(SEXP rPtr, SEXP refNum);
+SEXP populate_SEXP_2_bool(SEXP rPtr, SEXP refNum, SEXP rScalar);
+SEXP extract_bool_2_SEXP(SEXP rPtr, SEXP refNum);
+SEXP populate_SEXP_2_int(SEXP rPtr, SEXP refNum, SEXP rScalar);
+SEXP extract_int_2_SEXP(SEXP rPtr, SEXP refNum);
 
-  SEXP populate_SEXP_2_string(SEXP rPtr, SEXP rString);
-  SEXP populate_SEXP_2_stringVector(SEXP rPtr, SEXP rStringVector);
-  SEXP extract_string_2_SEXP(SEXP rPtr);
-  SEXP extract_stringVector_2_SEXP(SEXP rPtr);
+SEXP populate_SEXP_2_string(SEXP rPtr, SEXP rString);
+SEXP populate_SEXP_2_stringVector(SEXP rPtr, SEXP rStringVector);
+SEXP extract_string_2_SEXP(SEXP rPtr);
+SEXP extract_stringVector_2_SEXP(SEXP rPtr);
 
-  SEXP fastMatrixInsert(SEXP matrixInto, SEXP matrix, SEXP rowStart, SEXP colStart);
-  SEXP matrix2ListDouble(SEXP matrix, SEXP list, SEXP listStartIndex, SEXP RnRows,  SEXP dims);
-  SEXP matrix2ListInt(SEXP matrix, SEXP list, SEXP listStartIndex, SEXP RnRows,  SEXP dims);
+SEXP fastMatrixInsert(SEXP matrixInto, SEXP matrix, SEXP rowStart,
+                      SEXP colStart);
+SEXP matrix2ListDouble(SEXP matrix, SEXP list, SEXP listStartIndex, SEXP RnRows,
+                       SEXP dims);
+SEXP matrix2ListInt(SEXP matrix, SEXP list, SEXP listStartIndex, SEXP RnRows,
+                    SEXP dims);
 
-  SEXP C_rankSample(SEXP p, SEXP n, SEXP not_used, SEXP s);
+SEXP C_rankSample(SEXP p, SEXP n, SEXP not_used, SEXP s);
 
-  SEXP parseVar(SEXP Sinput);
+SEXP parseVar(SEXP Sinput);
 }
 
-void rawSample(double* p, int c_samps, int N, int* ans, bool unsort, bool silent);
+void rawSample(double *p, int c_samps, int N, int *ans, bool unsort,
+               bool silent);
 
 SEXP makeNewNimbleList(SEXP S_listName);
 
 #endif
-
-

--- a/packages/nimble/inst/include/nimble/Utils.h
+++ b/packages/nimble/inst/include/nimble/Utils.h
@@ -1,7 +1,6 @@
 #ifndef __UTILS
 #define __UTILS
 
-//#include <vector>
 #include "R.h"
 #include<Rinternals.h>
 #include<Rmath.h>
@@ -9,8 +8,6 @@
 #include<string>
 #include<time.h>
 using std::string;
-
-//using namespace std;
 
 // A utility function that will return floor(x) unless x is within numerical imprecision of an integer, in which case it will return round(x)
 int floorOrEquivalent(double x);
@@ -37,7 +34,7 @@ class nimbleTimerClass_ {
 #define PRINTF Rprintf
 #define NIMERROR error
 #define RBREAK(msg) {PRINTF(msg); return(R_NilValue);}
-/* #define NIM_ASSERT(cond, ...) { if(NIM_UNLIKELY(!(cond))) { NIMERROR("Error: " __VA_ARGS__); }} */ /* future */
+
 #define NIM_ASSERT1(cond, msg) { if(NIM_UNLIKELY(!(cond))) { NIMERROR("Error: ", msg); }}
 #define NIM_ASSERT2(cond, msg, msgArg1) { if(NIM_UNLIKELY(!(cond))) { NIMERROR("Error: ", msg, msgArg1); }}
 #define NIM_ASSERT3(cond, msg, msgArg1, msgArg2) { if(NIM_UNLIKELY(!(cond))) { NIMERROR("Error: ", msg, msgArg1, msgArg2); }}
@@ -48,7 +45,7 @@ class nimbleTimerClass_ {
                 #my_array " has wrong size: expected %d, actual %d", n, \
                 my_array.dimSize(0));
 
-// code copied from nmath.h - useful utilities 
+// Code copied from nmath.h - useful utilities.
 # define MATHLIB_ERROR(fmt,x)		error(fmt,x);
 # define MATHLIB_WARNING(fmt,x)		warning(fmt,x)
 # define MATHLIB_WARNING2(fmt,x,x2)	warning(fmt,x,x2)
@@ -103,7 +100,7 @@ class nimbleTimerClass_ {
 }
 
 
-// code copied from dpq.h - useful utilities for return values of dist functions
+// Code copied from dpq.h - useful utilities for return values of dist functions.
                                                         /* "DEFAULT" */
                                                         /* --------- */
 #define R_D__0  (log_p ? ML_NEGINF : 0.)                /* 0 */
@@ -126,12 +123,8 @@ class nimbleTimerClass_ {
    }
 
 #define EIGEN_CHOL(x)       (x).selfadjointView<Eigen::Upper>().llt().matrixU()
-//#define EIGEN_SOLVE(x,y)    (x).lu().solve(y)
-//#define EIGEN_FS(x,y)       (x).triangularView<Eigen::Lower>().solve(y)
-//#define EIGEN_BS(x,y)       (x).triangularView<Eigen::Upper>().solve(y)
 
 bool decide(double lMHr);
-//void allocate(vector< vector <double> > *vv, int sampleSize, int variableSize);
 
 void nimStop(string msg);
 void nimStop();
@@ -143,19 +136,16 @@ double ilogit(double x);
 double icloglog(double x);
 double iprobit(double x);
 double probit(double x);
-//double abs(double x);
 double cloglog(double x);
 int nimEquals(double x1, double x2);
 double nimbleIfElse(bool condition, double x1, double x2);
 double lfactorial(double x);
 double factorial(double x);
-//double loggam(double x);
 double logit(double x);
 double nimRound(double x);
 double pairmax(double x1, double x2);
 double pairmin(double x1, double x2);
-//double phi(double x);
-int nimStep(double x); 
+int nimStep(double x);
 double cube(double x);
 double inprod(double v1, double v2);
 

--- a/packages/nimble/inst/include/nimble/Utils.h
+++ b/packages/nimble/inst/include/nimble/Utils.h
@@ -1,15 +1,16 @@
 #ifndef __UTILS
 #define __UTILS
 
+#include <Rinternals.h>
+#include <Rmath.h>
+#include <time.h>
+#include <limits>
+#include <string>
 #include "R.h"
-#include<Rinternals.h>
-#include<Rmath.h>
-#include<limits>
-#include<string>
-#include<time.h>
 using std::string;
 
-// A utility function that will return floor(x) unless x is within numerical imprecision of an integer, in which case it will return round(x)
+// A utility function that will return floor(x) unless x is within numerical
+// imprecision of an integer, in which case it will return round(x)
 int floorOrEquivalent(double x);
 
 int rFunLength(int Arg);
@@ -19,110 +20,141 @@ int rFunLength(bool Arg);
 class nimbleTimerClass_ {
  public:
   clock_t t_start;
-  void startNimbleTimer() {t_start = clock();}
-  double endNimbleTimer() { return(((double)(clock() - t_start))/CLOCKS_PER_SEC); }
+  void startNimbleTimer() { t_start = clock(); }
+  double endNimbleTimer() {
+    return (((double)(clock() - t_start)) / CLOCKS_PER_SEC);
+  }
 };
 
 #if defined(__GNUG__) || defined(__clang__)
-#  define NIM_LIKELY(x) __builtin_expect(!!(x), 1)
-#  define NIM_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#define NIM_LIKELY(x) __builtin_expect(!!(x), 1)
+#define NIM_UNLIKELY(x) __builtin_expect(!!(x), 0)
 #else
-#  define NIM_LIKELY(x) (x)
-#  define NIM_UNLIKELY(x) (x)
+#define NIM_LIKELY(x) (x)
+#define NIM_UNLIKELY(x) (x)
 #endif
 
 #define PRINTF Rprintf
 #define NIMERROR error
-#define RBREAK(msg) {PRINTF(msg); return(R_NilValue);}
+#define RBREAK(msg)      \
+  {                      \
+    PRINTF(msg);         \
+    return (R_NilValue); \
+  }
 
-#define NIM_ASSERT1(cond, msg) { if(NIM_UNLIKELY(!(cond))) { NIMERROR("Error: ", msg); }}
-#define NIM_ASSERT2(cond, msg, msgArg1) { if(NIM_UNLIKELY(!(cond))) { NIMERROR("Error: ", msg, msgArg1); }}
-#define NIM_ASSERT3(cond, msg, msgArg1, msgArg2) { if(NIM_UNLIKELY(!(cond))) { NIMERROR("Error: ", msg, msgArg1, msgArg2); }}
-#define NIM_ASSERT4(cond, msg, msgArg1, msgArg2, msgArg3) { if(NIM_UNLIKELY(!(cond))) { NIMERROR("Error: ", msg, msgArg1, msgArg2, msgArg3); }}
+#define NIM_ASSERT1(cond, msg)   \
+  {                              \
+    if (NIM_UNLIKELY(!(cond))) { \
+      NIMERROR("Error: ", msg);  \
+    }                            \
+  }
+#define NIM_ASSERT2(cond, msg, msgArg1)  \
+  {                                      \
+    if (NIM_UNLIKELY(!(cond))) {         \
+      NIMERROR("Error: ", msg, msgArg1); \
+    }                                    \
+  }
+#define NIM_ASSERT3(cond, msg, msgArg1, msgArg2)  \
+  {                                               \
+    if (NIM_UNLIKELY(!(cond))) {                  \
+      NIMERROR("Error: ", msg, msgArg1, msgArg2); \
+    }                                             \
+  }
+#define NIM_ASSERT4(cond, msg, msgArg1, msgArg2, msgArg3)  \
+  {                                                        \
+    if (NIM_UNLIKELY(!(cond))) {                           \
+      NIMERROR("Error: ", msg, msgArg1, msgArg2, msgArg3); \
+    }                                                      \
+  }
 
-#define NIM_ASSERT_SIZE(my_array, n)                                    \
-    NIM_ASSERT3(my_array.dimSize(0) == n,                               \
-                #my_array " has wrong size: expected %d, actual %d", n, \
-                my_array.dimSize(0));
+#define NIM_ASSERT_SIZE(my_array, n)                                  \
+  NIM_ASSERT3(my_array.dimSize(0) == n,                               \
+              #my_array " has wrong size: expected %d, actual %d", n, \
+              my_array.dimSize(0));
 
 // Code copied from nmath.h - useful utilities.
-# define MATHLIB_ERROR(fmt,x)		error(fmt,x);
-# define MATHLIB_WARNING(fmt,x)		warning(fmt,x)
-# define MATHLIB_WARNING2(fmt,x,x2)	warning(fmt,x,x2)
-# define MATHLIB_WARNING3(fmt,x,x2,x3)	warning(fmt,x,x2,x3)
-# define MATHLIB_WARNING4(fmt,x,x2,x3,x4) warning(fmt,x,x2,x3,x4)
+#define MATHLIB_ERROR(fmt, x) error(fmt, x);
+#define MATHLIB_WARNING(fmt, x) warning(fmt, x)
+#define MATHLIB_WARNING2(fmt, x, x2) warning(fmt, x, x2)
+#define MATHLIB_WARNING3(fmt, x, x2, x3) warning(fmt, x, x2, x3)
+#define MATHLIB_WARNING4(fmt, x, x2, x3, x4) warning(fmt, x, x2, x3, x4)
 
-#define ML_POSINF	R_PosInf
-#define ML_NEGINF	R_NegInf
-#define ML_NAN		R_NaN
+#define ML_POSINF R_PosInf
+#define ML_NEGINF R_NegInf
+#define ML_NAN R_NaN
 
 #define _(String) String
 
-#define ML_VALID(x)	(!ISNAN(x))
+#define ML_VALID(x) (!ISNAN(x))
 
-#define ME_NONE		0
+#define ME_NONE 0
 /*	no error */
-#define ME_DOMAIN	1
+#define ME_DOMAIN 1
 /*	argument out of domain */
-#define ME_RANGE	2
+#define ME_RANGE 2
 /*	value out of range */
-#define ME_NOCONV	4
+#define ME_NOCONV 4
 /*	process did not converge */
-#define ME_PRECISION	8
+#define ME_PRECISION 8
 /*	does not have "full" precision */
-#define ME_UNDERFLOW	16
+#define ME_UNDERFLOW 16
 /*	and underflow occured (important for IEEE)*/
 
-#define ML_ERR_return_NAN { ML_ERROR(ME_DOMAIN, ""); return ML_NAN; }
+#define ML_ERR_return_NAN    \
+  {                          \
+    ML_ERROR(ME_DOMAIN, ""); \
+    return ML_NAN;           \
+  }
 
-#define ML_ERROR(x, s) { \
-   if(x > ME_DOMAIN) { \
-       const char *msg = ""; \
-       switch(x) { \
-       case ME_DOMAIN: \
-	   msg = _("argument out of domain in '%s'\n");	\
-	   break; \
-       case ME_RANGE: \
-	   msg = _("value out of range in '%s'\n");	\
-	   break; \
-       case ME_NOCONV: \
-	   msg = _("convergence failed in '%s'\n");	\
-	   break; \
-       case ME_PRECISION: \
-	   msg = _("full precision may not have been achieved in '%s'\n"); \
-	   break; \
-       case ME_UNDERFLOW: \
-	   msg = _("underflow occurred in '%s'\n");	\
-	   break; \
-       } \
-       MATHLIB_WARNING(msg, s); \
-   } \
-}
+#define ML_ERROR(x, s)                                                    \
+  {                                                                       \
+    if (x > ME_DOMAIN) {                                                  \
+      const char *msg = "";                                               \
+      switch (x) {                                                        \
+        case ME_DOMAIN:                                                   \
+          msg = _("argument out of domain in '%s'\n");                    \
+          break;                                                          \
+        case ME_RANGE:                                                    \
+          msg = _("value out of range in '%s'\n");                        \
+          break;                                                          \
+        case ME_NOCONV:                                                   \
+          msg = _("convergence failed in '%s'\n");                        \
+          break;                                                          \
+        case ME_PRECISION:                                                \
+          msg = _("full precision may not have been achieved in '%s'\n"); \
+          break;                                                          \
+        case ME_UNDERFLOW:                                                \
+          msg = _("underflow occurred in '%s'\n");                        \
+          break;                                                          \
+      }                                                                   \
+      MATHLIB_WARNING(msg, s);                                            \
+    }                                                                     \
+  }
 
-
-// Code copied from dpq.h - useful utilities for return values of dist functions.
-                                                        /* "DEFAULT" */
-                                                        /* --------- */
-#define R_D__0  (log_p ? ML_NEGINF : 0.)                /* 0 */
-#define R_D__1  (log_p ? 0. : 1.)                       /* 1 */
-#define R_DT_0  (lower_tail ? R_D__0 : R_D__1)          /* 0 */
-#define R_DT_1  (lower_tail ? R_D__1 : R_D__0)          /* 1 */
-#define R_D_val(x)	(log_p	? log(x) : (x))		/*  x  in pF(x,..) */
+// Code copied from dpq.h - useful utilities for return values of dist
+// functions.
+/* "DEFAULT" */
+/* --------- */
+#define R_D__0 (log_p ? ML_NEGINF : 0.)       /* 0 */
+#define R_D__1 (log_p ? 0. : 1.)              /* 1 */
+#define R_DT_0 (lower_tail ? R_D__0 : R_D__1) /* 0 */
+#define R_DT_1 (lower_tail ? R_D__1 : R_D__0) /* 1 */
+#define R_D_val(x) (log_p ? log(x) : (x))     /*  x  in pF(x,..) */
 
 #define give_log log_p
 
-#define R_D_forceint(x)   floor((x) + 0.5)
-#define R_D_nonint(x) 	  (fabs((x) - floor((x)+0.5)) > 1e-7)
+#define R_D_forceint(x) floor((x) + 0.5)
+#define R_D_nonint(x) (fabs((x)-floor((x) + 0.5)) > 1e-7)
 /* [neg]ative or [non int]eger : */
 #define R_D_negInonint(x) (x < 0. || R_D_nonint(x))
 
-#define R_D_nonint_check(x) 				\
-   if(R_D_nonint(x)) {					\
-	MATHLIB_WARNING("non-integer x = %f", x);	\
-	return R_D__0;					\
-   }
+#define R_D_nonint_check(x)                   \
+  if (R_D_nonint(x)) {                        \
+    MATHLIB_WARNING("non-integer x = %f", x); \
+    return R_D__0;                            \
+  }
 
-#define EIGEN_CHOL(x)       (x).selfadjointView<Eigen::Upper>().llt().matrixU()
+#define EIGEN_CHOL(x) (x).selfadjointView<Eigen::Upper>().llt().matrixU()
 
 bool decide(double lMHr);
 
@@ -151,7 +183,7 @@ double inprod(double v1, double v2);
 
 inline double nimble_NaN() {
   return std::numeric_limits<double>::has_quiet_NaN
-    ? std::numeric_limits<double>::quiet_NaN()
-    : (0./0.);
+             ? std::numeric_limits<double>::quiet_NaN()
+             : (0. / 0.);
 }
 #endif


### PR DESCRIPTION
This improves readability of eight of our C++ files.

## How

- Remove commented out code
- Apply `clang-format` by running `make clang-format` in the `packages` directory
- Manually fix trailing comments that were garbled by clang-format