### PR TITLE
Fix failing test-refactorCompilationSteps.R

### DIFF
--- a/packages/nimble/inst/tests/mathTestLists.R
+++ b/packages/nimble/inst/tests/mathTestLists.R
@@ -39,7 +39,7 @@ testsBasicMath = list(
   list(name = 'log of vector', expr = quote(out <- log(abs(arg1))), inputDim = 1, outputDim = 1),
   list(name = 'sqrt of vector', expr = quote(out <- sqrt(abs(arg1))), inputDim = 1, outputDim = 1),
   list(name = 'abs of vector', expr = quote(out <- abs(arg1)), inputDim = 1, outputDim = 1),
-  list(name = 'step of vector', expr = quote(out <- step(arg1)), inputDim = 1, outputDim = 1, Rcode = quote(out <- as.numeric(arg1 > 0)), xfail = 'math.*runs'), ## FAILS on compileNimble(nfR) with Eigen error.
+  list(name = 'step of vector', expr = quote(out <- step(arg1)), inputDim = 1, outputDim = 1, Rcode = quote(out <- as.numeric(arg1 > 0)), xfail = 'math.*compiles.*'), ## FAILS on compileNimble(nfR) with Eigen error.
   list(name = 'cube of vector', expr = quote(out <- cube(arg1)), inputDim = 1, outputDim = 1),
   list(name = 'cos of vector', expr = quote(out <- cos(arg1)), inputDim = 1, outputDim = 1),
   list(name = 'acos of cos of vector', expr = quote(out <- acos(cos(arg1))), inputDim = 1, outputDim = 1),
@@ -52,7 +52,7 @@ testsBasicMath = list(
   list(name = 'tanh of vector', expr = quote(out <- tanh(arg1)), inputDim = 1, outputDim = 1),
   list(name = 'acosh of vector', expr = quote(out <- acosh(1 + abs(arg1))), inputDim = 1, outputDim = 1),
   list(name = 'asinh of vector', expr = quote(out <- asinh(arg1)), inputDim = 1, outputDim = 1),
-  list(name = 'atanh of vector', expr = quote(out <- atanh(arg1%%1)), inputDim = 1, outputDim = 1, xfail = 'math.*runs'), ## FAILS - issue here is probably that modulo on vecs doesn't work but need to restrict domain for atanh
+  list(name = 'atanh of vector', expr = quote(out <- atanh(arg1%%1)), inputDim = 1, outputDim = 1, xfail = 'math.*compiles.*'), ## FAILS - issue here is probably that modulo on vecs doesn't work but need to restrict domain for atanh
   ###
   list(name = 'scalar + scalar', expr = quote(out <- arg1 + arg2), inputDim = c(0,0), outputDim = 0),
   list(name = 'diff of scalars', expr = quote(out <- arg1 - arg2), inputDim = c(0,0), outputDim = 0),
@@ -70,8 +70,8 @@ testsBasicMath = list(
   list(name = 'diff of vectors', expr = quote(out <- arg1 - arg2), inputDim = c(1,1), outputDim = 1),
   list(name = 'product of vectors', expr = quote(out <- arg1 * arg2), inputDim = c(1,1), outputDim = 1),
   list(name = 'ratio of vectors', expr = quote(out <- arg1 / arg2), inputDim = c(1,1), outputDim = 1),
-  list(name = 'power of vectors via ^', expr = quote(out <- arg1 ^ arg2), inputDim = c(1,1), outputDim = 1, xfail = 'math.*runs'), ## FAILS with Eigen casting
-  list(name = 'power of vectors via pow', expr = quote(out <- pow(arg1, arg2)), inputDim = c(1,1), outputDim = 1, xfail = 'math.*runs'), ## FAILS with Eigen casting
+  list(name = 'power of vectors via ^', expr = quote(out <- arg1 ^ arg2), inputDim = c(1,1), outputDim = 1, xfail = 'math.*compiles.*'), ## FAILS with Eigen casting
+  list(name = 'power of vectors via pow', expr = quote(out <- pow(arg1, arg2)), inputDim = c(1,1), outputDim = 1, xfail = 'math.*compiles.*'), ## FAILS with Eigen casting
   list(name = 'modulo of vectors', expr = quote(out <- arg1 %% arg2), inputDim = c(1,1), outputDim = 1, xfail = 'math.*runs'), ## FAILS with Eigen casting
   list(name = 'pmin of vectors', expr = quote(out <- pmin(arg1, arg2)), inputDim = c(1,1), outputDim = 1),
   list(name = 'pmax of vectors', expr = quote(out <- pmax(arg1, arg2)), inputDim = c(1,1), outputDim = 1),

--- a/packages/nimble/inst/tests/test-refactorCompilationSteps.R
+++ b/packages/nimble/inst/tests/test-refactorCompilationSteps.R
@@ -7,44 +7,45 @@ options(warn = -1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-
-
-## Known concern: ordering of asRow()/asCol() and intermediates
+## Known concern: ordering of asRow()/asCol() and intermediates.
 
 compareOldAndNewCompilationRC <- function(input) {
-    run <- input$run
-    name <- input$name
-    require(testthat)
+    name <- paste0('math: ', input$name, ': compiles')
+    test_that(name, {
+        wrap_if_matches(input$xfail, name, expect_error, {
+            run <- input$run
+            name <- input$name
 
-    foo <- nimbleFunction(run = run, name = 'foo')
-    nimbleOptions(useRefactoredSizeProcessing = FALSE)
-    nimble:::resetLabelFunctionCreators() ## sets any generated IDs back to 1
-    testProject <- nimble:::nimbleProjectClass(name = 'for_comparison')
-    ## management of compilation through the control list is crude and leads to error we don't care about
-    ## but the project does contain the result, so we can run this, catch the error to keep running
-    ## and extract the result from the project
-    wrap_if_matches(input$xfail, 'math runs', expect_error, {
-        compileNimble(foo, project = testProject, control = list(writeFiles = TRUE, compileCpp = FALSE, loadSO = FALSE))
-    })
-    filename <- testProject$RCfunInfos[['foo']][['cppClass']]$filename
-    newfilename <- paste0(filename,'_original')
-    pathedfilename <- file.path(tempdir(), 'nimble_generatedCode', filename)
-    original_pathedfilename <- file.path(tempdir(), 'nimble_generatedCode', newfilename)
-    for(ext in c('.h', '.cpp')) file.copy(paste0(pathedfilename, ext), paste0(original_pathedfilename, ext), overwrite = TRUE)
-    
-    nimbleOptions(useRefactoredSizeProcessing = TRUE)
-    nimble:::resetLabelFunctionCreators() ## sets any generated IDs back to 1
-    testProject <- nimble:::nimbleProjectClass(name = 'for_comparison')
-    wrap_if_matches(input$xfail, 'math runs', expect_error, {
-        compileNimble(foo, project = testProject, control = list(writeFiles = TRUE, compileCpp = FALSE, loadSO = FALSE))
-    })
-    filename <- testProject$RCfunInfos[['foo']][['cppClass']]$filename
-    ## we could regenerate it, but might as well read it from the file
-    refactored_pathedfilename <- file.path(tempdir(), 'nimble_generatedCode', filename)
+            foo <- nimbleFunction(run = run, name = 'foo')
+            nimbleOptions(useRefactoredSizeProcessing = FALSE)
+            nimble:::resetLabelFunctionCreators() ## This sets any generated IDs back to 1.
+            testProject <- nimble:::nimbleProjectClass(name = 'for_comparison')
+            ## Management of compilation through the control list is crude and leads to error we don't care about
+            ## but the project does contain the result, so we can run this, catch the error to keep running
+            ## and extract the result from the project.
+            compileNimble(foo, project = testProject, control = list(writeFiles = TRUE, compileCpp = FALSE, loadSO = FALSE))
+            filename <- testProject$RCfunInfos[['foo']][['cppClass']]$filename
+            newfilename <- paste0(filename,'_original')
+            pathedfilename <- file.path(tempdir(), 'nimble_generatedCode', filename)
+            original_pathedfilename <- file.path(tempdir(), 'nimble_generatedCode', newfilename)
+            for(ext in c('.h', '.cpp')) {
+                file.copy(paste0(pathedfilename, ext), paste0(original_pathedfilename, ext), overwrite = TRUE)
+            }
+            
+            nimbleOptions(useRefactoredSizeProcessing = TRUE)
+            nimble:::resetLabelFunctionCreators() ## This sets any generated IDs back to 1.
+            testProject <- nimble:::nimbleProjectClass(name = 'for_comparison')
+            compileNimble(foo, project = testProject, control = list(writeFiles = TRUE, compileCpp = FALSE, loadSO = FALSE))
+            filename <- testProject$RCfunInfos[['foo']][['cppClass']]$filename
+            ## We could regenerate it [edit: what is it?], but might as well read it from the file.
+            refactored_pathedfilename <- file.path(tempdir(), 'nimble_generatedCode', filename)
 
-    for(ext in c('.h','.cpp'))
-        compareFilesUsingDiff(paste0(refactored_pathedfilename, ext), paste0(original_pathedfilename, ext),
-                              main = paste0(ext, ' files do not match for: ', name))    
+            for(ext in c('.h','.cpp')) {
+                compareFilesUsingDiff(paste0(refactored_pathedfilename, ext), paste0(original_pathedfilename, ext),
+                                      main = paste0(ext, ' files do not match for: ', name))    
+            }
+        })
+    })
 }
 
 testCases <- list(

--- a/packages/nimble/inst/tests/test_utils.R
+++ b/packages/nimble/inst/tests/test_utils.R
@@ -344,7 +344,7 @@ wrap_if_matches <- function(pattern, string, wrapper, expr) {
 test_math <- function(param, caseName, verbose = TRUE, size = 3, dirName = NULL) {
     info <- paste0(caseName, ': ', param$name)
     test_that(info, {
-        wrap_if_matches(param$xfail, paste0(info, ': runs'), expect_error, {
+        wrap_if_matches(param$xfail, paste0(info, ': compiles and runs'), expect_error, {
             test_math_internal(param, info, verbose, size, dirName)
         })
     })

--- a/run_tests.R
+++ b/run_tests.R
@@ -100,7 +100,11 @@ runTest <- function(test, logToFile = FALSE, runViaTestthat = TRUE) {
     cat('TESTING', test, '\n')
     if (runViaTestthat) {
         name <- gsub('test-(.*)\\.R', '\\1', test)
-        script <- paste0('library(methods); library(testthat); library(nimble); test_package("nimble", "^', name, '$")')
+        script <- paste0('library(methods);',
+                         'library(testthat);',
+                         'library(nimble);',
+                         'tryCatch(test_package("nimble", "^', name, '$"),',
+                         'error = function(e) quit(status = 1))')
         command <- c(runner, '-e', shQuote(script))
     } else {
         command <- c(runner, file.path('packages', 'nimble', 'inst', 'tests', test))


### PR DESCRIPTION
Partially addresses: #501

## How?
- Add more precision to the `xfail` parameters in `mathTestLists.R`.
- Use `test_that()` inside `compareOldAndNewCompilation()`. This may have been the cause of silent failures addressed in #503 (on which this PR is based).