### PR TITLE
Add tests/test-benchmarks.R for simple math functions

### DIFF
--- a/packages/Makefile
+++ b/packages/Makefile
@@ -31,6 +31,9 @@ test: FORCE
 	cd .. ; ./install_requirements.R
 	cd .. ; ./run_tests.R --parallel
 
+benchmark: FORCE
+	cd .. ; ./run_tests.R benchmarks
+
 # We are progressively delegating style to clang-format.
 # Some older C++ files are still styled manually.
 clang-format: FORCE

--- a/packages/nimble/inst/tests/test-benchmarks.R
+++ b/packages/nimble/inst/tests/test-benchmarks.R
@@ -1,0 +1,105 @@
+## This runs benchmarks of compiled NIMBLE code. It is located in tests/ so
+## that it can continue to be tested, but it most useful to run this manually.
+
+source(system.file(file.path('tests', 'test_utils.R'), package = 'nimble'))
+
+context('Benchmarking Nimble code')
+cat('\n')
+
+## Computes number of iterations per second.
+## This increase iterations until test takes around 1 sec.
+benchmarkIters <- function(fun, minIters = 100L, minRunTimeSec = 0.1) {
+    iters <- minIters
+    elapsed <- fun(iters)
+    while (elapsed < minRunTimeSec) {
+        iters <- as.integer(iters * max(2, (minRunTimeSec / (elapsed + 1e-6)) ^ 0.8))
+        elapsed <- fun(iters)
+    }
+    return(iters / elapsed)
+}
+
+matrixSizes <- c(1, 2, 3, 4, 5, 8, 10, 16, 32, 64, 100, 128, 256)
+vectorSizes <- c(1, 2, 3, 4, 5, 8, 10, 16, 32, 64, 100, 128, 256,
+                 512, 1000, 1024, 2048, 4096, 8192, 10000)
+
+test_that('Benchmarking matrix arithmetic', {
+    nimBenchmark <- nimbleFunction(
+        run = function(x = double(2), y = double(2), numIters = integer(0)) {
+            result <- run.time({
+                for (i in 1:numIters) {
+                    z <- 2 * x + y
+                    w <- x ^ 2 - y * z
+                }
+            })
+            return(result)
+            returnType(double(0))
+        })
+    cBenchmark <- compileNimble(nimBenchmark)
+    cat('---------------------------------------\n')
+    cat('Benchmarking Matrix Arithmetic\n')
+    cat('  K   M   N DSL calls/ms C++ calls/ms\n')
+    for (K in matrixSizes) {
+        M <- K
+        N <- K
+        x <- matrix(rnorm(K * M), K, M)
+        y <- matrix(rnorm(M * N), M, N)
+        nimPerSec <- benchmarkIters(function(iters) nimBenchmark(x, y, iters))
+        cPerSec <- benchmarkIters(function(iters) cBenchmark(x, y, iters))
+        cat(sprintf('%3d %3d %3d %12.1f %12.1f\n',
+                    K, M, N, nimPerSec / 1e3, cPerSec / 1e3))
+    }
+    cat('---------------------------------------\n')
+})
+
+test_that('Benchmarking matrix multiplication', {
+    nimBenchmark <- nimbleFunction(
+        run = function(x = double(2), y = double(2), numIters = integer(0)) {
+            result <- run.time({
+                for (i in 1:numIters) {
+                    z <- x %*% y
+                }
+            })
+            return(result)
+            returnType(double(0))
+        })
+    cBenchmark <- compileNimble(nimBenchmark)
+    cat('---------------------------------------\n')
+    cat('Benchmarking Matrix Multiplication\n')
+    cat('  K   M   N DSL calls/ms C++ calls/ms\n')
+    for (K in matrixSizes) {
+        M <- K
+        N <- K
+        x <- matrix(rnorm(K * M), K, M)
+        y <- matrix(rnorm(M * N), M, N)
+        nimPerSec <- benchmarkIters(function(iters) nimBenchmark(x, y, iters))
+        cPerSec <- benchmarkIters(function(iters) cBenchmark(x, y, iters))
+        cat(sprintf('%3d %3d %3d %12.1f %12.1f\n',
+                    K, M, N, nimPerSec / 1e3, cPerSec / 1e3))
+    }
+    cat('---------------------------------------\n')
+})
+
+test_that('Benchmarking vectorized special functions', {
+    nimBenchmark <- nimbleFunction(
+        run = function(x = double(1), numIters = integer(0)) {
+            result <- run.time({
+                for (i in 1:numIters) {
+                    y <- sqrt(x) + log(x) + exp(x) + cos(x) + sin(x) + lgamma(x) + expit(x)
+                }
+            })
+            return(result)
+            returnType(double(0))
+        })
+    cBenchmark <- compileNimble(nimBenchmark)
+    cat('-------------------------------\n')
+    cat('Benchmarking Special Functions\n')
+    cat('    N DSL calls/ms C++ calls/ms\n')
+    for (N in vectorSizes) {
+        x <- exp(-rnorm(N))
+        nimPerSec <- benchmarkIters(function(iters) nimBenchmark(x, iters))
+        cPerSec <- benchmarkIters(function(iters) cBenchmark(x, iters))
+        cat(sprintf('%5d %12.1f %12.1f\n',
+                    N, nimPerSec / 1e3, cPerSec / 1e3))
+    }
+    cat('-------------------------------\n')
+})


### PR DESCRIPTION
This adds a `test-benchmarks.R` to our test suite. The test is run automatically. You can run it manually using `make benchmark`.

## Question for reviewers

Are there any other benchmarks you would like me to add?

## Benchmark Results
<details><pre><code>
---------------------------------------
Benchmarking Matrix Arithmetic
  K   M   N DSL calls/ms C++ calls/ms
  1   1   1       1077.6      36114.9
  2   2   2        914.1      21279.5
  3   3   3        910.7      13732.0
  4   4   4        858.1      10849.8
  5   5   5        699.0       7743.5
  8   8   8        323.8       5439.1
 10  10  10        464.3       4135.2
 16  16  16        323.9       2373.8
 32  32  32         87.6        861.3
 64  64  64          8.1        219.2
100 100 100         10.6        100.5
128 128 128          2.2         52.2
256 256 256          0.5         13.3
---------------------------------------
---------------------------------------
Benchmarking Matrix Multiplication
  K   M   N DSL calls/ms C++ calls/ms
  1   1   1       4056.4      20180.5
  2   2   2       3105.6      15315.2
  3   3   3       2652.5      10724.0
  4   4   4       2527.0       6685.9
  5   5   5       1876.2       4250.0
  8   8   8        481.3       2198.7
 10  10  10       1063.8       1512.8
 16  16  16        422.8        706.1
 32  32  32         75.0        136.1
 64  64  64          7.3         21.0
100 100 100          3.8          5.9
128 128 128          1.0          2.9
256 256 256          0.4          0.4
---------------------------------------
-------------------------------
Benchmarking Special Functions
    N DSL calls/ms C++ calls/ms
    1        529.9       4429.4
    2        486.9       2400.4
    3        446.0       1603.0
    4        407.2       1222.6
    5        366.8        982.5
    8        304.2        624.6
   10        247.5        506.8
   16        188.9        318.4
   32        103.4        158.3
   64         57.1         77.8
  100         39.3         48.9
  128         32.2         38.2
  256         16.6         18.6
  512          8.1          9.2
 1000          2.0          4.6
 1024          2.6          3.2
 2048          1.3          1.6
 4096          0.7          0.8
 8192          0.3          0.4
10000          0.3          0.3
-------------------------------
</code></pre></details>