### PR TITLE
Fix silent failure in run_tests.R

### DIFF
--- a/run_tests.R
+++ b/run_tests.R
@@ -100,7 +100,11 @@ runTest <- function(test, logToFile = FALSE, runViaTestthat = TRUE) {
     cat('TESTING', test, '\n')
     if (runViaTestthat) {
         name <- gsub('test-(.*)\\.R', '\\1', test)
-        script <- paste0('library(methods); library(testthat); library(nimble); test_package("nimble", "^', name, '$")')
+        script <- paste0('library(methods);',
+                         'library(testthat);',
+                         'library(nimble);',
+                         'tryCatch(test_package("nimble", "^', name, '$"),',
+                         'error = function(e) quit(status = 1))')
         command <- c(runner, '-e', shQuote(script))
     } else {
         command <- c(runner, file.path('packages', 'nimble', 'inst', 'tests', test))


### PR DESCRIPTION
Thanks, @paciorek for paying attention to the test logs!

I believe this only affects a tiny subset of tests that are both (1) not wrapped in a `test_that`, and (2) failing due to missing error inside `expect_error()`.

I don't understand what's going on here, since I've been seeing plenty of test failures locally and on travis (on my broken branches). What's disconcerting is that I was able to run a modified local version of `test-refactorCompilationSteps.R` that silently failed before this change (when run via `./run_tests.R refactorCompilationSteps`) and verbosely failed after this change. All other tests appear to be passing before and after this change :confused: 

I think the problematic behavior can be reproduced by
```sh
$ Rscript -e 'stop("Failed")' && echo 'silently' || echo 'verbosely'
Error: Failed
No traceback available 
silently

$ Rscript -e 'tryCatch(stop("Failed"), error=function(e)quit(status=1))' \
  && echo 'silently' || echo 'verbosely'
verbosely
```