### PR TITLE
Add failing tests for step(inprod(-,-))

### DIFF
--- a/packages/nimble/R/RCfunction_core.R
+++ b/packages/nimble/R/RCfunction_core.R
@@ -16,6 +16,7 @@ otherDSLcalls <- c("{",
                    "nimDerivs",
                    "void")
 
+# TODO(perrydv) Should inprod be added to this list?
 nimKeyWords <- list(copy = 'nimCopy',
                     print = 'nimPrint',
                     cat = 'nimCat',

--- a/packages/nimble/inst/CppCode/Utils.cpp
+++ b/packages/nimble/inst/CppCode/Utils.cpp
@@ -84,4 +84,3 @@ double pairmin(double x1, double x2) {return(x1 < x2 ? x1 : x2);}
 //double phi(double x) {return(pnorm(x, 0., 1., 1, 0));}
 int nimStep(double x) { return(x >= 0 ? 1 : 0);}
 double cube(double x) {return(x*x*x);}
-double inprod(double v1, double v2) {return(v1*v2);}

--- a/packages/nimble/inst/include/nimble/Utils.h
+++ b/packages/nimble/inst/include/nimble/Utils.h
@@ -159,6 +159,7 @@ void nimStop();
 
 bool nimNot(bool x);
 
+// TODO(perrydv) Which functions are needed for link functions? All of these?
 // needed for link functions
 double ilogit(double x);
 double icloglog(double x);
@@ -178,7 +179,6 @@ double pairmin(double x1, double x2);
 //double phi(double x);
 int nimStep(double x); 
 double cube(double x);
-double inprod(double v1, double v2);
 
 inline double nimble_NaN() {
   return std::numeric_limits<double>::has_quiet_NaN

--- a/packages/nimble/inst/tests/test-misc.R
+++ b/packages/nimble/inst/tests/test-misc.R
@@ -156,3 +156,29 @@ test_that("pi case 3", {
     expect_equal(cnf(), c(10.1, 20.2), info = 'pi case 1 compiled')
     }
 )
+
+test_that('step(inprod(-, -)) compiles', {
+    nf <- nimbleFunction(
+        run = function() {
+            x <- rep(0, 4)
+            z <- step(inprod(x, x))
+        }
+    )
+    expect_error(
+        cnf <- compileNimble(nf, showCompilerOutput = TRUE),
+        info = 'Known Failure: https://github.com/nimble-dev/nimble/issues/538'
+    )
+})
+
+test_that('sin(inprod(-, -)) compiles', {
+    nf <- nimbleFunction(
+        run = function() {
+            x <- rep(0, 4)
+            z <- sin(inprod(x, x))
+        }
+    )
+    expect_error(
+        cnf <- compileNimble(nf, showCompilerOutput = TRUE),
+        info = 'Known Failure: https://github.com/nimble-dev/nimble/issues/538'
+    )
+})


### PR DESCRIPTION
**Status:** Do not merge. @perrydv could you please take a look?

Addresses #538 

This PR:
- Adds an xfailing test for `step(inprod(x,x))`
- Removes the untested and apparently unused C++ scalar implementation of `inprod(-,-)`