### PR TITLE
Fixes #488: un-reference scalar arguments to rankSample

### DIFF
--- a/packages/nimble/inst/CppCode/RcppNimbleUtils.cpp
+++ b/packages/nimble/inst/CppCode/RcppNimbleUtils.cpp
@@ -764,12 +764,12 @@ double nimMod(double a, double b) {
 //   return(a.value < b.value);
 // }
 
-void rankSample(NimArr<1, double> &weights, int &n, NimArr<1, int> &output) {
+void rankSample(NimArr<1, double> &weights, int n, NimArr<1, int> &output) {
   bool silent = false;
   rankSample(weights, n, output, silent);
 }
 
-void rankSample(NimArr<1, double> &weights, int &n, NimArr<1, int> &output, bool& silent) {
+void rankSample(NimArr<1, double> &weights, int n, NimArr<1, int> &output, bool silent) {
   //PRINTF("in VOID rankSample\n");
   output.setSize(n);
   int N = weights.size();

--- a/packages/nimble/inst/include/nimble/RcppNimbleUtils.h
+++ b/packages/nimble/inst/include/nimble/RcppNimbleUtils.h
@@ -305,7 +305,7 @@ int length(vector<T> vec)
 /* bool compareOrderedPair(orderedPair a, orderedPair b);	 //function called for sort  */
 
 
-void rankSample(NimArr<1, double>& weights, int& n, NimArr<1, int>& output);
-void rankSample(NimArr<1, double>& weights, int& n, NimArr<1, int>& output, bool& silent);
+void rankSample(NimArr<1, double>& weights, int n, NimArr<1, int>& output);
+void rankSample(NimArr<1, double>& weights, int n, NimArr<1, int>& output, bool silent);
 
 #endif


### PR DESCRIPTION
There were three cases of scalar arguments unnecessarily passed by reference in the two versions of `rankSample`.  Until recently,  `rankSample` had not been used outside of its original need, so this oversight in style had gone unnoticed.  This PR removes the reference `&` from those arguments.