### PR TITLE
Clearly mark expected failures in test logs

### DIFF
--- a/packages/nimble/inst/tests/test-refactorCompilationSteps.R
+++ b/packages/nimble/inst/tests/test-refactorCompilationSteps.R
@@ -23,7 +23,9 @@ compareOldAndNewCompilationRC <- function(input) {
     ## management of compilation through the control list is crude and leads to error we don't care about
     ## but the project does contain the result, so we can run this, catch the error to keep running
     ## and extract the result from the project
-    old <- try(compileNimble(foo, project = testProject, control = list(writeFiles = TRUE, compileCpp = FALSE, loadSO = FALSE)))
+    wrap_if_matches(input$xfail, 'math runs', expect_error, {
+        compileNimble(foo, project = testProject, control = list(writeFiles = TRUE, compileCpp = FALSE, loadSO = FALSE))
+    })
     filename <- testProject$RCfunInfos[['foo']][['cppClass']]$filename
     newfilename <- paste0(filename,'_original')
     pathedfilename <- file.path(tempdir(), 'nimble_generatedCode', filename)
@@ -33,7 +35,9 @@ compareOldAndNewCompilationRC <- function(input) {
     nimbleOptions(useRefactoredSizeProcessing = TRUE)
     nimble:::resetLabelFunctionCreators() ## sets any generated IDs back to 1
     testProject <- nimble:::nimbleProjectClass(name = 'for_comparison')
-    new <- try(compileNimble(foo, project = testProject, control = list(writeFiles = TRUE, compileCpp = FALSE, loadSO = FALSE)))
+    wrap_if_matches(input$xfail, 'math runs', expect_error, {
+        compileNimble(foo, project = testProject, control = list(writeFiles = TRUE, compileCpp = FALSE, loadSO = FALSE))
+    })
     filename <- testProject$RCfunInfos[['foo']][['cppClass']]$filename
     ## we could regenerate it, but might as well read it from the file
     refactored_pathedfilename <- file.path(tempdir(), 'nimble_generatedCode', filename)

--- a/packages/nimble/inst/tests/test-returnTypeErrorTrapping.R
+++ b/packages/nimble/inst/tests/test-returnTypeErrorTrapping.R
@@ -17,8 +17,7 @@ test_that('return type error caught', {
             return(x + 1)
             returnType(integer(1))
         })
-    cfoo <- try(compileNimble(foo))
-    expect_failure(expect_identical(class(cfoo), "function"))
+    expect_error(compileNimble(foo))
 })
 
 test_that('return nDim error caught', {
@@ -27,8 +26,7 @@ test_that('return nDim error caught', {
             return(x + 1)
             returnType(double(2))
         })
-    cfoo <- try(compileNimble(foo))
-    expect_failure(expect_identical(class(cfoo), "function"))
+    expect_error(compileNimble(foo))
 })
 
 test_that('return type and nDim error caught', {
@@ -37,8 +35,7 @@ test_that('return type and nDim error caught', {
             return(x + 1)
             returnType(integer())
         })
-    cfoo <- try(compileNimble(foo))
-    expect_failure(expect_identical(class(cfoo), "function"))
+    expect_error(compileNimble(foo))
 })
 
 test_that('nimbleList return type error caught', {
@@ -53,8 +50,7 @@ test_that('nimbleList return type error caught', {
             return(l1)
         }
     )    
-    Cnf1 <- try(compileNimble(nf1))
-    expect_failure(expect_identical(class(Cnf1), "function"))
+    expect_error(compileNimble(nf1))
 })
 
 test_that('void() return passes return type error trapping', {
@@ -62,8 +58,8 @@ test_that('void() return passes return type error trapping', {
         run = function(x = double(1)) {
             return()
         })
-    cfoo <- try(compileNimble(foo))
-    expect_success(expect_identical(class(cfoo), "function"))
+    cfoo <- compileNimble(foo)
+    expect_identical(class(cfoo), "function")
 })
 
 test_that('return type error caught when non-void object is returned', {
@@ -72,8 +68,7 @@ test_that('return type error caught when non-void object is returned', {
             return(x)
             returnType(void())
         })
-    cfoo <- try(compileNimble(foo))
-    expect_failure(expect_identical(class(cfoo), "function"))
+    expect_error(compileNimble(foo))
 })
 
 options(warn = RwarnLevel)

--- a/packages/nimble/inst/tests/test_utils.R
+++ b/packages/nimble/inst/tests/test_utils.R
@@ -314,9 +314,11 @@ make_input <- function(dim, size = 3, logicalArg) {
   stop("not set for dimension greater than 2")
 }
 
-wrap_if_matches <- function(pattern, string, wrapper, expr) {
+xfail_if_matches <- function(pattern, string, wrapper, expr) {
     if (!is.null(pattern) && grepl(paste0('^', pattern, '$'), string)) {
+        cat('BEGIN XFAIL\n', file = stderr())
         wrapper(expr)
+        cat('END XFAIL\n', file = stderr())
     } else {
         expr
     }
@@ -332,7 +334,7 @@ wrap_if_matches <- function(pattern, string, wrapper, expr) {
 test_math <- function(param, caseName, verbose = TRUE, size = 3, dirName = NULL) {
     info <- paste0(caseName, ': ', param$name)
     test_that(info, {
-        wrap_if_matches(param$xfail, paste0(info, ': runs'), expect_error, {
+        xfail_if_matches(param$xfail, paste0(info, ': runs'), expect_error, {
             test_math_internal(param, info, verbose, size, dirName)
         })
     })
@@ -380,11 +382,11 @@ test_math_internal <- function(param, info, verbose = TRUE, size = 3, dirName = 
   if(is.logical(out_nfR)) out_nfR <- as.numeric(out_nfR)
 
   infoR <- paste0(info, ": (R vs Nimble DSL)")
-  wrap_if_matches(param$xfail, info, expect_failure, {
+  xfail_if_matches(param$xfail, info, expect_failure, {
       expect_equal(out, out_nfR, info = infoR)
   })
   infoC <- paste0(info, ": (R vs Nimble Cpp)")
-  wrap_if_matches(param$xfail, info, expect_failure, {
+  xfail_if_matches(param$xfail, info, expect_failure, {
       expect_equal(out, out_nfC, info = infoC)
   })
 


### PR DESCRIPTION
Fixes #495 
Fixes #496

@paciorek noticed that `run_tests.R` shows `test-math.R` as passing despite errors in `test-math.stderr`. These error messages are actually known failures. Nimble tests used to log "KNOWN FAILURE" messages in the test logs, but these messages were dropped during our transition to more automated tests. This PR resurrects "known failure" messages in the details section below.

This fixes:
- [x] `test-math.R`
- [x] `test-size.R`
- [x] `test-refactorCompilationSteps.R`
- [x] `test-returnTypeErrorTrapping.R`

<details><pre><code>
$ cat /tmp/log/nimble/test-math.stderr
nimble version 0.6-6 is loaded.
For more information on NIMBLE and a User Manual,
please visit http://R-nimble.org.

Attaching package: ‘nimble’

The following object is masked from ‘package:stats’:

    simulate

BEGIN XFAIL
END XFAIL
BEGIN XFAIL
Error : Information for eigenizing was not complete,
 This occurred for: eigAtanh(nimMod(Eig_ARG1_arg1_Interm_34,1))
 This was part of the call:  Eig_out <- eigAtanh(nimMod(Eig_ARG1_arg1_Interm_34,1))
In addition: Warning message:
Placing tests in `inst/tests/` is deprecated. Please use `tests/testthat/` instead 
END XFAIL
BEGIN XFAIL
Error : the second argument to pow must be a scalar.
 This occurred for: pow(Eig_ARG1_arg1_Interm_43,Eig_ARG2_arg2_Interm_44)
 This was part of the call:  Eig_out <- pow(Eig_ARG1_arg1_Interm_43,Eig_ARG2_arg2_Interm_44)
END XFAIL
BEGIN XFAIL
Error : the second argument to pow must be a scalar.
 This occurred for: pow(Eig_ARG1_arg1_Interm_45,Eig_ARG2_arg2_Interm_46)
 This was part of the call:  Eig_out <- pow(Eig_ARG1_arg1_Interm_45,Eig_ARG2_arg2_Interm_46)
END XFAIL
BEGIN XFAIL
END XFAIL
BEGIN XFAIL
END XFAIL
BEGIN XFAIL
Error : In sizeAssignAfterRecursing: 'norm' is not available or its output type is unknown.
 This occurred for: out <- norm(ARG1_arg1_)
 This was part of the call:  {
  out <- norm(ARG1_arg1_)
  return(out)
}
END XFAIL
BEGIN XFAIL
Error : In sizeAssignAfterRecursing: 'norm' is not available or its output type is unknown.
 This occurred for: out <- norm(ARG1_arg1_)
 This was part of the call:  {
  out <- norm(ARG1_arg1_)
  return(out)
}
END XFAIL
BEGIN XFAIL
END XFAIL
BEGIN XFAIL
END XFAIL
BEGIN XFAIL
END XFAIL
</code></pre></details>