### PR TITLE
Cosmetic: reindent setRefClass bodies to reduce wasted whitespace

### DIFF
--- a/packages/nimble/R/RCfunction_compile.R
+++ b/packages/nimble/R/RCfunction_compile.R
@@ -1,98 +1,103 @@
 ## Small class for information on compilation of each nf method
 RCfunctionCompileClass <- setRefClass('RCfunctionCompileClass',
-                                      fields = list(
-                                          origRcode = 'ANY',
-                                          origLocalSymTab = 'ANY',
-                                          nimExpr = 'ANY',
-                                          newLocalSymTab = 'ANY',
-                                          returnSymbol = 'ANY',
-                                          newRcode = 'ANY',
-                                          typeEnv = 'ANY'	#environment
-                                          ),
-                                          methods = list(initialize = function(...){typeEnv <<- new.env(); callSuper(...)}
-                                          ))
+    fields = list(
+        origRcode = 'ANY',
+        origLocalSymTab = 'ANY',
+        nimExpr = 'ANY',
+        newLocalSymTab = 'ANY',
+        returnSymbol = 'ANY',
+        newRcode = 'ANY',
+        typeEnv = 'ANY'	#environment
+    ),
+    methods = list(
+        initialize = function(...) {
+            typeEnv <<- new.env()
+            callSuper(...)
+        }
+    )
+)
 
 RCvirtualFunProcessing <- setRefClass('RCvirtualFunProcessing',
-                                      fields = list(
-                                          name = 'ANY',		#character
-                                          RCfun = 'ANY', ##nfMethodRC
-                                          nameSubList = 'ANY',
-                                          compileInfo = 'ANY', ## RCfunctionCompileClass``
-                                          const = 'ANY',
-                                          neededRCfuns = 'ANY',
-                                          initialTypeInferenceDone = 'ANY'
-                                          ),
-                                      methods = list(
-                                          initialize = function(f = NULL, funName, const = FALSE) {
-                                              const <<- const
-                                              if(!is.null(f)) {
-                                                  if(missing(funName)) {
-                                                      sf <- substitute(f)
-                                                      name <<- Rname2CppName(deparse(sf))
-                                                  } else {
-                                                      name <<- funName
-                                                  }
-                                                  if(is.function(f)) {
-                                                      RCfun <<- nfMethodRC$new(f)
-                                                  } else {
-                                                      if(!inherits(f, 'nfMethodRC')) {
-                                                          stop('Error: f must be a function or an RCfunClass')
-                                                      }
-                                                      RCfun <<- f
-                                                  }
-                                                  compileInfo <<- RCfunctionCompileClass$new(origRcode = RCfun$code, newRcode = RCfun$code)
-                                              }
-                                              neededRCfuns <<- list()
-                                              initialTypeInferenceDone <<- FALSE
-                                          },
-                                          showCpp = function() {
-                                              writeCode(nimGenerateCpp(compileInfo$nimExpr, compileInfo$newLocalSymTab))
-                                          },
-                                          setupSymbolTables = function(parentST = NULL, neededTypes = NULL, nimbleProject = NULL) {
-                                              argInfoWithMangledNames <- RCfun$argInfo
-                                              numArgs <- length(argInfoWithMangledNames)
-                                              if(numArgs > 0) {
-                                                  argIsBlank <- unlist(lapply(RCfun$argInfo, identical, formals(function(a) {})[[1]]))
-                                                  ## it seems to be impossible to store the value of a blank argument, formals(function(a) {})[[1]], in a variable
-                                                  if(any(argIsBlank)) {
-                                                      stop(paste0("Type declaration missing for argument(s) ", paste(names(RCfun$argInfo)[argIsBlank], collapse = ", ")), call. = FALSE)
-                                                  }
-                                              }
-                                              argInfoWithMangledNames <- RCfun$argInfo
-                                              numArgs <- length(argInfoWithMangledNames)
-                                              if(numArgs>0) names(argInfoWithMangledNames) <- paste0("ARG", 1:numArgs, "_", Rname2CppName(names(argInfoWithMangledNames)),"_")
-                                              nameSubList <<- lapply(names(argInfoWithMangledNames), as.name)
-                                              names(nameSubList) <<- names(RCfun$argInfo)
-
-                                              ## This will only handle basic types.  nimbleLists will be added below
-                                              compileInfo$origLocalSymTab <<- argTypeList2symbolTable(argInfoWithMangledNames, neededTypes, names(RCfun$argInfo)) ## will be used for function args.  must be a better way.
-                                              compileInfo$newLocalSymTab <<- argTypeList2symbolTable(argInfoWithMangledNames, neededTypes, names(RCfun$argInfo))
-
-                                              ## This modifies the symTab and returns types needed for input or return
-                                              ## Currently the only non-basic type resolves in this step would be nimbleLists
-                                              if(is.null(nimbleProject)) nimbleProject <- get('nimbleProject', envir = RCfun)
-                                              neededRCfuns <<- resolveUnknownTypes(compileInfo$origLocalSymTab, neededTypes, nimbleProject)
-                                              resolveUnknownTypes(compileInfo$newLocalSymTab, c(neededRCfuns, neededTypes), nimbleProject)
-                                              
-                                              if(!is.null(parentST)) {
-                                                  compileInfo$origLocalSymTab$setParentST(parentST)
-                                                  compileInfo$newLocalSymTab$setParentST(parentST)
-                                              }
-                                              compileInfo$returnSymbol <<- argType2symbol(RCfun$returnType, neededTypes, "return", "returnType")
-                                              updatedReturn <- resolveOneUnknownType(compileInfo$returnSymbol, c(neededRCfuns, neededTypes), nimbleProject)
-                                              compileInfo$returnSymbol <<- updatedReturn[[1]]
-                                              neededRCfuns <<- c(neededRCfuns, updatedReturn[[2]])
-                                          },
-                                          process = function(...) {
-                                              if(inherits(compileInfo$origLocalSymTab, 'uninitializedField')) {
-                                                  setupSymbolTables()
-                                              }
-                                          },
-                                          printCode = function() {
-                                              writeCode(nimDeparse(compileInfo$nimExpr))
-                                          }
-                                      )
-                                      )
+    fields = list(
+        name = 'ANY',		#character
+        RCfun = 'ANY', ##nfMethodRC
+        nameSubList = 'ANY',
+        compileInfo = 'ANY', ## RCfunctionCompileClass``
+        const = 'ANY',
+        neededRCfuns = 'ANY',
+        initialTypeInferenceDone = 'ANY'
+    ),
+    methods = list(
+        initialize = function(f = NULL, funName, const = FALSE) {
+            const <<- const
+            if(!is.null(f)) {
+                if(missing(funName)) {
+                    sf <- substitute(f)
+                    name <<- Rname2CppName(deparse(sf))
+                } else {
+                    name <<- funName
+                }
+                if(is.function(f)) {
+                    RCfun <<- nfMethodRC$new(f)
+                } else {
+                    if(!inherits(f, 'nfMethodRC')) {
+                        stop('Error: f must be a function or an nfMethodRC')
+                    }
+                    RCfun <<- f
+                }
+                compileInfo <<- RCfunctionCompileClass$new(origRcode = RCfun$code, newRcode = RCfun$code)
+            }
+            neededRCfuns <<- list()
+            initialTypeInferenceDone <<- FALSE
+        },
+        showCpp = function() {
+            writeCode(nimGenerateCpp(compileInfo$nimExpr, compileInfo$newLocalSymTab))
+        },
+        setupSymbolTables = function(parentST = NULL, neededTypes = NULL, nimbleProject = NULL) {
+            argInfoWithMangledNames <- RCfun$argInfo
+            numArgs <- length(argInfoWithMangledNames)
+            if(numArgs > 0) {
+                argIsBlank <- unlist(lapply(RCfun$argInfo, identical, formals(function(a) {})[[1]]))
+                ## it seems to be impossible to store the value of a blank argument, formals(function(a) {})[[1]], in a variable
+                if(any(argIsBlank)) {
+                    stop(paste0("Type declaration missing for argument(s) ", paste(names(RCfun$argInfo)[argIsBlank], collapse = ", ")), call. = FALSE)
+                }
+            }
+            argInfoWithMangledNames <- RCfun$argInfo
+            numArgs <- length(argInfoWithMangledNames)
+            if(numArgs>0) names(argInfoWithMangledNames) <- paste0("ARG", 1:numArgs, "_", Rname2CppName(names(argInfoWithMangledNames)),"_")
+            nameSubList <<- lapply(names(argInfoWithMangledNames), as.name)
+            names(nameSubList) <<- names(RCfun$argInfo)
+    
+            ## This will only handle basic types.  nimbleLists will be added below
+            compileInfo$origLocalSymTab <<- argTypeList2symbolTable(argInfoWithMangledNames, neededTypes, names(RCfun$argInfo)) ## will be used for function args.  must be a better way.
+            compileInfo$newLocalSymTab <<- argTypeList2symbolTable(argInfoWithMangledNames, neededTypes, names(RCfun$argInfo))
+    
+            ## This modifies the symTab and returns types needed for input or return
+            ## Currently the only non-basic type resolves in this step would be nimbleLists
+            if(is.null(nimbleProject)) nimbleProject <- get('nimbleProject', envir = RCfun)
+            neededRCfuns <<- resolveUnknownTypes(compileInfo$origLocalSymTab, neededTypes, nimbleProject)
+            resolveUnknownTypes(compileInfo$newLocalSymTab, c(neededRCfuns, neededTypes), nimbleProject)
+            
+            if(!is.null(parentST)) {
+                compileInfo$origLocalSymTab$setParentST(parentST)
+                compileInfo$newLocalSymTab$setParentST(parentST)
+            }
+            compileInfo$returnSymbol <<- argType2symbol(RCfun$returnType, neededTypes, "return", "returnType")
+            updatedReturn <- resolveOneUnknownType(compileInfo$returnSymbol, c(neededRCfuns, neededTypes), nimbleProject)
+            compileInfo$returnSymbol <<- updatedReturn[[1]]
+            neededRCfuns <<- c(neededRCfuns, updatedReturn[[2]])
+        },
+        process = function(...) {
+            if(inherits(compileInfo$origLocalSymTab, 'uninitializedField')) {
+                setupSymbolTables()
+            }
+        },
+        printCode = function() {
+            writeCode(nimDeparse(compileInfo$nimExpr))
+        }
+    )
+)
 
 RCfunction <- function(f, name = NA, returnCallable = TRUE, check) {
     if(is.na(name)) name <- rcFunLabelMaker()
@@ -144,205 +149,205 @@ nf_substituteExceptFunctionsAndDollarSigns <- function(code, subList) {
 }
 
 RCfunProcessing <- setRefClass('RCfunProcessing',
-                               contains = 'RCvirtualFunProcessing',
-                               fields = list(),
-                                   methods = list(
-                                   process = function(debug = FALSE, debugCpp = FALSE, debugCppLabel = character(), doKeywords = TRUE, nimbleProject = NULL, initialTypeInferenceOnly = FALSE) {
-                                       if(!is.null(nimbleOptions()$debugRCfunProcessing)) {
-                                           if(nimbleOptions()$debugRCfunProcessing) {
-                                               debug <- TRUE
-                                               writeLines('Debugging RCfunProcessing (nimbleOptions()$debugRCfunProcessing is set to TRUE)') 
-                                           }
-                                       }
-
-                                       if(debug) {
-                                           writeLines('**** READY to start RCfunProcessing::process *****')
-                                           browser()
-                                       }
-
-                                       if(is.null(nimbleProject)) nimbleProject <- get('nimbleProject', envir = RCfun)
-                                       
-                                       if(!initialTypeInferenceDone) {
-                                           
-                                           if(!is.null(nimbleOptions()$debugCppLineByLine)) {
-                                               if(nimbleOptions()$debugCppLineByLine) {
-                                                   debugCpp <- TRUE
-                                                   if(length(debugCppLabel) == 0) debugCppLabel <- name
-                                               }
-                                           }
-                                           
-                                           if(doKeywords) {
-                                               matchKeywords()
-                                               processKeywords()
-                                           }
-                                           
-                                           if(inherits(compileInfo$origLocalSymTab, 'uninitializedField')) {
-                                               setupSymbolTables()
-                                           }
-                                           initialTypeInferenceDone <<- TRUE
-                                       }
-                                       if(initialTypeInferenceOnly) return(NULL);
-                                      
-                                       if(debug) {
-                                           writeLines('**** READY FOR makeExprClassObjects *****')
-                                           browser()
-                                       }
-                                       if(length(nameSubList) > 0)
-                                           compileInfo$newRcode <<- nf_substituteExceptFunctionsAndDollarSigns(compileInfo$newRcode, nameSubList)
-                                       ## set up exprClass object
-                                       compileInfo$nimExpr <<- RparseTree2ExprClasses(compileInfo$newRcode)
-                                       
-                                       if(debug) {
-                                           print('nimDeparse(compileInfo$nimExpr)')
-                                           writeCode(nimDeparse(compileInfo$nimExpr))
-                                           writeLines('***** READY FOR processSpecificCalls *****')
-                                           browser()
-                                       }
-
-                                       exprClasses_processSpecificCalls(compileInfo$nimExpr, compileInfo$newLocalSymTab)
-
-                                       if(debug) {
-                                           print('nimDeparse(compileInfo$nimExpr)')
-                                           writeCode(nimDeparse(compileInfo$nimExpr))
-                                           writeLines('***** READY FOR buildInterms *****')
-                                           browser()
-                                       }
-                                       
-                                       ## build intermediate variables
-                                       exprClasses_buildInterms(compileInfo$nimExpr)
-
-                                       if(debug) {
-                                           print('nimDeparse(compileInfo$nimExpr)')
-                                           writeCode(nimDeparse(compileInfo$nimExpr))
-                                           print('compileInfo$newLocalSymTab')
-                                           print(compileInfo$newLocalSymTab)
-                                           writeLines('***** READY FOR initSizes *****')
-                                           browser()
-                                       }
-                                       compileInfo$typeEnv <<- exprClasses_initSizes(compileInfo$nimExpr, compileInfo$newLocalSymTab, returnSymbol = compileInfo$returnSymbol)
-                                       if(debug) {
-                                           print('ls(compileInfo$typeEnv)')
-                                           print(ls(compileInfo$typeEnv))
-                                           print('lapply(compileInfo$typeEnv, function(x) x$show())')
-                                           lapply(compileInfo$typeEnv, function(x) x$show())
-                                           writeLines('***** READY FOR setSizes *****')
-                                           browser()
-                                       }
-
-                                       compileInfo$typeEnv[['neededRCfuns']] <<- list()
-                                       compileInfo$typeEnv[['.AllowUnknowns']] <<- TRUE ## will be FALSE for RHS recursion in setSizes
-                                       compileInfo$typeEnv[['.ensureNimbleBlocks']] <<- FALSE ## will be TRUE for LHS recursion after RHS sees rmnorm and other vector dist "r" calls.
-                                       compileInfo$typeEnv[['.nimbleProject']] <<- nimbleProject
-                                       passedArgNames <- as.list(compileInfo$origLocalSymTab$getSymbolNames()) 
-                                       names(passedArgNames) <- compileInfo$origLocalSymTab$getSymbolNames() 
-                                       compileInfo$typeEnv[['passedArgumentNames']] <<- passedArgNames ## only the names are used.
-                                       compileInfo$typeEnv[['nameSubList']] <<- nameSubList
-
-                                       ## exprClasses_setSizes contains lots of reticulated error trapping.
-                                       ## If options('error') is not NULL (typically options(error = recover)), let that take precedent for error trapping of exprClasses_setSizes.
-                                       ## Otherwise, wrap the setSizes call in our own error-trapping that outputs: any local message from a stop() inside a size handler,
-                                       ##    a message from here showing the larger block of code in which the error occurred, and, if nimbleOptions('verboseErrors') is TRUE, the call stack. 
-                                       if(!is.null(options('error'))) exprClasses_setSizes(compileInfo$nimExpr, compileInfo$newLocalSymTab, compileInfo$typeEnv)
-                                       else tryCatch(withCallingHandlers(exprClasses_setSizes(compileInfo$nimExpr, compileInfo$newLocalSymTab, compileInfo$typeEnv),
-                                                                         error = function(e) {
-                                                                             stack <- sapply(sys.calls(), deparse)
-                                                                             .GlobalEnv$.nimble.traceback <- capture.output(traceback(stack))
-                                                                         }),
-                                                     error = function(e) {
-                                                         eMessage <- if(!is.null(e$message)) paste0(as.character(e$message),"\n") else ""
-                                                         message <- paste(eMessage, 'There was some problem in the the setSizes processing step for this code:',
-                                                                          paste(deparse(compileInfo$origRcode), collapse = '\n'))
-                                                         if(getNimbleOption('verboseErrors')) {
-                                                             message <- paste(message,
-                                                                              'Internal Error:', e,
-                                                                              'Traceback:', paste0(.GlobalEnv$.nimble.traceback, collapse = '\n'),
-                                                                              sep = '\n')
-                                                         }
-                                                         stop(message, call. = FALSE)
-                                                     })
-                                       neededRCfuns <<- c(neededRCfuns, compileInfo$typeEnv[['neededRCfuns']])
-                                       if(debug) {
-                                           print('compileInfo$nimExpr$show(showType = TRUE) -- broken')
-                                           print('compileInfo$nimExpr$show(showAssertions = TRUE) -- possible broken')
-                                           writeLines('***** READY FOR insertAssertions *****')
-                                           browser()
-                                       }
-
-                                       if(nimbleOptions('experimentalNewSizeProcessing')) {
-                                           exprClasses_setToEigenize(compileInfo$nimExpr, compileInfo$newLocalSymTab, compileInfo$typeEnv)
-                                       }
-
-                                       tryResult <- try(exprClasses_insertAssertions(compileInfo$nimExpr))
-                                       if(inherits(tryResult, 'try-error')) {
-                                           stop(paste('There is some problem at the insertAdditions processing step for this code:\n', paste(deparse(compileInfo$origRcode), collapse = '\n'), collapse = '\n'), call. = FALSE)
-                                       }
-                                       
-                                       if(debug) {
-                                           print('compileInfo$nimExpr$show(showAssertions = TRUE)')
-                                           compileInfo$nimExpr$show(showAssertions = TRUE)
-                                           print('compileInfo$nimExpr$show(showToEigenize = TRUE)')
-                                           compileInfo$nimExpr$show(showToEigenize = TRUE)
-                                           print('nimDeparse(compileInfo$nimExpr)')
-                                           writeCode(nimDeparse(compileInfo$nimExpr))
-                                           writeLines('***** READY FOR labelForEigenization *****')
-                                           browser()
-                                       }
-                                       
-                                       tryResult <- try(exprClasses_labelForEigenization(compileInfo$nimExpr))
-                                       if(inherits(tryResult, 'try-error')) {
-                                           stop(paste('There is some problem at the Eigen labeling processing step for this code:\n', paste(deparse(compileInfo$origRcode), collapse = '\n'), collapse = '\n'), call. = FALSE)
-                                       }
-                                       if(debug) {
-                                           print('nimDeparse(compileInfo$nimExpr)')
-                                           writeCode(nimDeparse(compileInfo$nimExpr))
-                                           writeLines('***** READY FOR eigenize *****')
-                                           browser()
-                                       }
-
-                                       tryResult <- try(exprClasses_eigenize(compileInfo$nimExpr, compileInfo$newLocalSymTab, compileInfo$typeEnv))
-                                       if(inherits(tryResult, 'try-error')) {
-                                           stop(paste('There is some problem at the Eigen processing step for this code:\n', paste(deparse(compileInfo$origRcode), collapse = '\n'), collapse = '\n'), call. = FALSE)
-                                       }
-                                       if(debug) {
-                                           print('nimDeparse(compileInfo$nimExpr)')
-                                           writeCode(nimDeparse(compileInfo$nimExpr))
-                                           print('compileInfo$newLocalSymTab')
-                                           print(compileInfo$newLocalSymTab)
-                                           print('ls(compileInfo$typeEnv)')
-                                           print(ls(compileInfo$typeEnv))
-                                           
-                                           writeLines('***** READY FOR liftMaps*****')
-                                           browser()
-                                       }
-
-                                       exprClasses_liftMaps(compileInfo$nimExpr, compileInfo$newLocalSymTab, compileInfo$typeEnv)
-                                       if(debug) {
-                                           print('nimDeparse(compileInfo$nimExpr)')
-                                           writeCode(nimDeparse(compileInfo$nimExpr))
-                                           writeLines('***** READY FOR cppOutput*****')
-                                           browser()
-                                       }
-                                       
-                                       if(debugCpp) {
-                                           if(debug) writeLines('*** Inserting debugging')
-                                           exprClasses_addDebugMarks(compileInfo$nimExpr, paste(debugCppLabel, name))
-                                           if(debug) {
-                                               print('nimDeparse(compileInfo$nimExpr)')
-                                               writeCode(nimDeparse(compileInfo$nimExpr))
-                                               writeLines('***** READY FOR cppOutput*****')
-                                               browser()
-                                           }
-                                       }
-                                       if(debug & debugCpp) {
-                                           print('writeCode(nimGenerateCpp(compileInfo$nimExpr, newMethods$run$newLocalSymTab))')
-                                           writeCode(nimGenerateCpp(compileInfo$nimExpr, compileInfo$newLocalSymTab))
-                                       }
-                                   },
-                                   processKeywords = function(nfProc = NULL) {
-                                       compileInfo$newRcode <<- processKeywords_recurse(compileInfo$origRcode, nfProc)
-                                   },
-                                   matchKeywords = function(nfProc = NULL) {
-                                       compileInfo$origRcode <<- matchKeywords_recurse(compileInfo$origRcode, nfProc) ## nfProc needed for member functions of nf objects
-                                   }
-                                   )
-                               )
+    contains = 'RCvirtualFunProcessing',
+    fields = list(),
+    methods = list(
+        process = function(debug = FALSE, debugCpp = FALSE, debugCppLabel = character(), doKeywords = TRUE, nimbleProject = NULL, initialTypeInferenceOnly = FALSE) {
+            if(!is.null(nimbleOptions()$debugRCfunProcessing)) {
+                if(nimbleOptions()$debugRCfunProcessing) {
+                    debug <- TRUE
+                    writeLines('Debugging RCfunProcessing (nimbleOptions()$debugRCfunProcessing is set to TRUE)') 
+                }
+            }
+    
+            if(debug) {
+                writeLines('**** READY to start RCfunProcessing::process *****')
+                browser()
+            }
+    
+            if(is.null(nimbleProject)) nimbleProject <- get('nimbleProject', envir = RCfun)
+            
+            if(!initialTypeInferenceDone) {
+                
+                if(!is.null(nimbleOptions()$debugCppLineByLine)) {
+                    if(nimbleOptions()$debugCppLineByLine) {
+                        debugCpp <- TRUE
+                        if(length(debugCppLabel) == 0) debugCppLabel <- name
+                    }
+                }
+                
+                if(doKeywords) {
+                    matchKeywords()
+                    processKeywords()
+                }
+                
+                if(inherits(compileInfo$origLocalSymTab, 'uninitializedField')) {
+                    setupSymbolTables()
+                }
+                initialTypeInferenceDone <<- TRUE
+            }
+            if(initialTypeInferenceOnly) return(NULL);
+           
+            if(debug) {
+                writeLines('**** READY FOR makeExprClassObjects *****')
+                browser()
+            }
+            if(length(nameSubList) > 0)
+                compileInfo$newRcode <<- nf_substituteExceptFunctionsAndDollarSigns(compileInfo$newRcode, nameSubList)
+            ## set up exprClass object
+            compileInfo$nimExpr <<- RparseTree2ExprClasses(compileInfo$newRcode)
+            
+            if(debug) {
+                print('nimDeparse(compileInfo$nimExpr)')
+                writeCode(nimDeparse(compileInfo$nimExpr))
+                writeLines('***** READY FOR processSpecificCalls *****')
+                browser()
+            }
+    
+            exprClasses_processSpecificCalls(compileInfo$nimExpr, compileInfo$newLocalSymTab)
+    
+            if(debug) {
+                print('nimDeparse(compileInfo$nimExpr)')
+                writeCode(nimDeparse(compileInfo$nimExpr))
+                writeLines('***** READY FOR buildInterms *****')
+                browser()
+            }
+            
+            ## build intermediate variables
+            exprClasses_buildInterms(compileInfo$nimExpr)
+    
+            if(debug) {
+                print('nimDeparse(compileInfo$nimExpr)')
+                writeCode(nimDeparse(compileInfo$nimExpr))
+                print('compileInfo$newLocalSymTab')
+                print(compileInfo$newLocalSymTab)
+                writeLines('***** READY FOR initSizes *****')
+                browser()
+            }
+            compileInfo$typeEnv <<- exprClasses_initSizes(compileInfo$nimExpr, compileInfo$newLocalSymTab, returnSymbol = compileInfo$returnSymbol)
+            if(debug) {
+                print('ls(compileInfo$typeEnv)')
+                print(ls(compileInfo$typeEnv))
+                print('lapply(compileInfo$typeEnv, function(x) x$show())')
+                lapply(compileInfo$typeEnv, function(x) x$show())
+                writeLines('***** READY FOR setSizes *****')
+                browser()
+            }
+    
+            compileInfo$typeEnv[['neededRCfuns']] <<- list()
+            compileInfo$typeEnv[['.AllowUnknowns']] <<- TRUE ## will be FALSE for RHS recursion in setSizes
+            compileInfo$typeEnv[['.ensureNimbleBlocks']] <<- FALSE ## will be TRUE for LHS recursion after RHS sees rmnorm and other vector dist "r" calls.
+            compileInfo$typeEnv[['.nimbleProject']] <<- nimbleProject
+            passedArgNames <- as.list(compileInfo$origLocalSymTab$getSymbolNames()) 
+            names(passedArgNames) <- compileInfo$origLocalSymTab$getSymbolNames() 
+            compileInfo$typeEnv[['passedArgumentNames']] <<- passedArgNames ## only the names are used.
+            compileInfo$typeEnv[['nameSubList']] <<- nameSubList
+    
+            ## exprClasses_setSizes contains lots of reticulated error trapping.
+            ## If options('error') is not NULL (typically options(error = recover)), let that take precedent for error trapping of exprClasses_setSizes.
+            ## Otherwise, wrap the setSizes call in our own error-trapping that outputs: any local message from a stop() inside a size handler,
+            ##    a message from here showing the larger block of code in which the error occurred, and, if nimbleOptions('verboseErrors') is TRUE, the call stack. 
+            if(!is.null(options('error'))) exprClasses_setSizes(compileInfo$nimExpr, compileInfo$newLocalSymTab, compileInfo$typeEnv)
+            else tryCatch(withCallingHandlers(exprClasses_setSizes(compileInfo$nimExpr, compileInfo$newLocalSymTab, compileInfo$typeEnv),
+                                              error = function(e) {
+                                                  stack <- sapply(sys.calls(), deparse)
+                                                  .GlobalEnv$.nimble.traceback <- capture.output(traceback(stack))
+                                              }),
+                          error = function(e) {
+                              eMessage <- if(!is.null(e$message)) paste0(as.character(e$message),"\n") else ""
+                              message <- paste(eMessage, 'There was some problem in the the setSizes processing step for this code:',
+                                               paste(deparse(compileInfo$origRcode), collapse = '\n'))
+                              if(getNimbleOption('verboseErrors')) {
+                                  message <- paste(message,
+                                                   'Internal Error:', e,
+                                                   'Traceback:', paste0(.GlobalEnv$.nimble.traceback, collapse = '\n'),
+                                                   sep = '\n')
+                              }
+                              stop(message, call. = FALSE)
+                          })
+            neededRCfuns <<- c(neededRCfuns, compileInfo$typeEnv[['neededRCfuns']])
+            if(debug) {
+                print('compileInfo$nimExpr$show(showType = TRUE) -- broken')
+                print('compileInfo$nimExpr$show(showAssertions = TRUE) -- possible broken')
+                writeLines('***** READY FOR insertAssertions *****')
+                browser()
+            }
+    
+            if(nimbleOptions('experimentalNewSizeProcessing')) {
+                exprClasses_setToEigenize(compileInfo$nimExpr, compileInfo$newLocalSymTab, compileInfo$typeEnv)
+            }
+    
+            tryResult <- try(exprClasses_insertAssertions(compileInfo$nimExpr))
+            if(inherits(tryResult, 'try-error')) {
+                stop(paste('There is some problem at the insertAdditions processing step for this code:\n', paste(deparse(compileInfo$origRcode), collapse = '\n'), collapse = '\n'), call. = FALSE)
+            }
+            
+            if(debug) {
+                print('compileInfo$nimExpr$show(showAssertions = TRUE)')
+                compileInfo$nimExpr$show(showAssertions = TRUE)
+                print('compileInfo$nimExpr$show(showToEigenize = TRUE)')
+                compileInfo$nimExpr$show(showToEigenize = TRUE)
+                print('nimDeparse(compileInfo$nimExpr)')
+                writeCode(nimDeparse(compileInfo$nimExpr))
+                writeLines('***** READY FOR labelForEigenization *****')
+                browser()
+            }
+            
+            tryResult <- try(exprClasses_labelForEigenization(compileInfo$nimExpr))
+            if(inherits(tryResult, 'try-error')) {
+                stop(paste('There is some problem at the Eigen labeling processing step for this code:\n', paste(deparse(compileInfo$origRcode), collapse = '\n'), collapse = '\n'), call. = FALSE)
+            }
+            if(debug) {
+                print('nimDeparse(compileInfo$nimExpr)')
+                writeCode(nimDeparse(compileInfo$nimExpr))
+                writeLines('***** READY FOR eigenize *****')
+                browser()
+            }
+    
+            tryResult <- try(exprClasses_eigenize(compileInfo$nimExpr, compileInfo$newLocalSymTab, compileInfo$typeEnv))
+            if(inherits(tryResult, 'try-error')) {
+                stop(paste('There is some problem at the Eigen processing step for this code:\n', paste(deparse(compileInfo$origRcode), collapse = '\n'), collapse = '\n'), call. = FALSE)
+            }
+            if(debug) {
+                print('nimDeparse(compileInfo$nimExpr)')
+                writeCode(nimDeparse(compileInfo$nimExpr))
+                print('compileInfo$newLocalSymTab')
+                print(compileInfo$newLocalSymTab)
+                print('ls(compileInfo$typeEnv)')
+                print(ls(compileInfo$typeEnv))
+                
+                writeLines('***** READY FOR liftMaps*****')
+                browser()
+            }
+    
+            exprClasses_liftMaps(compileInfo$nimExpr, compileInfo$newLocalSymTab, compileInfo$typeEnv)
+            if(debug) {
+                print('nimDeparse(compileInfo$nimExpr)')
+                writeCode(nimDeparse(compileInfo$nimExpr))
+                writeLines('***** READY FOR cppOutput*****')
+                browser()
+            }
+            
+            if(debugCpp) {
+                if(debug) writeLines('*** Inserting debugging')
+                exprClasses_addDebugMarks(compileInfo$nimExpr, paste(debugCppLabel, name))
+                if(debug) {
+                    print('nimDeparse(compileInfo$nimExpr)')
+                    writeCode(nimDeparse(compileInfo$nimExpr))
+                    writeLines('***** READY FOR cppOutput*****')
+                    browser()
+                }
+            }
+            if(debug & debugCpp) {
+                print('writeCode(nimGenerateCpp(compileInfo$nimExpr, newMethods$run$newLocalSymTab))')
+                writeCode(nimGenerateCpp(compileInfo$nimExpr, compileInfo$newLocalSymTab))
+            }
+        },
+        processKeywords = function(nfProc = NULL) {
+            compileInfo$newRcode <<- processKeywords_recurse(compileInfo$origRcode, nfProc)
+        },
+        matchKeywords = function(nfProc = NULL) {
+            compileInfo$origRcode <<- matchKeywords_recurse(compileInfo$origRcode, nfProc) ## nfProc needed for member functions of nf objects
+        }
+    )
+)

--- a/packages/nimble/R/genCpp_RparseTree2exprClasses.R
+++ b/packages/nimble/R/genCpp_RparseTree2exprClasses.R
@@ -20,7 +20,7 @@ embedListInRbracket <- function(code) {
 ## caller and callerArgID are for recursion, not to be used on first entry
 RparseTree2ExprClasses <- function(code, caller = NULL, callerArgID = numeric()) { ## input code is R parse tree
     ## name:
-    if(is.name(code)) return(exprClass(expr = code, isName = TRUE, isCall = FALSE, isAssign = FALSE, name = as.character(code), caller = caller, callerArgID = callerArgID))
+    if(is.name(code)) return(exprClass$new(expr = code, isName = TRUE, isCall = FALSE, isAssign = FALSE, name = as.character(code), caller = caller, callerArgID = callerArgID))
     ## call
     if(is.call(code)) {
         if(is.call(code[[1]])) { ## chained calls like a(b)(c) or a[[b]](c).  We wrap these as chainedCall(a(b), c) or chainedCall(a[[b]], c)
@@ -30,7 +30,7 @@ RparseTree2ExprClasses <- function(code, caller = NULL, callerArgID = numeric())
         isAssign <- name %in% c('<-','=','<<-')
         args <- vector('list', length = length(code)-1)
         ## build the object
-        ans <- exprClass(expr = code, isName = FALSE, isCall = TRUE, isAssign = isAssign, name = name, args = args, caller = caller, callerArgID = callerArgID)
+        ans <- exprClass$new(expr = code, isName = FALSE, isCall = TRUE, isAssign = isAssign, name = name, args = args, caller = caller, callerArgID = callerArgID)
 
         ## Ensure that bodies of for and if are in { expressions.  Makes for less special-case checking in later processing
         if(name == 'for') {

--- a/packages/nimble/R/genCpp_eigenization.R
+++ b/packages/nimble/R/genCpp_eigenization.R
@@ -642,7 +642,7 @@ eigenize_cWiseAddSub <- function(code, symTab, typeEnv, workEnv) {
 }
 
 eigenizeArrayize <- function(code) {
-    newExpr <- exprClass(name = 'eigArray', args = list(code), eigMatrix = FALSE,
+    newExpr <- exprClass$new(name = 'eigArray', args = list(code), eigMatrix = FALSE,
                          isName = FALSE, isCall = TRUE, isAssign = FALSE,
                          nDim = code$nDim, sizeExprs = code$sizeExprs, type = code$type,
                          caller = code$caller, callerArgID = code$callerArgID)
@@ -652,7 +652,7 @@ eigenizeArrayize <- function(code) {
 }
 
 eigenizeMatricize <- function(code) {
-    newExpr <- exprClass(name = 'eigMatrix', args = list(code), eigMatrix = TRUE,
+    newExpr <- exprClass$new(name = 'eigMatrix', args = list(code), eigMatrix = TRUE,
                          isName = FALSE, isCall = TRUE, isAssign = FALSE,
                          nDim = code$nDim, sizeExprs = code$sizeExprs, type = code$type,
                          caller = code$caller, callerArgID = code$callerArgID)

--- a/packages/nimble/R/genCpp_processSpecificCalls.R
+++ b/packages/nimble/R/genCpp_processSpecificCalls.R
@@ -135,8 +135,8 @@ declareHandler <- function(code, symTab) {
     if(length(typeDeclExpr$args) > 1) {
         newExprs <- vector('list', length(newNames))
         for(i in seq_along(newNames)) {
-            nameExpr <- exprClass(name = newNames[i], isCall = FALSE, isName = TRUE, isAssign = FALSE, args = list())
-            newExprs[[i]] <- exprClass(name = 'setSize', isCall = TRUE, isName = FALSE,
+            nameExpr <- exprClass$new(name = newNames[i], isCall = FALSE, isName = TRUE, isAssign = FALSE, args = list())
+            newExprs[[i]] <- exprClass$new(name = 'setSize', isCall = TRUE, isName = FALSE,
                                        isAssign = FALSE, args = c(list(nameExpr), sizeExprs),
                                        caller = code$caller, callerArgID = code$callerArgID)
             for(j in seq_along(newExprs[[i]]$args)) {
@@ -149,7 +149,7 @@ declareHandler <- function(code, symTab) {
         newBrackExpr <- newBracketExpr(newExprs)
         setArg(code$caller, code$callerArgID, newBrackExpr)
     } else {
-        code$caller$args[[code$callerArgID]] <- exprClass(name = 'blank', isCall = TRUE, isName = FALSE, isAssign = FALSE, args = list(),
+        code$caller$args[[code$callerArgID]] <- exprClass$new(name = 'blank', isCall = TRUE, isName = FALSE, isAssign = FALSE, args = list(),
                                                           caller = code$caller, callerArgID = code$callerArgID)
     }
 }

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -461,8 +461,8 @@ sizeConcatenate <- function(code, symTab, typeEnv) { ## This is two argument ver
             ## Construct:
             ## concatenateTemp(ConcatenateInterm_1),
             ##   concatenateTemp is not output to C++. It is a placeholder
-            newExpr <- exprClass(isName = FALSE, isCall = TRUE, isAssign = FALSE, name = "concatenateTemp", nDim = 1, sizeExprs = list(thisLength), type = 'double')
-            setArg(newExpr, 1, exprClass(isName = TRUE, isCall = FALSE, isAssign = FALSE, name = newTempVecName, nDim = 1, sizeExprs = list(thisLength), type = 'double'))
+            newExpr <- exprClass$new(isName = FALSE, isCall = TRUE, isAssign = FALSE, name = "concatenateTemp", nDim = 1, sizeExprs = list(thisLength), type = 'double')
+            setArg(newExpr, 1, exprClass$new(isName = TRUE, isCall = FALSE, isAssign = FALSE, name = newTempVecName, nDim = 1, sizeExprs = list(thisLength), type = 'double'))
 
             ## hardCodedVectorInitializer is a wrapper for the "contents1, contents2, ..." below 
             valuesExpr <- quote(hardCodedVectorInitializer())
@@ -521,7 +521,7 @@ sizeConcatenate <- function(code, symTab, typeEnv) { ## This is two argument ver
 
     newExprList <- vector(numArgGroups, mode = 'list')
     for(i in seq_along(splitArgIDs)) {
-        newExprList[[i]] <- exprClass(isName = FALSE, isCall = TRUE, isAssign = FALSE, name = 'nimC', nDim = 1, toEigenize = 'yes', type = 'double')
+        newExprList[[i]] <- exprClass$new(isName = FALSE, isCall = TRUE, isAssign = FALSE, name = 'nimC', nDim = 1, toEigenize = 'yes', type = 'double')
         for(j in seq_along(splitArgIDs[[i]])) setArg(newExprList[[i]], j, newArgs[[splitArgIDs[[i]][j]]])
     }
 
@@ -2305,7 +2305,7 @@ sizeIndexingBracket <- function(code, symTab, typeEnv) {
                     if(!indexIsScalar) warning("There is nested indexing with drop=FALSE where an index must be scalar but isn't")
                 } else {
                     ## construct i[k], which is really nimNonseqIndexedi(i, k)
-                    newExpr <- exprClass(name = 'nimNonseqIndexedi', isName = FALSE, isCall = TRUE, isAssign = FALSE)
+                    newExpr <- exprClass$new(name = 'nimNonseqIndexedi', isName = FALSE, isCall = TRUE, isAssign = FALSE)
                     newExpr$type <- 'integer'
                     indexIsScalar <- if(inherits(code$args[[iInd+1]], 'exprClass')) code$args[[iInd+1]]$nDim == 0 else TRUE
                     newExpr$sizeExprs <- if(!indexIsScalar) c(code$args[[iInd + 1]]$sizeExprs) else list(1)

--- a/packages/nimble/R/nimbleFunction_compile.R
+++ b/packages/nimble/R/nimbleFunction_compile.R
@@ -1,218 +1,218 @@
 virtualNFprocessing <- setRefClass('virtualNFprocessing',
-                                   fields = list(
-                                       name = 'ANY',                    ## character
-                                       setupSymTab = 'ANY',             ## symbolTable
-                                       nfGenerator =  'ANY',		## 'function',
-                                       compileInfos =  'ANY',		## list of RCfunctionCompileClass objects
-                                       origMethods = 'ANY',             ## list of original methods
-                                       RCfunProcs =  'ANY',		## list of RCfunProcessing  or RCvirtualFunProcessing objects
-                                       nimbleProject = 'ANY',           ## nimbleProjectclass object
-                                       cppDef = 'ANY',                  ## cppNimbleFunctionClass or cppVirtualNimbleFunctionClass object
-                                       isNode = 'ANY'                  ## logical, is it a nodeFunction?
-                                   ),
-                                   methods = list(
-                                       show = function() {
-                                           writeLines(paste0('virtualNFprocessing object ', name))
-                                       },
-                                       initialize = function(f = NULL, className, virtual = TRUE, isNode = FALSE, project = NULL) {
-                                           nimbleProject <<- project
-                                       		compileInfos <<- list()
-                                       		RCfunProcs <<- list()
-                                       		
-                                       		isNode <<- isNode
-
-                                           if(!is.null(f)) { ## This allows successful default instantiation by R when defining nfProcessing below -- crazy
-                                               ## nfGenerator allowed if it is a nimbleFunctionVirtual
-                                               if(is.nf(f) | is.nfGenerator(f)) nfGenerator <<- nf_getGeneratorFunction(f)
-                                               else if(inherits(f, 'list')) {
-                                                   if(length(unique(lapply(f, nfGetDefVar, 'name'))) != 1)
-                                                       stop('Error with list of instances not having same nfGenerator')
-                                                   nfGenerator <<- nf_getGeneratorFunction(f[[1]])
-                                               }
-                                               if(missing(className)) {
-                                                   sf <- environment(nfGenerator)$name
-                                                   name <<- Rname2CppName(sf)
-                                               } else {
-                                                   name <<- className
-                                               }
-                                               origMethods <<- nf_getMethodList(nfGenerator)
-                                               RCfunProcs <<- list()
-                                               for(i in seq_along(origMethods)) {
-                                                   RCname <- names(origMethods)[i]
-                                                   if(isNode && strsplit(RCname, '_', fixed = TRUE)[[1]][1] == getCalcADFunName()) constFlag <- FALSE
-                                                   else constFlag <- isNode
-                                                   RCfunProcs[[RCname]] <<- if(virtual) RCvirtualFunProcessing$new(origMethods[[i]], RCname, const = constFlag) else RCfunProcessing$new(origMethods[[i]], RCname, const = constFlag)
-                                               }
-                                               compileInfos <<- lapply(RCfunProcs,
-                                                                       function(x) x$compileInfo)
-                                           }
-                                        },
-                                       setupLocalSymbolTables = function() {
-                                           for(i in seq_along(RCfunProcs)) {
-                                               RCfunProcs[[i]]$setupSymbolTables(parentST = setupSymTab, neededTypes = list(), nimbleProject = nimbleProject)
-                                           }
-                                       },
-                                       doRCfunProcess = function(control = list(debug = FALSE, debugCpp = FALSE)) {
-                                           for(i in seq_along(RCfunProcs)) {
-                                               RCfunProcs[[i]]$process(debug = control$debug, debugCpp = control$debugCpp, debugCppLabel = name, doKeywords = FALSE, nimbleProject = nimbleProject)
-                                           }
-                                       },
-                                       addMemberFunctionsToSymbolTable = function() {
-                                           for(i in seq_along(origMethods)) {
-                                               thisName <- names(origMethods)[i]
-                                               newSym <- symbolMemberFunction(name = thisName, nfMethodRCobj = origMethods[[i]], RCfunProc = RCfunProcs[[i]])
-                                               setupSymTab$addSymbol(newSym)
-                                           }
-                                       },
-                                       process = function(control = list(debug = FALSE, debugCpp = FALSE)) {
-                                           setupSymTab <<- symbolTable(parentST = NULL)
-                                           addMemberFunctionsToSymbolTable()
-                                           setupLocalSymbolTables()
-                                           doRCfunProcess(control)
-                                       }
-                                       )
-                                   )
+    fields = list(
+        name = 'ANY',                    ## character
+        setupSymTab = 'ANY',             ## symbolTable
+        nfGenerator =  'ANY',		## 'function',
+        compileInfos =  'ANY',		## list of RCfunctionCompileClass objects
+        origMethods = 'ANY',             ## list of original methods
+        RCfunProcs =  'ANY',		## list of RCfunProcessing  or RCvirtualFunProcessing objects
+        nimbleProject = 'ANY',           ## nimbleProjectclass object
+        cppDef = 'ANY',                  ## cppNimbleFunctionClass or cppVirtualNimbleFunctionClass object
+        isNode = 'ANY'                  ## logical, is it a nodeFunction?
+    ),
+    methods = list(
+        show = function() {
+            writeLines(paste0('virtualNFprocessing object ', name))
+        },
+        initialize = function(f = NULL, className, virtual = TRUE, isNode = FALSE, project = NULL) {
+            nimbleProject <<- project
+            compileInfos <<- list()
+            RCfunProcs <<- list()
+            
+            isNode <<- isNode
+    
+            if(!is.null(f)) { ## This allows successful default instantiation by R when defining nfProcessing below -- crazy.
+                ## nfGenerator is allowed if it is a nimbleFunctionVirtual.
+                if(is.nf(f) | is.nfGenerator(f)) nfGenerator <<- nf_getGeneratorFunction(f)
+                else if(inherits(f, 'list')) {
+                    if(length(unique(lapply(f, nfGetDefVar, 'name'))) != 1)
+                        stop('Error with list of instances not having same nfGenerator')
+                    nfGenerator <<- nf_getGeneratorFunction(f[[1]])
+                }
+                if(missing(className)) {
+                    sf <- environment(nfGenerator)$name
+                    name <<- Rname2CppName(sf)
+                } else {
+                    name <<- className
+                }
+                origMethods <<- nf_getMethodList(nfGenerator)
+                RCfunProcs <<- list()
+                for(i in seq_along(origMethods)) {
+                    RCname <- names(origMethods)[i]
+                    if(isNode && strsplit(RCname, '_', fixed = TRUE)[[1]][1] == getCalcADFunName()) constFlag <- FALSE
+                    else constFlag <- isNode
+                    RCfunProcs[[RCname]] <<- if(virtual) RCvirtualFunProcessing$new(origMethods[[i]], RCname, const = constFlag) else RCfunProcessing$new(origMethods[[i]], RCname, const = constFlag)
+                }
+                compileInfos <<- lapply(RCfunProcs,
+                                        function(x) x$compileInfo)
+            }
+         },
+        setupLocalSymbolTables = function() {
+            for(i in seq_along(RCfunProcs)) {
+                RCfunProcs[[i]]$setupSymbolTables(parentST = setupSymTab, neededTypes = list(), nimbleProject = nimbleProject)
+            }
+        },
+        doRCfunProcess = function(control = list(debug = FALSE, debugCpp = FALSE)) {
+            for(i in seq_along(RCfunProcs)) {
+                RCfunProcs[[i]]$process(debug = control$debug, debugCpp = control$debugCpp, debugCppLabel = name, doKeywords = FALSE, nimbleProject = nimbleProject)
+            }
+        },
+        addMemberFunctionsToSymbolTable = function() {
+            for(i in seq_along(origMethods)) {
+                thisName <- names(origMethods)[i]
+                newSym <- symbolMemberFunction(name = thisName, nfMethodRCobj = origMethods[[i]], RCfunProc = RCfunProcs[[i]])
+                setupSymTab$addSymbol(newSym)
+            }
+        },
+        process = function(control = list(debug = FALSE, debugCpp = FALSE)) {
+            setupSymTab <<- symbolTable(parentST = NULL)
+            addMemberFunctionsToSymbolTable()
+            setupLocalSymbolTables()
+            doRCfunProcess(control)
+        }
+    )
+)
 
 
 nfProcessing <- setRefClass('nfProcessing',
-                            contains = 'virtualNFprocessing',
-                            fields = list(
-                                instances = 'ANY',           ## list of instances of the nimbleFunction to used for setup types and receive newSetupCode
-                                neededTypes =  'ANY',	     ## list of symbols for non-trivial types that will be needed for compilation, such as derived models or modelValues
-                              neededObjectNames =  'ANY',     ## character vector of the names of objects such as models or modelValues that need to exist during C++ instantiation and population so their contents can be pointed to 
-                                newSetupOutputNames =  'ANY', ## character vector of names of objects created by newSetupCode from "keyword processing"
-                                blockFromCppNames = 'ANY',    ## character vector of names of setup outputs that should not be propagated to C++
-                                newSetupCode =  'ANY',	      ## list of lines of setup code populated by keyword processing
-                                newSetupCodeOneExpr = 'ANY',  ## all lines of new setup code put into one expression for evaluation
-                                inModel =  'ANY'	      ## logical: whether this nfProcessing object is for a nodeFunction in a model
-                              ),
-                          methods = list(
-                              show = function() {
-                                  writeLines(paste0('nfProcessing object ', name))
-                              },
-                              initialize = function(f = NULL, className, fromModel = FALSE, project, isNode = FALSE) {
-                                  neededTypes <<- list()
-                                  neededObjectNames <<- character()
-                                  newSetupCode <<- list()
-                                  if(!is.null(f)) {
-                                      ## f must be a specialized nf, or a list of them
-                                      inModel <<- fromModel
-                                      if(missing(className)) {
-                                          sf <- if(is.list(f)) nfGetDefVar(f[[1]], 'name') else nfGetDefVar(f, 'name')
-                                          name <<- Rname2CppName(sf)
-                                      } else {
-                                          name <<- className
-                                      }
-                                      callSuper(f, name, virtual = FALSE, isNode = isNode, project = project)
-                                      instances <<- if(inherits(f, 'list')) lapply(f, nf_getRefClassObject) else list(nf_getRefClassObject(f))
-                                     
-                                      newSetupOutputNames <<- character()
-                                      blockFromCppNames <<- character()
-                                      newSetupCode <<- list()
-                                  }
-                              },
+    contains = 'virtualNFprocessing',
+    fields = list(
+        instances = 'ANY',           ## list of instances of the nimbleFunction to used for setup types and receive newSetupCode
+        neededTypes =  'ANY',	     ## list of symbols for non-trivial types that will be needed for compilation, such as derived models or modelValues
+        neededObjectNames =  'ANY',     ## character vector of the names of objects such as models or modelValues that need to exist during C++ instantiation and population so their contents can be pointed to 
+        newSetupOutputNames =  'ANY', ## character vector of names of objects created by newSetupCode from "keyword processing"
+        blockFromCppNames = 'ANY',    ## character vector of names of setup outputs that should not be propagated to C++
+        newSetupCode =  'ANY',	      ## list of lines of setup code populated by keyword processing
+        newSetupCodeOneExpr = 'ANY',  ## all lines of new setup code put into one expression for evaluation
+        inModel =  'ANY'	      ## logical: whether this nfProcessing object is for a nodeFunction in a model
+    ),
+    methods = list(
+        show = function() {
+            writeLines(paste0('nfProcessing object ', name))
+        },
+        initialize = function(f = NULL, className, fromModel = FALSE, project, isNode = FALSE) {
+            neededTypes <<- list()
+            neededObjectNames <<- character()
+            newSetupCode <<- list()
+            if(!is.null(f)) {
+                ## f must be a specialized nf, or a list of them
+                inModel <<- fromModel
+                if(missing(className)) {
+                    sf <- if(is.list(f)) nfGetDefVar(f[[1]], 'name') else nfGetDefVar(f, 'name')
+                    name <<- Rname2CppName(sf)
+                } else {
+                    name <<- className
+                }
+                callSuper(f, name, virtual = FALSE, isNode = isNode, project = project)
+                instances <<- if(inherits(f, 'list')) lapply(f, nf_getRefClassObject) else list(nf_getRefClassObject(f))
+               
+                newSetupOutputNames <<- character()
+                blockFromCppNames <<- character()
+                newSetupCode <<- list()
+            }
+        },
 
-                              getSymbolTable = function() setupSymTab,
-                              getMethodInterfaces = function() origMethods,
-                              
-                              processKeywords_all = function(){},
-                              matchKeywords_all = function(){},
-                              
-                              doSetupTypeInference_processNF = function() {},
-                              makeTypeObject = function() {},
-                              replaceCall = function() {},
-                              evalNewSetupLines = function(){},
-                              makeNewSetupLinesOneExpr = function() {},
-                              evalNewSetupLinesOneInstance = function(instances, check = FALSE){},
-                              setupTypesForUsingFunction = function(){},
-                              doSetupTypeInference = function(){},
-                              clearSetupOutputs = function() {},
-                              
-                              setupLocalSymbolTables = function() {
-                                  for(i in seq_along(RCfunProcs)) {
-                                      RCfunProcs[[i]]$setupSymbolTables(parentST = setupSymTab, neededTypes = neededTypes, nimbleProject = nimbleProject)
-                                  }
-                              },
-                              collectRCfunNeededTypes = function() {
-                                  for(i in seq_along(RCfunProcs)) {
-                                      for(j in names(RCfunProcs[[i]]$neededRCfuns)) {
-                                          if(is.null(neededTypes[[j]])) {
-                                              neededTypes[[j]] <<- RCfunProcs[[i]]$neededRCfuns[[j]]
-                                          }
-                                      }
-                                      ## could clear RCfunProc[[i]]$neededRCtypes, but instead will prevent them from being used at compilation
-                                  }
-                              },
-                              addBaseClassTypes = function() {
-                                  ## If this class has a virtual base class, we add it to the needed types here
-                                  contains <- environment(nfGenerator)$contains
-                                  if(!is.null(contains)) {
-                                      className <- environment(contains)$className
-                                      nfp <- nimbleProject$setupVirtualNimbleFunction(contains, fromModel = inModel)
-                                      newSym <- symbolNimbleFunction(name = name, type = 'nimbleFunctionVirtual', nfProc = nfp) 
-                                      if(!(className %in% names(neededTypes))) neededTypes[[className]] <<- newSym
-                                  }
-                              },
-                              process = function(control = list(debug = FALSE, debugCpp = FALSE)) {
-                                  ## Modifications to R code
-                                  debug <- control$debug
-                                  debugCpp <- control$debugCpp
-                                  if(!is.null(nimbleOptions()$debugNFProcessing)) {
-                                      if(nimbleOptions()$debugNFProcessing) {
-                                          debug <- TRUE
-                                          control$debug <- TRUE
-                                          writeLines('Debugging nfProcessing (nimbleOptions()$debugRCfunProcessing is set to TRUE)') 
-                                      }
-                                  }
-                                  
-                                  if(debug) {
-                                      print('setupSymTab')
-                                      print(setupSymTab)
-                                      
-                                      writeLines('***** READY FOR replaceModelSingleValues *****')
-                                      browser()
-                                  }
+        getSymbolTable = function() setupSymTab,
+        getMethodInterfaces = function() origMethods,
+        
+        processKeywords_all = function(){},
+        matchKeywords_all = function(){},
+        
+        doSetupTypeInference_processNF = function() {},
+        makeTypeObject = function() {},
+        replaceCall = function() {},
+        evalNewSetupLines = function(){},
+        makeNewSetupLinesOneExpr = function() {},
+        evalNewSetupLinesOneInstance = function(instances, check = FALSE){},
+        setupTypesForUsingFunction = function(){},
+        doSetupTypeInference = function(){},
+        clearSetupOutputs = function() {},
+        
+        setupLocalSymbolTables = function() {
+            for(i in seq_along(RCfunProcs)) {
+                RCfunProcs[[i]]$setupSymbolTables(parentST = setupSymTab, neededTypes = neededTypes, nimbleProject = nimbleProject)
+            }
+        },
+        collectRCfunNeededTypes = function() {
+            for(i in seq_along(RCfunProcs)) {
+                for(j in names(RCfunProcs[[i]]$neededRCfuns)) {
+                    if(is.null(neededTypes[[j]])) {
+                        neededTypes[[j]] <<- RCfunProcs[[i]]$neededRCfuns[[j]]
+                    }
+                }
+                ## could clear RCfunProc[[i]]$neededRCtypes, but instead will prevent them from being used at compilation
+            }
+        },
+        addBaseClassTypes = function() {
+            ## If this class has a virtual base class, we add it to the needed types here
+            contains <- environment(nfGenerator)$contains
+            if(!is.null(contains)) {
+                className <- environment(contains)$className
+                nfp <- nimbleProject$setupVirtualNimbleFunction(contains, fromModel = inModel)
+                newSym <- symbolNimbleFunction(name = name, type = 'nimbleFunctionVirtual', nfProc = nfp) 
+                if(!(className %in% names(neededTypes))) neededTypes[[className]] <<- newSym
+            }
+        },
+        process = function(control = list(debug = FALSE, debugCpp = FALSE)) {
+            ## Modifications to R code
+            debug <- control$debug
+            debugCpp <- control$debugCpp
+            if(!is.null(nimbleOptions()$debugNFProcessing)) {
+                if(nimbleOptions()$debugNFProcessing) {
+                    debug <- TRUE
+                    control$debug <- TRUE
+                    writeLines('Debugging nfProcessing (nimbleOptions()$debugRCfunProcessing is set to TRUE)') 
+                }
+            }
+            
+            if(debug) {
+                print('setupSymTab')
+                print(setupSymTab)
+                
+                writeLines('***** READY FOR replaceModelSingleValues *****')
+                browser()
+            }
 
-                                  if(inherits(setupSymTab, 'uninitializedField')) {
-                                      ## This step could have already been done if the types were needed by another nimbleFunction
-                                      setupTypesForUsingFunction()
-                                  }
+            if(inherits(setupSymTab, 'uninitializedField')) {
+                ## This step could have already been done if the types were needed by another nimbleFunction
+                setupTypesForUsingFunction()
+            }
 
-                                  if(debug) browser()
-                                  makeNewSetupLinesOneExpr()
-                                  
-                                  evalNewSetupLines()
-								
-                                  if(debug) {
-                                      print('setupSymTab')
-                                      print(setupSymTab) 
-                                      print('newSetupOutputNames')
-                                      print(newSetupOutputNames)
-                                      print('newSetupCode')
-                                      print(newSetupCode)
-                                      writeLines('***** READY FOR doSetupTypeInference *****')
-                                      browser()
-                                  }
-                                  doSetupTypeInference(setupOrig = FALSE, setupNew = TRUE)
-                                  
-                                  if(debug) {
-                                      print('lapply(compileInfos, function(x) print(x$newLocalSymTab))')
-                                      lapply(compileInfos, function(x) print(x$newLocalSymTab))
-                                      writeLines('**** READY FOR RFfunProcessing *****')
-                                      browser()
-                                  }
+            if(debug) browser()
+            makeNewSetupLinesOneExpr()
+            
+            evalNewSetupLines()
 
-                                  doRCfunProcess(control)
+            if(debug) {
+                print('setupSymTab')
+                print(setupSymTab) 
+                print('newSetupOutputNames')
+                print(newSetupOutputNames)
+                print('newSetupCode')
+                print(newSetupCode)
+                writeLines('***** READY FOR doSetupTypeInference *****')
+                browser()
+            }
+            doSetupTypeInference(setupOrig = FALSE, setupNew = TRUE)
+            
+            if(debug) {
+                print('lapply(compileInfos, function(x) print(x$newLocalSymTab))')
+                lapply(compileInfos, function(x) print(x$newLocalSymTab))
+                writeLines('**** READY FOR RFfunProcessing *****')
+                browser()
+            }
 
-                                  collectRCfunNeededTypes()
+            doRCfunProcess(control)
 
-                                  if(debug) {
-                                      print('done with RCfunProcessing')
-                                      browser()
-                                  }
-                              }
-                              )
-                          )
+            collectRCfunNeededTypes()
+
+            if(debug) {
+                print('done with RCfunProcessing')
+                browser()
+            }
+        }
+    )
+)
 
 nfProcessing$methods(evalNewSetupLines = function() {
     if(length(instances) == 0)      { warning('No specialized instances of nimble function');   return() }

--- a/packages/nimble/R/nimbleProject.R
+++ b/packages/nimble/R/nimbleProject.R
@@ -3,1037 +3,1039 @@
 projectNameCreator <- labelFunctionCreator('P')
 
 nfCompilationInfoClass <- setRefClass('nfCompilationInfoClass',
-                                      fields = list(
-                                          nfProc = 		'ANY',      ## an nfProcessing object 
-                                          nfGenerator = 'ANY', ## a nfGenerator, which is a function with special stuff in its environment
-                                          cppDef = 'ANY',       ## a cppNimbleFunctionClass object
-                                          labelMaker = 'ANY',    ## a label maker function
-                                          virtual =  'ANY',		#'logical',
-                                          RinitTypesProcessed = 'ANY',		# 'logical', ## setupTypesForUsingFunction() 
-                                          Rcompiled =  'ANY',		#'logical',
-                                          written =  'ANY',		#'logical',
-                                          cppCompiled =  'ANY',		#'logical',
-                                          loaded =  'ANY',		#'logical',
-                                          fromModel =  'ANY',		#'logical',
-                                          Rinstances =  'ANY'		#'list'
-                                          ),
-                                      methods = list(
-                                      		initialize = function(...){Rinstances <<- list(); callSuper(...)},
-                                          addRinstance = function(nfi) {Rinstances[[ length(Rinstances)+1 ]] <<- nfi},
-                                          addRinstanceList = function(nfList) {Rinstances[length(Rinstances) + seq_along(nfList)] <<- nfList}
-                                          ))
+    fields = list(
+        nfProc = 		'ANY',      ## an nfProcessing object 
+        nfGenerator = 'ANY', ## a nfGenerator, which is a function with special stuff in its environment
+        cppDef = 'ANY',       ## a cppNimbleFunctionClass object
+        labelMaker = 'ANY',    ## a label maker function
+        virtual =  'ANY',		#'logical',
+        RinitTypesProcessed = 'ANY',		# 'logical', ## setupTypesForUsingFunction() 
+        Rcompiled =  'ANY',		#'logical',
+        written =  'ANY',		#'logical',
+        cppCompiled =  'ANY',		#'logical',
+        loaded =  'ANY',		#'logical',
+        fromModel =  'ANY',		#'logical',
+        Rinstances =  'ANY'		#'list'
+    ),
+    methods = list(
+        initialize = function(...){Rinstances <<- list(); callSuper(...)},
+        addRinstance = function(nfi) {Rinstances[[ length(Rinstances)+1 ]] <<- nfi},
+        addRinstanceList = function(nfList) {Rinstances[length(Rinstances) + seq_along(nfList)] <<- nfList}
+    )
+)
 
 nlCompilationInfoClass <- setRefClass('nlCompilationInfoClass',
-                                      fields = list(
-                                          nlProc = 'ANY',
-                                          cppDef = 'ANY',       ## a cppNimbleFunctionClass object
-                                          written =  'ANY',		#'logical'
-                                          loaded = 'ANY',
-                                          cppCompiled =  'ANY',		#'logical'
-                                          labelMaker = 'ANY', ## a label maker function
-                                          RinitTypesProcessed = 'ANY',		# 'logical', ## setupTypesForUsingFunction() 
-                                          Rcompiled = 'ANY'   # 'logical'
-                                      ),
-                                      methods = list(
-                                          initialize = function(...){callSuper(...)}
-                                      ))
+    fields = list(
+        nlProc = 'ANY',
+        cppDef = 'ANY',       ## a cppNimbleFunctionClass object
+        written =  'ANY',		#'logical'
+        loaded = 'ANY',
+        cppCompiled =  'ANY',		#'logical'
+        labelMaker = 'ANY', ## a label maker function
+        RinitTypesProcessed = 'ANY',		# 'logical', ## setupTypesForUsingFunction() 
+        Rcompiled = 'ANY'   # 'logical'
+    ),
+    methods = list(
+        initialize = function(...){callSuper(...)}
+    )
+)
 
 mvInfoClass <- setRefClass('mvInfoClass',
-                           fields = list(
-                               mvConf = 'ANY', ## a custom modelValues class
-                               cppClassName =  'ANY',		#'character',
-                               cppClass = 'ANY', ## a cppModelValuesClass object,
-                               fromModel =  'ANY',		#'logical',
-                               RmvObjs =  'ANY'		#'list'
-                               ),
-                           methods = list(
-                           		initialize = function(...){RmvObjs <<- list(); callSuper(...)},
-                               addRmv = function(Rmv) RmvObjs[[length(RmvObjs)+1]] <<- Rmv))
+    fields = list(
+        mvConf = 'ANY', ## a custom modelValues class
+        cppClassName =  'ANY',		#'character',
+        cppClass = 'ANY', ## a cppModelValuesClass object,
+        fromModel =  'ANY',		#'logical',
+        RmvObjs =  'ANY'		#'list'
+        ),
+    methods = list(
+        initialize = function(...) {
+            RmvObjs <<- list()
+            callSuper(...)
+        },
+        addRmv = function(Rmv) RmvObjs[[length(RmvObjs)+1]] <<- Rmv
+    )
+)
 
 RCfunInfoClass <- setRefClass('RCfunInfoClass',
-                              fields = list(
-                                  nfMethodRCobj = 'ANY', ## an mfMethodRC
-                                  RCfunProc     = 'ANY', ## an RCfunProcessing or NULL
-                                  cppClass      = 'ANY',  ## an RCfunctionDef or NULL
-                                  RinitTypesProcessed = 'ANY',
-                                  Rcompiled           = 'ANY',
-                                  fromModel     =  'ANY'		#'logical'
-                                  ))
+    fields = list(
+        nfMethodRCobj = 'ANY', ## an mfMethodRC
+        RCfunProc     = 'ANY', ## an RCfunProcessing or NULL
+        cppClass      = 'ANY',  ## an RCfunctionDef or NULL
+        RinitTypesProcessed = 'ANY',
+        Rcompiled           = 'ANY',
+        fromModel     =  'ANY'		#'logical'
+    )
+)
 
 modelDefInfoClass <- setRefClass('modelDefInfoClass',
-                                 fields = list(
-                                     labelMaker = 'ANY'
-                                     ))
-
-
-## removeVariableFromEnv <- function(name, env)
-## 	eval(substitute(remove(VAR, envir = env), list(VAR = name)))
+    fields = list(
+        labelMaker = 'ANY'
+    )
+)
 
 nimbleProjectClass <- setRefClass('nimbleProjectClass',
-                             fields = list(
-                                 RCfunInfos         =  'ANY',		#'list', ## a list of RCfunInfoClass objects
-                                 RCfunCppInterfaces =  'ANY',		#'list', 
-                                 mvInfos            =  'ANY',		#'list', ## a list of mvInfoClass objects
-                                 modelDefInfos      =  'ANY',		#'list',
-                                 ##modelCppInterfaces =  'ANY',		#'list',
-                                 models             =  'ANY',		#'list',
-                                 nimbleFunctions    =  'ANY',		#'list',
-                                 nimbleLists        =  'ANY',   #'list',
-                                 nfCompInfos        =  'ANY',		#'list', ## list of nfCompilationInfoClass objects
-                                 nlCompInfos        =  'ANY',   #'list', ## list of nfCompilationInfoClass objects
-                                 cppProjects        =  'ANY',		#'list', ## list of cppProjectClass objects, 1 for each dll to be produced
-                                 dirName            =  'ANY',		#'character',
-                                 nimbleLabel        =  'ANY',		#'character',
-                                 refClassDefsEnv    =  'ANY',		#'environment',
-                                 projectName        =  'ANY'		#'character'
-                                 ),
-                             methods = list(
-                                 show = function() {
-                                     writeLines(paste0('nimbleProject object'))
-                                 },
-                                 initialize = function(dir = NULL, name = '') {
-                                 	RCfunInfos <<- new.env()						# list()
-                                 	RCfunCppInterfaces <<- new.env()				# list()
-                                 	mvInfos <<- new.env()							# list()
-                                 	modelDefInfos <<- new.env()						# list()
-                                 ##	modelCppInterfaces <<- new.env()				# list()
-                                 	models <<- new.env()							# list()
-                                 	nimbleFunctions <<- new.env()					# list
-                                 	nimbleLists <<- new.env()
-                                 	nfCompInfos <<- list()							# list()
-                                 	nlCompInfos <<- list()
-                                 	cppProjects <<- list()							#new.env()						#list()
-                                 	refClassDefsEnv <<- new.env()
-                                     dirName <<- if(is.null(dir)) makeDefaultDirName() else dir
-                                     if(name == '') projectName <<- projectNameCreator() else projectName <<- name
-                                    },
-                                 clearCompiled = function(functions = TRUE, models = TRUE, DLLs = TRUE) {
-                                     if(functions) resetFunctions(finalize = TRUE)
-                                     if(models) resetModels(finalize = TRUE)
-                                     if(DLLs) unloadDLLs()
-                                 },
-                                 unloadDLLs = function() {
-                                     for(i in seq_along(cppProjects)) {
-                                         cppProjects[[i]]$unloadSO(check = TRUE, force = FALSE)
-                                     }
-                                 },
-                                 resetModels = function(finalize = TRUE) {
-                                     for(i in ls(models)) {
-                                         models[[i]]$CobjectInterface$finalizeInternal()
-                                         models[[i]]$CobjectInterface <<- NULL
-                                         models[[i]]$nimbleProject <<- NULL
-                                         models[[i]]$Cname <<- character(0)
-                                         models[[i]] <<- NULL
-                                     }
-                                     for(i in ls(RCfunInfos)) {
-                                         if(length(RCfunInfos[[i]]$fromModel) > 0) {
-                                             if(RCfunInfos[[i]]$fromModel) {
-                                                 if(!is.null(RCfunCppInterfaces[[i]])) { ## could be null if it was a neededType and an interface was never built 
-                                                     environment(RCfunCppInterfaces[[i]])$CnativeSymbolInfo_ <<- NULL
-                                                     ##RCfunCppInterfaces[[i]] <<- NULL
-                                                     rm(list = i, envir = RCfunCppInterfaces)
-                                                 }
-                                                 assign('nimbleProject', NULL, envir = RCfunInfos[[i]]$nfMethodRCobj)
-                                                 thisName <- RCfunInfos[[i]]$nfMethodRCobj$uniqueName
-                                                 ##if(!is.null(cppProjects[[thisName]])) cppProjects[[thisName]] <<- NULL
-                                                 ##RCfunInfos[[i]] <<- NULL
-                                                 rm(list = i, envir = RCfunInfos)
-                                             }
-                                         }
-                                     }
-                                     for(i in ls(nfCompInfos)) {
-                                         if(length(nfCompInfos[[i]]$fromModel) > 0) {
-                                             if(nfCompInfos[[i]]$fromModel) {
-                                                 for(j in seq_along(nfCompInfos[[i]]$Rinstances)) {
-                                                     thisEnv <- environment(nfCompInfos[[i]]$Rinstances[[j]])
-                                                     thisRCO <- nf_getRefClassObject(nfCompInfos[[i]]$Rinstances[[j]])
-                                                     if(exists('name', envir = thisRCO, inherits = FALSE)) {
-                                                         thisname <- thisRCO$name
-                                                         rm(list = thisname, envir = nimbleFunctions)
-                                                         rm('name', envir = thisRCO)
-                                                     }
-                                                     thisRCO[['nimbleProject']] <- NULL
-                                                     ## finalization done internally to the model interface
-                                                 }
-                                                 nfCompInfos[[i]] <<- NULL
-                                                 ## cppProjects[[i]] <<- NULL
-                                             }
-                                         }
-                                     }
-
-                                 },
-                                 resetFunctions = function(finalize = FALSE) {
-                                     ## clear everything except models and nimbleFunctions from models
-                                     for(i in ls(mvInfos)) {
-                                         clearThisMV <- TRUE ## It looked like in some situations we'd not want to clear here, but apparently we always should
-                                         ## OK, what happens is we used to check if a cppClass was from a model and then not clear, but that isn't right.
-                                         ## It could be defined from a model but then have objects from nimbleFunctions that need to be cleared.
-                                         if(clearThisMV) {
-                                             mvInfos[[i]]$cppClass <<- NULL
-                                             for(j in seq_along(mvInfos[[i]]$RmvObjs)) {
-                                                 if(!is.null(mvInfos[[i]]$RmvObjs[[j]]$CobjectInterface)) {
-                                                     if(finalize) {
-                                                         mvInfos[[i]]$RmvObjs[[j]]$CobjectInterface$finalizeInternal() 
-                                                     }
-                                                     mvInfos[[i]]$RmvObjs[[j]]$CobjectInterface <<- NULL
-                                                 }
-                                             }
-                                             rm(list = i, envir = mvInfos)
-                                         }
-                                     }
-                                     
-                                     for(i in ls(RCfunInfos)) {
-                                         if(length(RCfunInfos[[i]]$fromModel) > 0) {
-                                             if(!RCfunInfos[[i]]$fromModel) {
-                                                 if(!is.null(RCfunCppInterfaces[[i]])) { ## could be null if it was a neededType and an interface was never built 
-                                                     environment(RCfunCppInterfaces[[i]])$CnativeSymbolInfo_ <<- NULL
-                                                     ##RCfunCppInterfaces[[i]] <<- NULL
-                                                     rm(list = i, envir = RCfunCppInterfaces)
-                                                 }
-                                                 assign('nimbleProject', NULL, envir = RCfunInfos[[i]]$nfMethodRCobj)
-                                                 thisName <- RCfunInfos[[i]]$nfMethodRCobj$uniqueName
-                                                 ##if(!is.null(cppProjects[[thisName]])) cppProjects[[thisName]] <<- NULL
-                                                 ##RCfunInfos[[i]] <<- NULL
-                                                 rm(list = i, envir = RCfunInfos)
-                                             }
-                                         }
-                                     }
-                                     for(i in ls(nfCompInfos)) {
-                                         if(length(nfCompInfos[[i]]$fromModel) > 0) {
-                                             if(!nfCompInfos[[i]]$fromModel) {
-                                                 for(j in seq_along(nfCompInfos[[i]]$Rinstances)) {
-                                                     thisEnv <- environment(nfCompInfos[[i]]$Rinstances[[j]])
-                                                     thisRCO <- nf_getRefClassObject(nfCompInfos[[i]]$Rinstances[[j]])
-                                                     if(exists('name', envir = thisRCO, inherits = FALSE)) {
-                                                         thisname <- thisRCO$name
-                                                         rm(list = thisname, envir = nimbleFunctions)
-                                                         ##nimbleFunctions[[ thisname ]] <<- NULL
-                                                         rm('name', envir = thisRCO)
-                                                     }
-                                                     thisRCO[['nimbleProject']] <- NULL
-                                                     if(finalize) {
-                                                         if(!is.null(thisRCO$.CobjectInterface)) {
-                                                             if(is.list( thisRCO$.CobjectInterface)) { ## CmultiNimbleFunctionInterface
-                                                                 thisRCO$.CobjectInterface[[1]]$finalizeInstance(thisRCO$.CobjectInterface[[2]])
-                                                             } else {
-                                                                 thisRCO$.CobjectInterface$finalizeInternal()
-                                                             }
-                                                             thisRCO$.CobjectInterface <- NULL
-                                                         }
-                                                     }
-                                                 }
-                                                 nfCompInfos[[i]] <<- NULL
-                                                 ## cppProjects[[i]] <<- NULL
-                                             }
-                                         }
-                                     }
-                                 },
-                                     
-                                 addModelValuesClass = function(mvConf, fromModel = FALSE) {
-                                     mvClassName <- environment(mvConf)$className
-                                     if(!is.null(mvInfos[[mvClassName]])) stop('Trying to add a modelValues class with the same name as one already in this project', call. = FALSE)
-                                     mvInfos[[mvClassName]] <<-  mvInfoClass(cppClassName = mvClassName, cppClass = NULL, mvConf = mvConf, fromModel = fromModel)
-                                 },
-                                 getModelValuesCppDef = function(mvConf, NULLok = FALSE) {
-                                     mvClassName <- environment(mvConf)$className
-                                     if(is.null(mvInfos[[mvClassName]])) {
-                                         if(!NULLok) stop('Project does not know about this modelValues class but the cppDef is being requested', call. = FALSE)
-                                         else return(NULL)
-                                     }
-                                     ans <- mvInfos[[mvClassName]]$cppClass
-                                     if(is.null(ans)) {
-                                         if(!NULLok) stop('cppDef for a requested modelValues class has not been generated but was requested.', call. = FALSE)
-                                         else return(NULL)
-                                     }
-                                     ans
-                                 },
-                                 addModel = function(model) {
-                                     if(!inherits(model, 'RmodelBaseClass')) stop('model provided to project is not an RmodelBaseClass', call. = FALSE)
-                                     modelDefName <- model$modelDef$name
-                                     if(is.null(modelDefInfos[[modelDefName]])) {
-                                         modelDefInfos[[modelDefName]] <<- modelDefInfoClass(
-                                             labelMaker = labelFunctionCreator(paste0(modelDefName, '_'))
-                                             )
-                                         if(identical(model$name, character(0))) {
-                                             model$name <- modelDefInfos[[modelDefName]]$labelMaker()
-                                         } else {
-                                             if(!is.null(models[[ model$name ]])) stop('Model provided to project has same name as another one in the same project')
-                                         }
-                                         if(identical(model$Cname, character(0))) {
-                                             model$Cname <- Rname2CppName(model$name)
-                                         } 
-                                         model$nimbleProject <- .self
-                                         models[[ model$name ]] <<- model
-                                         ##modelCppInterfaces[[ model$name ]] <<- new.env()	#list(NULL)
-                                     }
-                                 },
-                                 addNimbleFunctionMulti = function(funList, fromModel = FALSE, generatorFunNames = NULL) {
-                                     if(length(funList) == 0) return(invisible(NULL))
-                                     if(!is.nf(funList[[1]])) stop('first nimbleFunction provided to project is not a nimbleFunction.', call. = FALSE)
-                                     inProjectAlready <- unlist(lapply(funList, function(x) identical(x[['nimbleProject']], .self)))
-                                     if(any(inProjectAlready)) {
-                                         stop('Trying to add list of nimbleFunctions but some are already part of another project. If you are recompiling, try redefining models and specialized nimbleFunctions. (The reset option works now for nimbleFunctions but not models.)', call. = FALSE)
-                                     }
-                                     allGeneratorNames <- if(is.null(generatorFunNames))
-                                                              unlist(lapply(funList, function(x) environment(x$.generatorFunction)$name), use.names = FALSE)
-                                                          else
-                                                              generatorFunNames
-                                     generatorName2Indices <- split(seq_along(funList), allGeneratorNames) ##uniqueGeneratorNamesIndices <- which(!duplicated(allGeneratorNames))
-                                     for(i in seq_along(generatorName2Indices)) { ##genID in uniqueGeneratorNameIndices) {
-                                         genID <- generatorName2Indices[[i]][1]
-                                         generatorName <- names(generatorName2Indices)[i] ##allGeneratorNames[genID]
-                                         if(is.null(nfCompInfos[[generatorName]])) {
-                                             ## nfProc could have been created already during makeTypeObject for another nimbleFunction so it knows the types of this one.
-                                             nfCompInfos[[generatorName]] <<- nfCompilationInfoClass(nfGenerator = nf_getGeneratorFunction(funList[[genID]]),
-                                                                                                     Rcompiled = FALSE, written = FALSE, cppCompiled = FALSE, loaded = FALSE,
-                                                                                                     RinitTypesProcessed = FALSE, virtual = FALSE,
-                                                                                                     fromModel = fromModel)
-                                             nfCompInfos[[generatorName]]$labelMaker <<- labelFunctionCreator(paste0(generatorName,'_'))
-                                         }
-                                         genIDs <- generatorName2Indices[[i]]
-                                         newLabels <- nfCompInfos[[generatorName]]$labelMaker(count = length(genIDs))
-                                         
-                                         namedFunList <- funList[genIDs]
-                                         names(namedFunList) <- newLabels
-                                         list2env(namedFunList, envir = nimbleFunctions)
-                                         nfCompInfos[[generatorName]]$addRinstanceList(namedFunList)
-                                         
-                                         newEnvs <- lapply(seq_along(newLabels), new.env)
-                                         names(newEnvs) <- newLabels
-                                         CppNewLabels <- Rname2CppName(newLabels)
-                                         for(j in seq_along(newLabels)) {
-                                             funList[[genIDs[j]]][['Cname']] <- CppNewLabels[j]
-                                             funList[[genIDs[j]]][['name']] <- newLabels[j] ## skip the checking done in addNimbleFunction
-                                             funList[[genIDs[j]]][['nimbleProject']] <- .self
-                                         }
-                                     }
-                                 },
-                                 addNimbleFunction = function(fun, fromModel = FALSE) {
-                                     if(!is.nf(fun)) stop('nimbleFunction provided to project is not a nimbleFunction.', call. = FALSE)
-                                     inProjectAlready <- nf_getRefClassObject(fun)[['nimbleProject']]
-                                     if(!is.null(inProjectAlready)) {
-                                         if(!identical(inProjectAlready, .self)) stop('Trying to add a specialized nimbleFunction to a project, but it is already part of another project. \nIf you did not specify a project, this error can occur in trying to create a new project -- you likely need to specify the relevant model as the project.\nIf you are recompiling, try redefining models and specialized nimbleFunctions. (The reset option works now for nimbleFunctions but not models.)', call. = FALSE)
-                                         else warning('Adding a specialized nimbleFunction to a project to which it already belongs', call. = FALSE)
-                                     }
-                                     generatorName <- nfGetDefVar(fun, 'name')
-                                     if(is.null(nfCompInfos[[generatorName]])) {
-                                         ## nfProc could have been created already during makeTypeObject for another nimbleFunction so it knows the types of this one.
-                                         nfCompInfos[[generatorName]] <<- nfCompilationInfoClass(nfGenerator = nf_getGeneratorFunction(fun),
-                                                                                                 Rcompiled = FALSE, written = FALSE, cppCompiled = FALSE, loaded = FALSE,
-                                                                                                 RinitTypesProcessed = FALSE, virtual = FALSE,
-                                                                                                 fromModel = fromModel)
-                                         nfCompInfos[[generatorName]]$labelMaker <<- labelFunctionCreator(paste0(generatorName,'_'))
-                                     }
-                                     if(!exists('name', envir = nf_getRefClassObject(fun), inherits = FALSE)) {
-                                         assign('name', nfCompInfos[[generatorName]]$labelMaker(), envir = nf_getRefClassObject(fun))
-                                     } else {
-                                         if(!is.null(nimbleFunctions[[ nf_getRefClassObject(fun)$name ]])) {
-                                             stop('nimbleFunction provided to project has same name as another one in the same project', call. = FALSE)
-                                         }
-                                     }
-                                     nimbleFunctions[[ nf_getRefClassObject(fun)$name ]] <<- fun
-                                     nfCompInfos[[generatorName]]$addRinstance(fun)
-                                    
-                                     if(!exists('Cname', envir = nf_getRefClassObject(fun), inherits = FALSE)) {
-                                         assign('Cname', Rname2CppName(nf_getRefClassObject(fun)$name), envir = nf_getRefClassObject(fun))
-                                     }
-
-                                     assign('nimbleProject', .self, envir = nf_getRefClassObject(fun))
-                                     ## could check for duplicate Cnames here, but if the names are unique the Cnames should be too.
-                                 },
-                                 addNimbleListGen = function(nlGen) {
-                                     if(!is.nlGenerator(nlGen)) stop('invalid nimbleListGen provided to addNimbleListGen.', call. = FALSE)
-                                     ## get className
-                                     className <- nl.getListDef(nlGen)$className
-                                     
-                                     ## check if there is a nlCompInfos,
-                                     ## add if needed
-                                     if(is.null(nlCompInfos[[className]])) {
-                                         ## nfProc could have been created already during makeTypeObject for another nimbleFunction so it knows the types of this one.
-                                         nlCompInfos[[className]] <<- nlCompilationInfoClass(written = FALSE, cppCompiled = FALSE, Rcompiled = FALSE,
-                                                                                             RinitTypesProcessed = FALSE, loaded = FALSE)
-                                         nlCompInfos[[className]]$labelMaker <<- labelFunctionCreator(paste0(className,'_'))
-                                     }
-                                     nestedListGens <- nl.getNestedGens(nlGen)
-                                     for(i in seq_along(nestedListGens))
-                                         addNimbleListGen(nestedListGens[[i]])
-                                 },
-                                 addNimbleList = function(nl, fromModel = FALSE, nestedList = FALSE) { ##fromModel never used: clean up. 
-                                   if(!is.nl(nl)) stop('nimbleList provided to project is not a nimbleList.', call. = FALSE)
-                                   inProjectAlready <- nl[['nimbleProject']]
-                                   if(!is.null(inProjectAlready)) {
-                                     if(!identical(inProjectAlready, .self)) stop('Trying to add a specialized nimbleList to a project, but it is already part of another project. \nIf you did not specify a project, this error can occur in trying to create a new project -- you likely need to specify the relevant model as the project.\nIf you are recompiling, try redefining models and specialized nimbleFunctions and nimbleLists.', call. = FALSE)
-                                     else warning('Adding a specialized nimbleList to a project to which it already belongs', call. = FALSE)
-                                   }
-
-                                   ## Next two lines can become addNimbleListGen, but would have to migrate recursion out of compileNimbleList
-                                   className <- nl$nimbleListDef$className
-                                   if(is.null(nlCompInfos[[className]])) {
-                                     ## nfProc could have been created already during makeTypeObject for another nimbleFunction so it knows the types of this one.
-                                     nlCompInfos[[className]] <<- nlCompilationInfoClass(written = FALSE, cppCompiled = FALSE, Rcompiled = FALSE,
-                                                                                         RinitTypesProcessed = FALSE, loaded = FALSE)
-                                     nlCompInfos[[className]]$labelMaker <<- labelFunctionCreator(paste0(className,'_'))
-                                   }
-                                  
-                                   if(!exists('name', envir = nl, inherits = FALSE)) {
-                                     assign('name', nlCompInfos[[className]]$labelMaker(), envir = nl)
-                                   } else {
-                                     if(!is.null(nimbleLists[[ nl$name ]])) {
-                                       stop('nimbleList provided to project has same name as another one in the same project', call. = FALSE)
-                                     }
-                                   }
-                                   if(!nestedList)   nimbleLists[[ nl$name ]] <<- nl
-                                   # nlCompInfos[[generatorName]]$addRinstance(nl)
-                                   
-                                   if(!exists('Cname', envir = nl, inherits = FALSE)) {
-                                     assign('Cname', Rname2CppName(nl$name), envir = nl)
-                                   }
-                                   
-                                   assign('nimbleProject', .self, envir = nl)
-                                   ## could check for duplicate Cnames here, but if the names are unique the Cnames should be too.
-                                 },
-                                 addRCfun = function(nfmObj, fromModel = FALSE) {
-                                     if(!inherits(nfmObj, 'nfMethodRC')) stop("Can't add this function. nfmObj is not an nfMethodRC", call. = FALSE)
-                                     className <- nfmObj$uniqueName
-                                     if(is.null(RCfunInfos[[className]])) {
-                                         RCfunInfos[[className]] <<- RCfunInfoClass(nfMethodRCobj = nfmObj, RCfunProc = NULL, cppClass = NULL, fromModel = fromModel, RinitTypesProcessed = FALSE, Rcompiled = FALSE)
-                                     }
-                                     assign('nimbleProject', .self, envir = nfmObj) ## needed for clearCompiled(), i.e. safe dyn.unload()
-                                 },
-                                 getRCfunCppDef = function(nfmObj, NULLok = FALSE) {
-                                     className <- nfmObj$uniqueName
-                                     ans <- RCfunInfos[[className]]
-                                     if(is.null(ans)) {
-                                         if(!NULLok) stop("Requested to get an RCfunCppDef but it is not in the project and NULLok = FALSE", call. = FALSE)
-                                         return(NULL)
-                                     }
-                                     ans <- ans$cppClass
-                                     if(inherits(ans, 'uninitializedField') )  return(NULL)                                     	 
-                                     ans
-                                 },
-                                 needRCfunCppClass = function(nfmObj, genNeededTypes = TRUE, initialTypeInference = FALSE, control = list(debug = FALSE, debugCpp = FALSE), fromModel = FALSE) {
-                                     if(!inherits(nfmObj, 'nfMethodRC')) stop("Can't compile this function. nfmObj is not an nfMethodRC", call. = FALSE)
-                                     className <- nfmObj$uniqueName
-                                     Cname <- Rname2CppName(className)
-                                     RCfunInfo <- RCfunInfos[[className]]
-                                     if(is.null(RCfunInfo)) addRCfun(nfmObj, fromModel = fromModel)
-                                     if(is.null(RCfunInfos[[className]]$RCfunProc)) {
-                                         RCfunInfos[[className]]$RCfunProc <<- RCfunProcessing$new(nfmObj, Cname)
-                                     }
-                                     if(!RCfunInfos[[className]]$RinitTypesProcessed) {
-                                         RCfunInfos[[className]]$RCfunProc$process(debug = control$debug, debugCpp = control$debugCpp, initialTypeInferenceOnly = TRUE, nimbleProject = .self)
-                                         RCfunInfos[[className]]$RinitTypesProcessed <<- TRUE
-                                     }
-                                     if(initialTypeInference) return(RCfunInfos[[className]]$RCfunProc)
-                                     if(!RCfunInfos[[className]]$Rcompiled) {
-                                         RCfunInfos[[className]]$RCfunProc$process(debug = control$debug, debugCpp = control$debugCpp, initialTypeInferenceOnly = FALSE, nimbleProject = .self)
-                                         RCfunInfos[[className]]$Rcompiled <<- TRUE
-                                     }
-                                     cppClass <- RCfunInfos[[className]]$cppClass
-                                     if(is.null(cppClass)) {
-                                         cppClass <- RCfunctionDef(project = .self)
-                                         cppClass$buildFunction(RCfunInfos[[className]]$RCfunProc)
-                                         cppClass$buildSEXPinterfaceFun()
-                                         if(genNeededTypes) cppClass$genNeededTypes()
-                                         RCfunInfos[[className]]$cppClass <<- cppClass
-                                     }
-                                     cppClass
-                                 },
-                                 compileRCfun = function( fun, filename = NULL, initialTypeInference = FALSE, control = list(debug = FALSE, debugCpp = FALSE, writeFiles = TRUE, returnAsList = FALSE), showCompilerOutput = nimbleOptions('showCompilerOutput')) {
-                                     disableWrite <- FALSE
-                                     if(nimbleOptions('enableSpecialHandling')) {
-                                         SH <- filenameFromSpecialHandling(fun)
-                                         if(!is.null(filename)) {
-                                             filename <- SH
-                                             disableWrite <- TRUE
-                                         }
-                                     }
-                                     if(is.rcf(fun)) fun <- environment(fun)$nfMethodRCobject
-                                     addRCfun(fun) ## checks if it already exists and if it is an nfMethodRC ## redundant? done also in next step.
-                                     cppClass <- needRCfunCppClass(fun, genNeededTypes = TRUE, initialTypeInference = initialTypeInference, control = control)
-                                     if(initialTypeInference) return(cppClass) ## in this case cppClass with be an RCfunProc
-                                     className <- fun$uniqueName
-                                     if(control$writeFiles) {
-                                         cppProj <- cppProjectClass(dirName = dirName)
-                                         cppProjects[[ className ]] <<- cppProj
-                                         if(is.null(filename)) filename <- paste0(projectName, '_', className)
-                                         cppProj$addClass( cppClass, className, filename )
-                                         if(!disableWrite) cppProj$writeFiles(filename)
-                                     }
-                                     if(control$compileCpp) {
-                                         cppProj$compileFile(filename, showCompilerOutput)
-                                     }
-                                     if(control$loadSO) {
-                                         cppProj$loadSO(filename)
-                                     }
-                                     RCfunCppInterfaces[[className]] <<- cppClass$buildRwrapperFunCode(includeLHS = FALSE, eval = TRUE, returnArgsAsList = control$returnAsList, dll = cppProj$dll)
-                                     RCfunCppInterfaces[[className]]
-                                 },
-                                 needModelValuesCppClass = function(mvConf, fromModel = FALSE) {
-                                     if(!isModelValuesConf(mvConf)) stop("Can't compileModelValues: mvConf is not a modelValuesConf", call. = FALSE)
-                                     mvClassName <- environment(mvConf)$className
-                                     mvInfo <- mvInfos[[mvClassName]]
-                                     if(is.null(mvInfo)) addModelValuesClass(mvConf, fromModel)
-                                     cppClass <- mvInfos[[mvClassName]]$cppClass
-                                     if(is.null(cppClass)) {
-                                         cppClass <- cppModelValuesClass(name = mvClassName,
-                                                                            vars = environment(mvConf)$symTab,
-                                                                            project = .self)
-                                         cppClass$buildAll()
-                                          mvInfos[[mvClassName]]$cppClass <<- cppClass
-                                     }
-                                     cppClass
-                                 },
-                                 instantiateCmodelValues = function(mv, dll) {
-                                     mvClassName <- class(mv)
-                                     cppDef <- mvInfos[[mvClassName]]$cppClass
-                                     if(is.null(cppDef)) stop('Trying to instantiate a modelValues type that the project has no record of. Try setting option resetFunctions = TRUE in compileNimble')
-                                     generatorName <- cppDef$SEXPgeneratorFun$name
-                                     sym = if(!is.null(dll))
-                                         getNativeSymbolInfo(generatorName, dll)
-                                     else {
-                                         warning('a nimbleFunctionInterface is about to build a CmodelValues without dll info, based on generatorFun name only.', call. = FALSE)
-                                         generatorName
-                                     }
-                                     ans <- CmodelValues(sym, dll = dll)
-                                     mvInfos[[mvClassName]]$addRmv(mv) ## simply a list for later clearing
-                                     mv$CobjectInterface <- ans
-                                     ans
-                                 },
-                                 compileModel = function(model, filename = NULL,
-                                                         control = list(debug = FALSE, debugCpp = FALSE, writeFiles = TRUE, compileCpp = TRUE, loadSO = TRUE), showCompilerOutput = nimbleOptions('showCompilerOutput'), where = globalenv()) {
-                                     disableWrite <- FALSE
-                                     if(nimbleOptions('enableSpecialHandling')) {
-                                         filenames <- filenameFromSpecialHandling(model)
-                                         if(!is.null(filenames)) {
-                                             filename <- filenames$filename
-                                             nfFileName <- filenames$nfFileName
-                                             disableWrite <- TRUE
-                                         }
-                                     }
-                                     if(is.character(model)) {
-                                         tmp <- models[[model]]
-                                         if(is.null(tmp)) stop(paste0("Model provided as name: ", model, " but it is not in this project."), call. = FALSE)
-                                         model <- tmp
-                                     } else addModel(model)
-                                                                          
-                                     modelDef <- model$getModelDef()
-                                     modelDefName <- modelDef$name
-                                     Cname <- Rname2CppName(modelDefName)
-                                     if(!disableWrite) {
-                                         if(is.null(filename)) {
-                                             filename <- paste0(projectName, '_', Rname2CppName(modelDefName)) 
-                                         }
-                                         nfFileName <- paste0(projectName, '_', Rname2CppName(modelDefName),'_nfCode')
-                                     }
-                                     modelCpp <- cppBUGSmodelClass(modelDef = modelDef, model = model,
-                                                                   name = Cname, project = .self)
-                                     ## buildAll will call back to the project to add its nimbleFunctions 
-                                     modelCpp$buildAll(buildNodeDefs = TRUE, where = where, control = control)
-                                     
-                                     cppProj <- cppProjectClass(dirName = dirName)
-                                     cppProjects[[ modelDefName ]] <<- cppProj
-                                     ## genModelValuesCppClass will back to the project to add its mv class
-                                     mvc <- modelCpp$genModelValuesCppClass()
-                                     ##if(is.null(filename)) filename <- paste0(projectName, '_', modelDefName)
-                                     cppProj$addClass(mvc, filename = filename)
-                                     cppProj$addClass(modelCpp, modelDefName, filename)
-                                     ##if compileNodes
-                                     ##nfFileName <- paste0(projectName, '_', Rname2CppName(modelDefName),'_nfCode')
-                                     for(i in names(modelCpp$nodeFuns)) {
-                                         cppProj$addClass(modelCpp$nodeFuns[[i]], filename = nfFileName)
-                                     }
-                                     if(control$writeFiles) {
-                                         if(!disableWrite) {
-                                             cppProj$writeFiles(filename)
-                                             cppProj$writeFiles(nfFileName) ## if compileNodes
-                                         }
-                                     } else return(cppProj)
-                                     if(control$compileCpp) {
-                                         compileList <- filename
-                                         compileList <- c(compileList, nfFileName) ## if compileNodes
-                                         cppProj$compileFile(compileList, showCompilerOutput)
-                                     } else return(cppProj)
-                                     if(control$loadSO) {
-                                         ## if loadSO
-                                         cppProj$loadSO(filename)
-                                     } else return(cppProj)
-                                     ## if buildInterface
-                                     interfaceName <- paste0('C', modelDefName)
-                                     
-                                     compiledModel <- modelCpp ## cppProj$cppDefs[[2]]
-                                     newCall <- paste0('new_',Rname2CppName(modelDefName))
-                                     ans <- buildModelInterface(interfaceName, compiledModel, newCall, where = where, project = .self, dll = cppProj$dll)
-                                     createModel <- TRUE
-                                     if(!createModel) return(ans) else return(ans(model, where, dll = cppProj$dll))
-                                     ## creating the model populates model$CobjectInterface
-                                 },
-                                 ## nimbleList functions
-                                 addNestedNls = function(nl){
-                                   for(iNl in names(nl$nestedListGenList)){
-                                     addNimbleList(nl[[iNl]], nestedList = TRUE)
-                                     if(length(nl[[iNl]]$nestedListGenList) > 0){
-                                       addNestedNls(nl[[iNl]])
-                                     }
-                                   }
-                                 },
-                                 compileNimbleList = function(nl, filename = NULL, initialTypeInferenceOnly = FALSE,
-                                     control = list(debug = FALSE, debugCpp = FALSE, compileR = TRUE, writeFiles = TRUE, compileCpp = TRUE, loadSO = TRUE),
-                                     reset = FALSE, returnCppClass = FALSE, className = NULL, alreadyAdded = FALSE) { ## className? alreadyAdded?
-
-                                     ## add possibility that nl is a generator
-                                     generatorOnly <- FALSE
-                                     if(is.nlGenerator(nl)) {
-                                         ## determine className
-                                         className <- nl.getListDef(nl)$className
-                                         generatorOnly <- TRUE
-                                         nlGen <- nl
-                                         nlList <- nl
-                                     } else {
-                                     
-                                         if(is.list(nl)) {
-                                             if(is.null(className)) className <- unique(unlist(lapply(nl, function(x) x$nimbleListDef$className)))
-                                             if(length(className) != 1) stop(paste0('Not all elements in the nimbleList list for compileNimbleList are from the same nimbleFunctionDef.  The class names include:', paste(className, collapse = ' ')), call. = FALSE)
-                                             nlList <- nl
-                                             ## set generator
-                                         } else {
-                                             if(!is.nl(nl)) stop(paste0("nl argument provided is not a nimbleList."), call. = FALSE)
-                                             nlList <- list(nl)
-                                             className <- nl$nimbleListDef$className
-                                             ## set generator
-                                         }
-                                         nlGen <- nl.getGenerator(nlList[[1]])
-                                     }
-                                     if(reset) nlCompInfos[[className]] <<- NULL
-                                     if(!alreadyAdded) {
-                                         if(generatorOnly) {
-                                             ## check if generator exists and do addNimbleListGen
-                                             ## and recurse into nestedListGenList
-                                             addNimbleListGen(nlGen)
-                                         } else {
-                                             for(i in seq_along(nlList)) {
-                                                 addNL <- TRUE
-                                                 thisName <- nlList[[i]][['name']]
-                                                 if(!is.null(thisName)) {
-                                                     tmp <- nimbleLists[[thisName]]
-                                                     if(!is.null(tmp)) {
-                                                         if(reset) {
-                                                             nimbleLists[[thisName]] <<- NULL
-                                                         } else {
-                                                             if(!identical(nlList[[i]], tmp)) stop('Trying to compile something with same name as previously added nimbleList that is not the same thing')
-                                                             addNL <- FALSE
-                                                         }
-                                                     }
-                                                 }
-                                                 if(addNL){
-                                                     addNimbleList(nlList[[i]])
-                                                     ## if any nested lists, add them too (recursively)
-                                                     if(length(nlList[[i]]$nestedListGenList) > 0){
-                                                         addNestedNls(nlList[[i]])
-                                                     }
-                                                 }
-                                             }
-                                         }
-                                     }
-
-                                     ## modify to pull nestedListGenList from generator
-                                     nestedListGens <- nl.getNestedGens(nlGen)
-                                     for(iNestedNL in seq_along(nestedListGens)) {
-                                         compileNimbleList(nestedListGens[[iNestedNL]], initialTypeInferenceOnly = TRUE, alreadyAdded = TRUE)
-                                     }
-                                     ## for(iNestedNl in seq_along(nlList[[1]]$nestedListGenList)){
-                                     ##   ## create cppInfo for any nested list classes 
-                                     ##   compileNimbleList(nlList[[1]][[names(nlList[[1]]$nestedListGenList)[iNestedNl]]], initialTypeInferenceOnly = TRUE, alreadyAdded = TRUE)
-                                     ## }
-                                     cppClass <- buildNimbleListCompilationInfo(nlList, initialTypeInferenceOnly = initialTypeInferenceOnly)
-                                     
-
-                                     
-                                     if(initialTypeInferenceOnly || returnCppClass) return(cppClass)
-                                     message('Remaining compileNimbleList is not yet adapted')
-                                     if(!nlCompInfos[[className]]$written && control$writeFiles) {
-                                         cppProj <- cppProjectClass(dirName = dirName)
-                                         cppProjects[[ className ]] <<- cppProj
-                                         if(is.null(filename)) filename <- paste0(projectName, '_', Rname2CppName(className))
-                                         cppProj$addClass(cppClass, className, filename)
-                                         cppProj$writeFiles(filename)
-                                         nlCompInfos[[className]]$written <<- TRUE
-                                     } else {
-                                         if(!control$writeFiles) return(cppProj)
-                                         cppProj <- cppProjects[[ className ]]
-                                     }
-                                     if(!nlCompInfos[[className]]$cppCompiled && control$compileCpp) {
-                                         if(control$compileCpp) {
-                                             cppProj$compileFile(filename)
-                                             nlCompInfos[[className]]$cppCompiled <<- TRUE
-                                         } else writeLines('Skipping compilation because control$compileCpp is FALSE')
-                                     } else {if(!control$compileCpp) return(cppProj)}#writeLines('Using previously compiled C++ code.')
-                                     if(!nlCompInfos[[className]]$loaded && control$loadSO) {
-                                         cppProj$loadSO(filename)
-                                         nlCompInfos[[className]]$loaded <<- TRUE
-                                     } else{if(!control$loadSO) return(cppProj)}# writeLines('Using previously loaded compilation unit.')
-                                     
-                                     ans <- vector('list', length(nlList))
-
-                                     for(i in seq_along(nlList)) {
-                                         ans[[i]] <- nlCompInfos[[className]]$cppDef$buildCallable(nlList[[i]], cppProj$dll, asTopLevel = TRUE)
-                                     }
-                                     if(length(ans) == 1) ans[[1]] else ans
-                                 },
-                                 
-                                 ## nimbleFunction functions
-                                 getNimbleFunctionCppDef = function(generatorName, nfProc) {
-                                     if(missing(generatorName)) {
-                                         if(missing(nfProc)) stop('No good information provided to getNimbleFunctionCppDef', call. = FALSE)
-                                         generatorName <- environment(nfProc$nfGenerator)[['name']]
-                                         if(is.null(generatorName)) stop('Invalid generatorName', call. = FALSE)
-                                     }
-                                     if(is.null(nfCompInfos[[generatorName]])){
-                                     	 return(NULL)
+    fields = list(
+        RCfunInfos         =  'ANY',		#'list', ## a list of RCfunInfoClass objects
+        RCfunCppInterfaces =  'ANY',		#'list', 
+        mvInfos            =  'ANY',		#'list', ## a list of mvInfoClass objects
+        modelDefInfos      =  'ANY',		#'list',
+        models             =  'ANY',		#'list',
+        nimbleFunctions    =  'ANY',		#'list',
+        nimbleLists        =  'ANY',   #'list',
+        nfCompInfos        =  'ANY',		#'list', ## list of nfCompilationInfoClass objects
+        nlCompInfos        =  'ANY',   #'list', ## list of nfCompilationInfoClass objects
+        cppProjects        =  'ANY',		#'list', ## list of cppProjectClass objects, 1 for each dll to be produced
+        dirName            =  'ANY',		#'character',
+        nimbleLabel        =  'ANY',		#'character',
+        refClassDefsEnv    =  'ANY',		#'environment',
+        projectName        =  'ANY'		#'character'
+    ),
+    methods = list(
+        show = function() {
+            writeLines(paste0('nimbleProject object'))
+        },
+        initialize = function(dir = NULL, name = '') {
+            RCfunInfos <<- new.env()						# list()
+            RCfunCppInterfaces <<- new.env()				# list()
+            mvInfos <<- new.env()							# list()
+            modelDefInfos <<- new.env()						# list()
+            models <<- new.env()							# list()
+            nimbleFunctions <<- new.env()					# list
+            nimbleLists <<- new.env()
+            nfCompInfos <<- list()							# list()
+            nlCompInfos <<- list()
+            cppProjects <<- list()							#new.env()						#list()
+            refClassDefsEnv <<- new.env()
+            dirName <<- if(is.null(dir)) makeDefaultDirName() else dir
+            if(name == '') projectName <<- projectNameCreator() else projectName <<- name
+           },
+        clearCompiled = function(functions = TRUE, models = TRUE, DLLs = TRUE) {
+            if(functions) resetFunctions(finalize = TRUE)
+            if(models) resetModels(finalize = TRUE)
+            if(DLLs) unloadDLLs()
+        },
+        unloadDLLs = function() {
+            for(i in seq_along(cppProjects)) {
+                cppProjects[[i]]$unloadSO(check = TRUE, force = FALSE)
+            }
+        },
+        resetModels = function(finalize = TRUE) {
+            for(i in ls(models)) {
+                models[[i]]$CobjectInterface$finalizeInternal()
+                models[[i]]$CobjectInterface <<- NULL
+                models[[i]]$nimbleProject <<- NULL
+                models[[i]]$Cname <<- character(0)
+                models[[i]] <<- NULL
+            }
+            for(i in ls(RCfunInfos)) {
+                if(length(RCfunInfos[[i]]$fromModel) > 0) {
+                    if(RCfunInfos[[i]]$fromModel) {
+                        if(!is.null(RCfunCppInterfaces[[i]])) { ## could be null if it was a neededType and an interface was never built 
+                            environment(RCfunCppInterfaces[[i]])$CnativeSymbolInfo_ <<- NULL
+                            ##RCfunCppInterfaces[[i]] <<- NULL
+                            rm(list = i, envir = RCfunCppInterfaces)
+                        }
+                        assign('nimbleProject', NULL, envir = RCfunInfos[[i]]$nfMethodRCobj)
+                        thisName <- RCfunInfos[[i]]$nfMethodRCobj$uniqueName
+                        ##if(!is.null(cppProjects[[thisName]])) cppProjects[[thisName]] <<- NULL
+                        ##RCfunInfos[[i]] <<- NULL
+                        rm(list = i, envir = RCfunInfos)
+                    }
+                }
+            }
+            for(i in ls(nfCompInfos)) {
+                if(length(nfCompInfos[[i]]$fromModel) > 0) {
+                    if(nfCompInfos[[i]]$fromModel) {
+                        for(j in seq_along(nfCompInfos[[i]]$Rinstances)) {
+                            thisEnv <- environment(nfCompInfos[[i]]$Rinstances[[j]])
+                            thisRCO <- nf_getRefClassObject(nfCompInfos[[i]]$Rinstances[[j]])
+                            if(exists('name', envir = thisRCO, inherits = FALSE)) {
+                                thisname <- thisRCO$name
+                                rm(list = thisname, envir = nimbleFunctions)
+                                rm('name', envir = thisRCO)
+                            }
+                            thisRCO[['nimbleProject']] <- NULL
+                            ## finalization done internally to the model interface
+                        }
+                        nfCompInfos[[i]] <<- NULL
+                        ## cppProjects[[i]] <<- NULL
+                    }
+                }
+            }
+        },
+        resetFunctions = function(finalize = FALSE) {
+            ## clear everything except models and nimbleFunctions from models
+            for(i in ls(mvInfos)) {
+                clearThisMV <- TRUE ## It looked like in some situations we'd not want to clear here, but apparently we always should
+                ## OK, what happens is we used to check if a cppClass was from a model and then not clear, but that isn't right.
+                ## It could be defined from a model but then have objects from nimbleFunctions that need to be cleared.
+                if(clearThisMV) {
+                    mvInfos[[i]]$cppClass <<- NULL
+                    for(j in seq_along(mvInfos[[i]]$RmvObjs)) {
+                        if(!is.null(mvInfos[[i]]$RmvObjs[[j]]$CobjectInterface)) {
+                            if(finalize) {
+                                mvInfos[[i]]$RmvObjs[[j]]$CobjectInterface$finalizeInternal() 
+                            }
+                            mvInfos[[i]]$RmvObjs[[j]]$CobjectInterface <<- NULL
+                        }
+                    }
+                    rm(list = i, envir = mvInfos)
+                }
+            }
+            
+            for(i in ls(RCfunInfos)) {
+                if(length(RCfunInfos[[i]]$fromModel) > 0) {
+                    if(!RCfunInfos[[i]]$fromModel) {
+                        if(!is.null(RCfunCppInterfaces[[i]])) { ## could be null if it was a neededType and an interface was never built 
+                            environment(RCfunCppInterfaces[[i]])$CnativeSymbolInfo_ <<- NULL
+                            ##RCfunCppInterfaces[[i]] <<- NULL
+                            rm(list = i, envir = RCfunCppInterfaces)
+                        }
+                        assign('nimbleProject', NULL, envir = RCfunInfos[[i]]$nfMethodRCobj)
+                        thisName <- RCfunInfos[[i]]$nfMethodRCobj$uniqueName
+                        ##if(!is.null(cppProjects[[thisName]])) cppProjects[[thisName]] <<- NULL
+                        ##RCfunInfos[[i]] <<- NULL
+                        rm(list = i, envir = RCfunInfos)
+                    }
+                }
+            }
+            for(i in ls(nfCompInfos)) {
+                if(length(nfCompInfos[[i]]$fromModel) > 0) {
+                    if(!nfCompInfos[[i]]$fromModel) {
+                        for(j in seq_along(nfCompInfos[[i]]$Rinstances)) {
+                            thisEnv <- environment(nfCompInfos[[i]]$Rinstances[[j]])
+                            thisRCO <- nf_getRefClassObject(nfCompInfos[[i]]$Rinstances[[j]])
+                            if(exists('name', envir = thisRCO, inherits = FALSE)) {
+                                thisname <- thisRCO$name
+                                rm(list = thisname, envir = nimbleFunctions)
+                                ##nimbleFunctions[[ thisname ]] <<- NULL
+                                rm('name', envir = thisRCO)
+                            }
+                            thisRCO[['nimbleProject']] <- NULL
+                            if(finalize) {
+                                if(!is.null(thisRCO$.CobjectInterface)) {
+                                    if(is.list( thisRCO$.CobjectInterface)) { ## CmultiNimbleFunctionInterface
+                                        thisRCO$.CobjectInterface[[1]]$finalizeInstance(thisRCO$.CobjectInterface[[2]])
+                                    } else {
+                                        thisRCO$.CobjectInterface$finalizeInternal()
                                     }
-                                     ans <- nfCompInfos[[generatorName]]$cppDef
-                                     if(inherits(ans, 'uninitializedField') )  return(NULL)                                     	 
-                                     ans
-                                 },
-                                 getNimbleFunctionNFproc = function(fun) {
-                                     generatorName <- nfGetDefVar(fun, 'name')
-                                     if(is.null(nfCompInfos[[generatorName]])) return(NULL)
-                                     ans <- nfCompInfos[[generatorName]]$nfProc
-                                     if(inherits(ans, 'uninitializedField')) return(NULL)
-                                     ans
-                                 },
-                                 getNimbleListCppDef = function(generatorName, nlProc) {
-                                   if(missing(generatorName)) {
-                                     if(missing(nlProc)) stop('No good information provided to getNimbleListCppDef', call. = FALSE)
-                                     generatorName <- nlProc$nimbleListObj$className
-                                     if(is.null(generatorName)) stop('Invalid generatorName', call. = FALSE)
-                                   }
-                                   if(is.null(nlCompInfos[[generatorName]])){
-                                     return(NULL)
-                                   }
-                                   ans <- nlCompInfos[[generatorName]]$cppDef
-                                   if(inherits(ans, 'uninitializedField') )  return(NULL)                                     	 
-                                   ans
-                                 },
-                                 getNimbleListNLproc = function(fun) {
-                                   generatorName <- fun$name
-                                   if(is.null(nlCompInfos[[generatorName]])) return(NULL)
-                                   ans <- nlCompInfos[[generatorName]]$nlProc
-                                   if(inherits(ans, 'uninitializedField')) return(NULL)
-                                   ans
-                                 },
-                                 buildVirtualNimbleFunctionCompilationInfo = function(vfun, initialTypeInferenceOnly = FALSE, control = list(debug = FALSE, debugCpp = FALSE)) {
-                                     if(!is.character(vfun)) {
-                                         if(!is.nfGenerator(vfun)) stop("Something provided as a nimbleFunctionVirtual does not appear to be correct.", call. = FALSE)
-                                         if(!(environment(vfun)$virtual)) stop("Something provided as a nimbleFunctionVirtual is an nfGenerator but not a virtual one.", call. = FALSE)
-                                         if(initialTypeInferenceOnly) stop("Can't do initialTypeInferenceOnly on a virtualNimbleFunction", call. = FALSE)
-                                         generatorName <- environment(vfun)$name
-                                     } else {
-                                         generatorName <- vfun
-                                     }
-                                     if(is.null(nfCompInfos[[generatorName]])) stop("It doesn't look like nfCompInfos was set up for this generator.  Call setupVirtualNimbleFunction first.", call. = FALSE) 
-                                     if(inherits(nfCompInfos[[generatorName]]$nfProc, 'uninitializedField')) {## might always be FALSE by this point in processing
-                                         if(is.character(vfun)) stop("vfun given as character but nfProc doesn't exist yet", call. = FALSE)
-                                         nfCompInfos[[generatorName]]$nfProc <<- virtualNFprocessing$new(vfun, generatorName, project = .self)
-                                     }
-                                     if(!nfCompInfos[[generatorName]]$Rcompiled) {
-                                         nfCompInfos[[generatorName]]$nfProc$process(control = control)
-                                         nfCompInfos[[generatorName]]$Rcompiled <<- TRUE
-                                     }
-                                     if(inherits(nfCompInfos[[generatorName]]$cppDef, 'uninitializedField')) {
-                                         newCppClass <- cppVirtualNimbleFunctionClass(name = generatorName,
-                                                                                      nfProc = nfCompInfos[[generatorName]]$nfProc,
-                                                                                      project = .self)
-                                         nfCompInfos[[generatorName]]$cppDef <<- newCppClass
-                                         newCppClass ## possible return value
-                                     } else {
-                                         nfCompInfos[[generatorName]]$cppDef ## return value if already exists
-                                     }
-                                 },
-                                 buildNimbleFunctionCompilationInfo = function(funList = NULL, generatorName, initialTypeInferenceOnly = FALSE,
-                                     isNode = FALSE, control = list(debug = FALSE, debugCpp = FALSE), where = globalenv(), fromModel = FALSE) {
-                                     ## like old makeCppNIMBLEfunction
-                                     ## check of make new nfCompInfos item
-                                     ## ensure it is build up to the cppNimbleFunctionClass
-                                     if(!is.null(funList)) {
-                                         generatorName <- nfGetDefVar(funList[[1]], 'name')
-                                         name <- nf_getRefClassObject(funList[[1]])$name
-                                         Cname <- nf_getRefClassObject(funList[[1]])$Cname
-                                         if(is.null(nfCompInfos[[generatorName]])) stop("Requested buildNimbleFunctionCompilationInfo for a generator for which no specialized NF has been added to the project", call. = FALSE)
-                                         if(inherits(nfCompInfos[[generatorName]]$nfProc, 'uninitializedField')) 
-                                             nfCompInfos[[generatorName]]$nfProc <<- nfProcessing(funList, generatorName, fromModel = fromModel, project = .self, isNode = isNode)
-                                     } else {
-                                         if(missing(generatorName)) stop("If funList is omitted, a generator name must be provided to buildNimbleFunctionCompilationInfo", call. = FALSE)
-                                         if(inherits(nfCompInfos[[generatorName]]$nfProc, 'uninitializedField')) stop("buildNimbleFunctionCompilationInfo was called with only a generatorName (probably from genNeededTypes), but the nfProc is missing.", call. = FALSE)
-                                     }
-                                     if(initialTypeInferenceOnly) {
-                                         if(!nfCompInfos[[generatorName]]$RinitTypesProcessed) {
-                                             nfCompInfos[[generatorName]]$nfProc$setupTypesForUsingFunction() 
-                                             nfCompInfos[[generatorName]]$RinitTypesProcessed <<- TRUE
-                                         }
-                                         return(nfCompInfos[[generatorName]]$nfProc)
-                                     }
-                                     if(!nfCompInfos[[generatorName]]$Rcompiled) {
-                                         nfCompInfos[[generatorName]]$nfProc$process(control = control)
-                                         nfCompInfos[[generatorName]]$Rcompiled <<- TRUE
-                                     }
-                                     if(inherits(nfCompInfos[[generatorName]]$cppDef, 'uninitializedField')) {
-                                         newCppClass <- cppNimbleFunctionClass(name = generatorName,
-                                                                               nfProc = nfCompInfos[[generatorName]]$nfProc,
-                                                                               isNode = isNode,
-                                                                               debugCpp = control$debugCpp,
-                                                                               project = .self,
-                                                                               fromModel = fromModel
-                                                                               )
-                                         newCppClass$buildAll(where = where)
-                                         nfCompInfos[[generatorName]]$cppDef <<- newCppClass
-                                         newCppClass ## possible return value
-                                     } else {
-                                         nfCompInfos[[generatorName]]$cppDef ## return value if already exists
-                                     }
-                                 },
-                                 buildNimbleListCompilationInfo = function(listList = NULL, className, initialTypeInferenceOnly = FALSE, 
-                                                                             control = list(debug = FALSE, debugCpp = FALSE), where = globalenv(), fromModel = FALSE
-                                                                           ) {
-                                     if(!is.null(listList)) {
-                                         ## check for nimbleListGen and get className
-                                         if(is.nlGenerator(listList)) {
-                                             className <- nl.getListDef(listList)$className
-                                         } else {
-                                             className <- listList[[1]]$nimbleListDef$className
-                                             name <- listList[[1]]$name
-                                             Cname <- listList[[1]]$Cname
-                                         }
-                                         if(is.null(nlCompInfos[[className]])) stop("Requested buildNimbleListCompilationInfo for a generator that has not been added to the project", call. = FALSE)
-                                         if(inherits(nlCompInfos[[className]]$nlProc, 'uninitializedField')) 
-                                             nlCompInfos[[className]]$nlProc <<- nlProcessing(listList, className, project = .self)
-                                     } else {
-                                         if(missing(className)) stop("If listList is omitted, a class name must be provided to buildNimbleListCompilationInfo", call. = FALSE)
-                                         if(inherits(nlCompInfos[[className]]$nlProc, 'uninitializedField')) stop("buildNimbleListCompilationInfo was called with only a className (probably from genNeededTypes), but the nfProc is missing.", call. = FALSE)
-                                     }
-                                     if(initialTypeInferenceOnly) {
-                                         if(!nlCompInfos[[className]]$RinitTypesProcessed) {
-                                       nlCompInfos[[className]]$nlProc$setupTypesForUsingFunction() 
-                                       nlCompInfos[[className]]$RinitTypesProcessed <<- TRUE
-                                     }
-                                     return(nlCompInfos[[className]]$nlProc)
-                                   }
-                                   if(!nlCompInfos[[className]]$Rcompiled) {
-                                     nlCompInfos[[className]]$nlProc$process(control = control)
-                                     nlCompInfos[[className]]$Rcompiled <<- TRUE
-                                   }
-                                   if(inherits(nlCompInfos[[className]]$cppDef, 'uninitializedField')) {
-                                     newCppClass <- cppNimbleListClass(name = className,
-                                                                       nimCompProc = nlCompInfos[[className]]$nlProc,
-                                                                       debugCpp = control$debugCpp,
-                                                                       project = .self
-                                     )
-                                     newCppClass$buildAll(where = where)
-                                     nlCompInfos[[className]]$cppDef <<- newCppClass
-                                     newCppClass ## possible return value
-                                   } else {
-                                     nfCompInfos[[className]]$cppDef ## return value if already exists
-                                   }
-                                 },
-                                 instantiateNimbleList = function(nl, dll, asTopLevel = TRUE) { ## called by cppInterfaces_models and cppInterfaces_nimbleFunctions
-                                   ## to instantiate neededObjects
-                                   for(nestedNL in names(nl$nestedListGenList)) {
-                                     nestedAns <- instantiateNimbleList(nl[[nestedNL]], dll, asTopLevel)
-                                   }
+                                    thisRCO$.CobjectInterface <- NULL
+                                }
+                            }
+                        }
+                        nfCompInfos[[i]] <<- NULL
+                        ## cppProjects[[i]] <<- NULL
+                    }
+                }
+            }
+        },
+            
+        addModelValuesClass = function(mvConf, fromModel = FALSE) {
+            mvClassName <- environment(mvConf)$className
+            if(!is.null(mvInfos[[mvClassName]])) stop('Trying to add a modelValues class with the same name as one already in this project', call. = FALSE)
+            mvInfos[[mvClassName]] <<-  mvInfoClass(cppClassName = mvClassName, cppClass = NULL, mvConf = mvConf, fromModel = fromModel)
+        },
+        getModelValuesCppDef = function(mvConf, NULLok = FALSE) {
+            mvClassName <- environment(mvConf)$className
+            if(is.null(mvInfos[[mvClassName]])) {
+                if(!NULLok) stop('Project does not know about this modelValues class but the cppDef is being requested', call. = FALSE)
+                else return(NULL)
+            }
+            ans <- mvInfos[[mvClassName]]$cppClass
+            if(is.null(ans)) {
+                if(!NULLok) stop('cppDef for a requested modelValues class has not been generated but was requested.', call. = FALSE)
+                else return(NULL)
+            }
+            ans
+        },
+        addModel = function(model) {
+            if(!inherits(model, 'RmodelBaseClass')) stop('model provided to project is not an RmodelBaseClass', call. = FALSE)
+            modelDefName <- model$modelDef$name
+            if(is.null(modelDefInfos[[modelDefName]])) {
+                modelDefInfos[[modelDefName]] <<- modelDefInfoClass(
+                    labelMaker = labelFunctionCreator(paste0(modelDefName, '_'))
+                    )
+                if(identical(model$name, character(0))) {
+                    model$name <- modelDefInfos[[modelDefName]]$labelMaker()
+                } else {
+                    if(!is.null(models[[ model$name ]])) stop('Model provided to project has same name as another one in the same project')
+                }
+                if(identical(model$Cname, character(0))) {
+                    model$Cname <- Rname2CppName(model$name)
+                } 
+                model$nimbleProject <- .self
+                models[[ model$name ]] <<- model
+                ##modelCppInterfaces[[ model$name ]] <<- new.env()	#list(NULL)
+            }
+        },
+        addNimbleFunctionMulti = function(funList, fromModel = FALSE, generatorFunNames = NULL) {
+            if(length(funList) == 0) return(invisible(NULL))
+            if(!is.nf(funList[[1]])) stop('first nimbleFunction provided to project is not a nimbleFunction.', call. = FALSE)
+            inProjectAlready <- unlist(lapply(funList, function(x) identical(x[['nimbleProject']], .self)))
+            if(any(inProjectAlready)) {
+                stop('Trying to add list of nimbleFunctions but some are already part of another project. If you are recompiling, try redefining models and specialized nimbleFunctions. (The reset option works now for nimbleFunctions but not models.)', call. = FALSE)
+            }
+            allGeneratorNames <- if(is.null(generatorFunNames))
+                                     unlist(lapply(funList, function(x) environment(x$.generatorFunction)$name), use.names = FALSE)
+                                 else
+                                     generatorFunNames
+            generatorName2Indices <- split(seq_along(funList), allGeneratorNames) ##uniqueGeneratorNamesIndices <- which(!duplicated(allGeneratorNames))
+            for(i in seq_along(generatorName2Indices)) { ##genID in uniqueGeneratorNameIndices) {
+                genID <- generatorName2Indices[[i]][1]
+                generatorName <- names(generatorName2Indices)[i] ##allGeneratorNames[genID]
+                if(is.null(nfCompInfos[[generatorName]])) {
+                    ## nfProc could have been created already during makeTypeObject for another nimbleFunction so it knows the types of this one.
+                    nfCompInfos[[generatorName]] <<- nfCompilationInfoClass(nfGenerator = nf_getGeneratorFunction(funList[[genID]]),
+                                                                            Rcompiled = FALSE, written = FALSE, cppCompiled = FALSE, loaded = FALSE,
+                                                                            RinitTypesProcessed = FALSE, virtual = FALSE,
+                                                                            fromModel = fromModel)
+                    nfCompInfos[[generatorName]]$labelMaker <<- labelFunctionCreator(paste0(generatorName,'_'))
+                }
+                genIDs <- generatorName2Indices[[i]]
+                newLabels <- nfCompInfos[[generatorName]]$labelMaker(count = length(genIDs))
+                
+                namedFunList <- funList[genIDs]
+                names(namedFunList) <- newLabels
+                list2env(namedFunList, envir = nimbleFunctions)
+                nfCompInfos[[generatorName]]$addRinstanceList(namedFunList)
+                
+                newEnvs <- lapply(seq_along(newLabels), new.env)
+                names(newEnvs) <- newLabels
+                CppNewLabels <- Rname2CppName(newLabels)
+                for(j in seq_along(newLabels)) {
+                    funList[[genIDs[j]]][['Cname']] <- CppNewLabels[j]
+                    funList[[genIDs[j]]][['name']] <- newLabels[j] ## skip the checking done in addNimbleFunction
+                    funList[[genIDs[j]]][['nimbleProject']] <- .self
+                }
+            }
+        },
+        addNimbleFunction = function(fun, fromModel = FALSE) {
+            if(!is.nf(fun)) stop('nimbleFunction provided to project is not a nimbleFunction.', call. = FALSE)
+            inProjectAlready <- nf_getRefClassObject(fun)[['nimbleProject']]
+            if(!is.null(inProjectAlready)) {
+                if(!identical(inProjectAlready, .self)) stop('Trying to add a specialized nimbleFunction to a project, but it is already part of another project. \nIf you did not specify a project, this error can occur in trying to create a new project -- you likely need to specify the relevant model as the project.\nIf you are recompiling, try redefining models and specialized nimbleFunctions. (The reset option works now for nimbleFunctions but not models.)', call. = FALSE)
+                else warning('Adding a specialized nimbleFunction to a project to which it already belongs', call. = FALSE)
+            }
+            generatorName <- nfGetDefVar(fun, 'name')
+            if(is.null(nfCompInfos[[generatorName]])) {
+                ## nfProc could have been created already during makeTypeObject for another nimbleFunction so it knows the types of this one.
+                nfCompInfos[[generatorName]] <<- nfCompilationInfoClass(nfGenerator = nf_getGeneratorFunction(fun),
+                                                                        Rcompiled = FALSE, written = FALSE, cppCompiled = FALSE, loaded = FALSE,
+                                                                        RinitTypesProcessed = FALSE, virtual = FALSE,
+                                                                        fromModel = fromModel)
+                nfCompInfos[[generatorName]]$labelMaker <<- labelFunctionCreator(paste0(generatorName,'_'))
+            }
+            if(!exists('name', envir = nf_getRefClassObject(fun), inherits = FALSE)) {
+                assign('name', nfCompInfos[[generatorName]]$labelMaker(), envir = nf_getRefClassObject(fun))
+            } else {
+                if(!is.null(nimbleFunctions[[ nf_getRefClassObject(fun)$name ]])) {
+                    stop('nimbleFunction provided to project has same name as another one in the same project', call. = FALSE)
+                }
+            }
+            nimbleFunctions[[ nf_getRefClassObject(fun)$name ]] <<- fun
+            nfCompInfos[[generatorName]]$addRinstance(fun)
+           
+            if(!exists('Cname', envir = nf_getRefClassObject(fun), inherits = FALSE)) {
+                assign('Cname', Rname2CppName(nf_getRefClassObject(fun)$name), envir = nf_getRefClassObject(fun))
+            }
 
-                                   if(!is.nl(nl)) stop("Can't instantiateNimbleList, nl is not a nimbleList")
-                                   className <- nl$nimbleListDef$className
-                                   nlCppDef <- getNimbleListCppDef(generatorName = className)
-                                     ok <- TRUE
-                                     dllToUse <- if(isTRUE(nl.getDefinitionContent(nl.getGenerator(nl), 'predefined')))
-                                                     nimbleUserNamespace$sessionSpecificDll
-                                                 else dll
-                                   if(asTopLevel) {
-                                     if(is.null(nlCppDef$Rgenerator)) ok <- FALSE
-                                     else ans <- nlCppDef$Rgenerator(nl, dll = dllToUse, project = .self)
-                                   } else {
-                                     if(is.null(nlCppDef$CmultiInterface)) ok <- FALSE
-                                     else ans <- nlCppDef$CmultiInterface$addInstance(nl, dll = dllToUse)
-                                   }
-                                   if(!ok) stop("Oops, there is something in this compilation job that doesn\'t fit together.  This can happen in some cases if you are trying to compile new pieces into an exising project.  If that is the situation, please try including \"resetFunctions = TRUE\" as an argument to compileNimble.  Alternatively please try rebuilding the project from the beginning with more pieces in the same call to compileNimble.  For example, if you are compiling multiple algorithms for the same model in multiple calls to compileNimble, try compiling them all with one call.", call. = FALSE) 
-                                   ans
-                                 },
-                                 instantiateNimbleFunction = function(nf, dll, asTopLevel = TRUE) { ## called by cppInterfaces_models and cppInterfaces_nimbleFunctions
-                                     ## to instantiate neededObjects
-                                     if(!is.nf(nf)) stop("Can't instantiateNimbleFunction, nf is not a nimbleFunction")
-                                     generatorName <- nfGetDefVar(nf, 'name')
+            assign('nimbleProject', .self, envir = nf_getRefClassObject(fun))
+            ## could check for duplicate Cnames here, but if the names are unique the Cnames should be too.
+        },
+        addNimbleListGen = function(nlGen) {
+            if(!is.nlGenerator(nlGen)) stop('invalid nimbleListGen provided to addNimbleListGen.', call. = FALSE)
+            ## get className
+            className <- nl.getListDef(nlGen)$className
+            
+            ## check if there is a nlCompInfos,
+            ## add if needed
+            if(is.null(nlCompInfos[[className]])) {
+                ## nfProc could have been created already during makeTypeObject for another nimbleFunction so it knows the types of this one.
+                nlCompInfos[[className]] <<- nlCompilationInfoClass(written = FALSE, cppCompiled = FALSE, Rcompiled = FALSE,
+                                                                    RinitTypesProcessed = FALSE, loaded = FALSE)
+                nlCompInfos[[className]]$labelMaker <<- labelFunctionCreator(paste0(className,'_'))
+            }
+            nestedListGens <- nl.getNestedGens(nlGen)
+            for(i in seq_along(nestedListGens))
+                addNimbleListGen(nestedListGens[[i]])
+        },
+        addNimbleList = function(nl, fromModel = FALSE, nestedList = FALSE) { ##fromModel never used: clean up. 
+          if(!is.nl(nl)) stop('nimbleList provided to project is not a nimbleList.', call. = FALSE)
+          inProjectAlready <- nl[['nimbleProject']]
+          if(!is.null(inProjectAlready)) {
+            if(!identical(inProjectAlready, .self)) stop('Trying to add a specialized nimbleList to a project, but it is already part of another project. \nIf you did not specify a project, this error can occur in trying to create a new project -- you likely need to specify the relevant model as the project.\nIf you are recompiling, try redefining models and specialized nimbleFunctions and nimbleLists.', call. = FALSE)
+            else warning('Adding a specialized nimbleList to a project to which it already belongs', call. = FALSE)
+          }
 
-                                     nfCppDef <- getNimbleFunctionCppDef(generatorName = generatorName)
+          ## Next two lines can become addNimbleListGen, but would have to migrate recursion out of compileNimbleList
+          className <- nl$nimbleListDef$className
+          if(is.null(nlCompInfos[[className]])) {
+            ## nfProc could have been created already during makeTypeObject for another nimbleFunction so it knows the types of this one.
+            nlCompInfos[[className]] <<- nlCompilationInfoClass(written = FALSE, cppCompiled = FALSE, Rcompiled = FALSE,
+                                                                RinitTypesProcessed = FALSE, loaded = FALSE)
+            nlCompInfos[[className]]$labelMaker <<- labelFunctionCreator(paste0(className,'_'))
+          }
+         
+          if(!exists('name', envir = nl, inherits = FALSE)) {
+            assign('name', nlCompInfos[[className]]$labelMaker(), envir = nl)
+          } else {
+            if(!is.null(nimbleLists[[ nl$name ]])) {
+              stop('nimbleList provided to project has same name as another one in the same project', call. = FALSE)
+            }
+          }
+          if(!nestedList)   nimbleLists[[ nl$name ]] <<- nl
+          # nlCompInfos[[generatorName]]$addRinstance(nl)
+          
+          if(!exists('Cname', envir = nl, inherits = FALSE)) {
+            assign('Cname', Rname2CppName(nl$name), envir = nl)
+          }
+          
+          assign('nimbleProject', .self, envir = nl)
+          ## could check for duplicate Cnames here, but if the names are unique the Cnames should be too.
+        },
+        addRCfun = function(nfmObj, fromModel = FALSE) {
+            if(!inherits(nfmObj, 'nfMethodRC')) stop("Can't add this function. nfmObj is not an nfMethodRC", call. = FALSE)
+            className <- nfmObj$uniqueName
+            if(is.null(RCfunInfos[[className]])) {
+                RCfunInfos[[className]] <<- RCfunInfoClass(nfMethodRCobj = nfmObj, RCfunProc = NULL, cppClass = NULL, fromModel = fromModel, RinitTypesProcessed = FALSE, Rcompiled = FALSE)
+            }
+            assign('nimbleProject', .self, envir = nfmObj) ## needed for clearCompiled(), i.e. safe dyn.unload()
+        },
+        getRCfunCppDef = function(nfmObj, NULLok = FALSE) {
+            className <- nfmObj$uniqueName
+            ans <- RCfunInfos[[className]]
+            if(is.null(ans)) {
+                if(!NULLok) stop("Requested to get an RCfunCppDef but it is not in the project and NULLok = FALSE", call. = FALSE)
+                return(NULL)
+            }
+            ans <- ans$cppClass
+            if(inherits(ans, 'uninitializedField') )  return(NULL)                                     	 
+            ans
+        },
+        needRCfunCppClass = function(nfmObj, genNeededTypes = TRUE, initialTypeInference = FALSE, control = list(debug = FALSE, debugCpp = FALSE), fromModel = FALSE) {
+            if(!inherits(nfmObj, 'nfMethodRC')) stop("Can't compile this function. nfmObj is not an nfMethodRC", call. = FALSE)
+            className <- nfmObj$uniqueName
+            Cname <- Rname2CppName(className)
+            RCfunInfo <- RCfunInfos[[className]]
+            if(is.null(RCfunInfo)) addRCfun(nfmObj, fromModel = fromModel)
+            if(is.null(RCfunInfos[[className]]$RCfunProc)) {
+                RCfunInfos[[className]]$RCfunProc <<- RCfunProcessing$new(nfmObj, Cname)
+            }
+            if(!RCfunInfos[[className]]$RinitTypesProcessed) {
+                RCfunInfos[[className]]$RCfunProc$process(debug = control$debug, debugCpp = control$debugCpp, initialTypeInferenceOnly = TRUE, nimbleProject = .self)
+                RCfunInfos[[className]]$RinitTypesProcessed <<- TRUE
+            }
+            if(initialTypeInference) return(RCfunInfos[[className]]$RCfunProc)
+            if(!RCfunInfos[[className]]$Rcompiled) {
+                RCfunInfos[[className]]$RCfunProc$process(debug = control$debug, debugCpp = control$debugCpp, initialTypeInferenceOnly = FALSE, nimbleProject = .self)
+                RCfunInfos[[className]]$Rcompiled <<- TRUE
+            }
+            cppClass <- RCfunInfos[[className]]$cppClass
+            if(is.null(cppClass)) {
+                cppClass <- RCfunctionDef(project = .self)
+                cppClass$buildFunction(RCfunInfos[[className]]$RCfunProc)
+                cppClass$buildSEXPinterfaceFun()
+                if(genNeededTypes) cppClass$genNeededTypes()
+                RCfunInfos[[className]]$cppClass <<- cppClass
+            }
+            cppClass
+        },
+        compileRCfun = function( fun, filename = NULL, initialTypeInference = FALSE, control = list(debug = FALSE, debugCpp = FALSE, writeFiles = TRUE, returnAsList = FALSE), showCompilerOutput = nimbleOptions('showCompilerOutput')) {
+            disableWrite <- FALSE
+            if(nimbleOptions('enableSpecialHandling')) {
+                SH <- filenameFromSpecialHandling(fun)
+                if(!is.null(filename)) {
+                    filename <- SH
+                    disableWrite <- TRUE
+                }
+            }
+            if(is.rcf(fun)) fun <- environment(fun)$nfMethodRCobject
+            addRCfun(fun) ## checks if it already exists and if it is an nfMethodRC ## redundant? done also in next step.
+            cppClass <- needRCfunCppClass(fun, genNeededTypes = TRUE, initialTypeInference = initialTypeInference, control = control)
+            if(initialTypeInference) return(cppClass) ## in this case cppClass with be an RCfunProc
+            className <- fun$uniqueName
+            if(control$writeFiles) {
+                cppProj <- cppProjectClass(dirName = dirName)
+                cppProjects[[ className ]] <<- cppProj
+                if(is.null(filename)) filename <- paste0(projectName, '_', className)
+                cppProj$addClass( cppClass, className, filename )
+                if(!disableWrite) cppProj$writeFiles(filename)
+            }
+            if(control$compileCpp) {
+                cppProj$compileFile(filename, showCompilerOutput)
+            }
+            if(control$loadSO) {
+                cppProj$loadSO(filename)
+            }
+            RCfunCppInterfaces[[className]] <<- cppClass$buildRwrapperFunCode(includeLHS = FALSE, eval = TRUE, returnArgsAsList = control$returnAsList, dll = cppProj$dll)
+            RCfunCppInterfaces[[className]]
+        },
+        needModelValuesCppClass = function(mvConf, fromModel = FALSE) {
+            if(!isModelValuesConf(mvConf)) stop("Can't compileModelValues: mvConf is not a modelValuesConf", call. = FALSE)
+            mvClassName <- environment(mvConf)$className
+            mvInfo <- mvInfos[[mvClassName]]
+            if(is.null(mvInfo)) addModelValuesClass(mvConf, fromModel)
+            cppClass <- mvInfos[[mvClassName]]$cppClass
+            if(is.null(cppClass)) {
+                cppClass <- cppModelValuesClass(name = mvClassName,
+                                                   vars = environment(mvConf)$symTab,
+                                                   project = .self)
+                cppClass$buildAll()
+                 mvInfos[[mvClassName]]$cppClass <<- cppClass
+            }
+            cppClass
+        },
+        instantiateCmodelValues = function(mv, dll) {
+            mvClassName <- class(mv)
+            cppDef <- mvInfos[[mvClassName]]$cppClass
+            if(is.null(cppDef)) stop('Trying to instantiate a modelValues type that the project has no record of. Try setting option resetFunctions = TRUE in compileNimble')
+            generatorName <- cppDef$SEXPgeneratorFun$name
+            sym = if(!is.null(dll))
+                getNativeSymbolInfo(generatorName, dll)
+            else {
+                warning('a nimbleFunctionInterface is about to build a CmodelValues without dll info, based on generatorFun name only.', call. = FALSE)
+                generatorName
+            }
+            ans <- CmodelValues(sym, dll = dll)
+            mvInfos[[mvClassName]]$addRmv(mv) ## simply a list for later clearing
+            mv$CobjectInterface <- ans
+            ans
+        },
+        compileModel = function(model, filename = NULL,
+                                control = list(debug = FALSE, debugCpp = FALSE, writeFiles = TRUE, compileCpp = TRUE, loadSO = TRUE), showCompilerOutput = nimbleOptions('showCompilerOutput'), where = globalenv()) {
+            disableWrite <- FALSE
+            if(nimbleOptions('enableSpecialHandling')) {
+                filenames <- filenameFromSpecialHandling(model)
+                if(!is.null(filenames)) {
+                    filename <- filenames$filename
+                    nfFileName <- filenames$nfFileName
+                    disableWrite <- TRUE
+                }
+            }
+            if(is.character(model)) {
+                tmp <- models[[model]]
+                if(is.null(tmp)) stop(paste0("Model provided as name: ", model, " but it is not in this project."), call. = FALSE)
+                model <- tmp
+            } else addModel(model)
+                                                 
+            modelDef <- model$getModelDef()
+            modelDefName <- modelDef$name
+            Cname <- Rname2CppName(modelDefName)
+            if(!disableWrite) {
+                if(is.null(filename)) {
+                    filename <- paste0(projectName, '_', Rname2CppName(modelDefName)) 
+                }
+                nfFileName <- paste0(projectName, '_', Rname2CppName(modelDefName),'_nfCode')
+            }
+            modelCpp <- cppBUGSmodelClass(modelDef = modelDef, model = model,
+                                          name = Cname, project = .self)
+            ## buildAll will call back to the project to add its nimbleFunctions 
+            modelCpp$buildAll(buildNodeDefs = TRUE, where = where, control = control)
+            
+            cppProj <- cppProjectClass(dirName = dirName)
+            cppProjects[[ modelDefName ]] <<- cppProj
+            ## genModelValuesCppClass will back to the project to add its mv class
+            mvc <- modelCpp$genModelValuesCppClass()
+            ##if(is.null(filename)) filename <- paste0(projectName, '_', modelDefName)
+            cppProj$addClass(mvc, filename = filename)
+            cppProj$addClass(modelCpp, modelDefName, filename)
+            ##if compileNodes
+            ##nfFileName <- paste0(projectName, '_', Rname2CppName(modelDefName),'_nfCode')
+            for(i in names(modelCpp$nodeFuns)) {
+                cppProj$addClass(modelCpp$nodeFuns[[i]], filename = nfFileName)
+            }
+            if(control$writeFiles) {
+                if(!disableWrite) {
+                    cppProj$writeFiles(filename)
+                    cppProj$writeFiles(nfFileName) ## if compileNodes
+                }
+            } else return(cppProj)
+            if(control$compileCpp) {
+                compileList <- filename
+                compileList <- c(compileList, nfFileName) ## if compileNodes
+                cppProj$compileFile(compileList, showCompilerOutput)
+            } else return(cppProj)
+            if(control$loadSO) {
+                ## if loadSO
+                cppProj$loadSO(filename)
+            } else return(cppProj)
+            ## if buildInterface
+            interfaceName <- paste0('C', modelDefName)
+            
+            compiledModel <- modelCpp ## cppProj$cppDefs[[2]]
+            newCall <- paste0('new_',Rname2CppName(modelDefName))
+            ans <- buildModelInterface(interfaceName, compiledModel, newCall, where = where, project = .self, dll = cppProj$dll)
+            createModel <- TRUE
+            if(!createModel) return(ans) else return(ans(model, where, dll = cppProj$dll))
+            ## creating the model populates model$CobjectInterface
+        },
+        ## nimbleList functions
+        addNestedNls = function(nl){
+          for(iNl in names(nl$nestedListGenList)){
+            addNimbleList(nl[[iNl]], nestedList = TRUE)
+            if(length(nl[[iNl]]$nestedListGenList) > 0){
+              addNestedNls(nl[[iNl]])
+            }
+          }
+        },
+        compileNimbleList = function(nl, filename = NULL, initialTypeInferenceOnly = FALSE,
+            control = list(debug = FALSE, debugCpp = FALSE, compileR = TRUE, writeFiles = TRUE, compileCpp = TRUE, loadSO = TRUE),
+            reset = FALSE, returnCppClass = FALSE, className = NULL, alreadyAdded = FALSE) { ## className? alreadyAdded?
 
-                                     ok <- TRUE
-                                     if(asTopLevel) {
-                                         if(is.null(nfCppDef$Rgenerator)) ok <- FALSE
-                                         else ans <- nfCppDef$Rgenerator(nf, dll = dll, project = .self)
-                                     } else {
-                                         if(is.null(nfCppDef$CmultiInterface)) ok <- FALSE
-                                         else ans <- nfCppDef$CmultiInterface$addInstance(nf, dll = dll)
-                                     }
-                                     if(!ok) stop("Oops, there is something in this compilation job that doesn\'t fit together.  This can happen in some cases if you are trying to compile new pieces into an exising project.  If that is the situation, please try including \"resetFunctions = TRUE\" as an argument to compileNimble.  Alternatively please try rebuilding the project from the beginning with more pieces in the same call to compileNimble.  For example, if you are compiling multiple algorithms for the same model in multiple calls to compileNimble, try compiling them all with one call.", call. = FALSE) 
+            ## add possibility that nl is a generator
+            generatorOnly <- FALSE
+            if(is.nlGenerator(nl)) {
+                ## determine className
+                className <- nl.getListDef(nl)$className
+                generatorOnly <- TRUE
+                nlGen <- nl
+                nlList <- nl
+            } else {
+            
+                if(is.list(nl)) {
+                    if(is.null(className)) className <- unique(unlist(lapply(nl, function(x) x$nimbleListDef$className)))
+                    if(length(className) != 1) stop(paste0('Not all elements in the nimbleList list for compileNimbleList are from the same nimbleFunctionDef.  The class names include:', paste(className, collapse = ' ')), call. = FALSE)
+                    nlList <- nl
+                    ## set generator
+                } else {
+                    if(!is.nl(nl)) stop(paste0("nl argument provided is not a nimbleList."), call. = FALSE)
+                    nlList <- list(nl)
+                    className <- nl$nimbleListDef$className
+                    ## set generator
+                }
+                nlGen <- nl.getGenerator(nlList[[1]])
+            }
+            if(reset) nlCompInfos[[className]] <<- NULL
+            if(!alreadyAdded) {
+                if(generatorOnly) {
+                    ## check if generator exists and do addNimbleListGen
+                    ## and recurse into nestedListGenList
+                    addNimbleListGen(nlGen)
+                } else {
+                    for(i in seq_along(nlList)) {
+                        addNL <- TRUE
+                        thisName <- nlList[[i]][['name']]
+                        if(!is.null(thisName)) {
+                            tmp <- nimbleLists[[thisName]]
+                            if(!is.null(tmp)) {
+                                if(reset) {
+                                    nimbleLists[[thisName]] <<- NULL
+                                } else {
+                                    if(!identical(nlList[[i]], tmp)) stop('Trying to compile something with same name as previously added nimbleList that is not the same thing')
+                                    addNL <- FALSE
+                                }
+                            }
+                        }
+                        if(addNL){
+                            addNimbleList(nlList[[i]])
+                            ## if any nested lists, add them too (recursively)
+                            if(length(nlList[[i]]$nestedListGenList) > 0){
+                                addNestedNls(nlList[[i]])
+                            }
+                        }
+                    }
+                }
+            }
 
-                                     ans
-                                 },
-                                 setupVirtualNimbleFunction = function(vfun, fromModel = FALSE) {
-                                     if(!is.nfGenerator(vfun)) stop('nimbleFunctionVirtual provided to project is not a nimbleFunction generator.', call. = FALSE)
-                                     if(!(environment(vfun)$virtual)) stop("Something provided as a nimbleFunctionVirtual is an nfGenerator but not a virtual one.", call. = FALSE)
-                                     
-                                     generatorName <- environment(vfun)$name
-                                     if(is.null(nfCompInfos[[generatorName]])) {
-                                         nfCompInfos[[generatorName]] <<- nfCompilationInfoClass(nfGenerator = vfun,
-                                                                                                 Rcompiled = FALSE, written = FALSE, cppCompiled = FALSE, loaded = FALSE,
-                                                                                                 RinitTypesProcessed = FALSE, virtual = TRUE, fromModel = fromModel)
-                                         nfCompInfos[[generatorName]]$labelMaker <<- NULL ## not needed?
-                                     }
-                                     if(inherits(nfCompInfos[[generatorName]]$nfProc, 'uninitializedField'))
-                                         nfCompInfos[[generatorName]]$nfProc <<- virtualNFprocessing$new(vfun, generatorName, project = .self)
-                                     if(!nfCompInfos[[generatorName]]$Rcompiled) { ## to support nimbleLists, this step goes here now, so by size processing the method symbol tables will be set up
-                                         nfCompInfos[[generatorName]]$nfProc$process(control = control) ## there is no need for an initialTypeInference flag because that is *all* that a virtual NF really does anyway
-                                         nfCompInfos[[generatorName]]$Rcompiled <<- TRUE
-                                     }
-                                     nfCompInfos[[generatorName]]$nfProc
-                                 },
-                                 compileNimbleFunctionMulti = function(funList, isNode = FALSE, filename = NULL, initialTypeInferenceOnly = FALSE,
-                                     control = list(debug = FALSE, debugCpp = FALSE, compileR = TRUE, writeFiles = TRUE, compileCpp = TRUE, loadSO = TRUE),
-                                     reset = FALSE, returnCppClass = FALSE, where = globalenv(), fromModel = FALSE, generatorFunNames = NULL, alreadyAdded = FALSE, showCompilerOutput = nimbleOptions('showCompilerOutput')) {
-                                     if(!is.list(funList)) stop('funList in compileNimbleFunctionMulti should be a list', call. = FALSE)
-                                     allGeneratorNames <- if(is.null(generatorFunNames)) lapply(funList, nfGetDefVar, 'name') else generatorFunNames
-                                     uniqueGeneratorNames <- unique(allGeneratorNames)
-                                     if(initialTypeInferenceOnly || returnCppClass) {
-                                         ans <- list()
-                                         if(initialTypeInferenceOnly) oldKnownGeneratorNames <- ls(nfCompInfos)	#names(nfCompInfos)
-                                     } else ans <- vector('list', length(funList))
-                                     for(uGN in uniqueGeneratorNames) {
-                                         thisBool <- allGeneratorNames == uGN
-                                         thisAns <- compileNimbleFunction( funList[ thisBool ], isNode = isNode, filename = filename,
-                                                                          initialTypeInferenceOnly = initialTypeInferenceOnly,
-                                                                          control = control, reset = reset, returnCppClass = returnCppClass, where = where,
-                                                                          fromModel = fromModel, generatorName = uGN, alreadyAdded = alreadyAdded, showCompilerOutput = showCompilerOutput)
-                                         if(initialTypeInferenceOnly || returnCppClass) {
-                                             
-                                             if(initialTypeInferenceOnly) { ## return only new NFprocs in this case.
-                                                 thisGeneratorName <- environment(thisAns$nfGenerator)$name ## should be same as uGN
-                                                 if(!(thisGeneratorName %in% oldKnownGeneratorNames)) ans[[ thisGeneratorName ]] <- thisAns
-                                             }
-                                             else ## they should all be new in this case anyway
-                                                 ans[[ uGN ]] <- thisAns
-                                         } else {
-                                             ans[thisBool] <- thisAns ##if(is.list(thisAns)) thisAns else list(thisAns)
-                                         }
-                                     }
-                                     ans
-                                 },
-                                 compileNimbleFunction = function(fun, isNode = FALSE, filename = NULL, initialTypeInferenceOnly = FALSE,
-                                     control = list(debug = FALSE, debugCpp = FALSE, compileR = TRUE, writeFiles = TRUE, compileCpp = TRUE, loadSO = TRUE),
-                                     reset = FALSE, returnCppClass = FALSE, where = globalenv(), fromModel = FALSE, generatorName = NULL, alreadyAdded = FALSE, showCompilerOutput = nimbleOptions('showCompilerOutput')) {
-                                   if(is.character(fun)) {
-                                         tmp <- nimbleFunctions[[fun]]
-                                         if(is.null(tmp)) stop(paste0("nimbleFunction name ", fun, " not recognized in this project."), call. = FALSE)
-                                         if(reset) {
-                                             nf_getRefClassObject(tmp)$.CobjectInterface <- NULL
-                                         }
-                                         fun <- tmp
-                                         funList <- list(fun)
-                                         generatorName <- nfGetDefVar(fun, 'name')
-                                         if(reset) nfCompInfos[[generatorName]] <<- NULL
-                                     } else {
-                                         if(is.list(fun)) {
-                                             if(length(fun) == 0) stop('Empty list provided to compileNimbleFunction', call. = FALSE)
-                                             if(is.null(generatorName)) generatorName <- unique(unlist(lapply(fun, nfGetDefVar, 'name')))
-                                             if(length(generatorName) != 1) stop(paste0('Not all elements in the fun list for compileNimbleFunction are specialized from the same nimbleFunction.  The generator names include:', paste(generatorName, collapse = ' ')), call. = FALSE)
-                                             if(reset) nfCompInfos[[generatorName]] <<- NULL
-                                             funList <- fun
-                                         } else {
-                                             if(!is.nf(fun)) stop(paste0("fun argument provided is not a nimbleFunction."), call. = FALSE)
-                                             funList <- list(fun)
-                                             generatorName <- nfGetDefVar(fun, 'name')
-                                             if(reset) nfCompInfos[[generatorName]] <<- NULL
-                                         }
-                                         if(!alreadyAdded) {
-                                             for(i in seq_along(funList)) {
-                                                 addNF <- TRUE
-                                                 thisName <- nf_getRefClassObject(funList[[i]])[['name']] 
-                                                 if(!is.null(thisName)) {
-                                                     tmp <- nimbleFunctions[[thisName]]
-                                                     if(!is.null(tmp)) {
-                                                         if(reset) {
-                                                             nimbleFunctions[[thisName]] <<- NULL
-                                                         } else {
-                                                             if(!identical(funList[[i]], tmp)) stop('Trying to compile something with same name as previously added nimbleFunction that is not the same thing')
-                                                             addNF <- FALSE
-                                                         }
-                                                     }
-                                                 }
-                                                 if(addNF) {
-                                                     addNimbleFunction(funList[[i]], fromModel = fromModel)
-                                                 }
-                                             }
-                                         }
-                                     }
-##                                     Cname <- nf_getRefClassObject(funList[[1]])$Cname
+            ## modify to pull nestedListGenList from generator
+            nestedListGens <- nl.getNestedGens(nlGen)
+            for(iNestedNL in seq_along(nestedListGens)) {
+                compileNimbleList(nestedListGens[[iNestedNL]], initialTypeInferenceOnly = TRUE, alreadyAdded = TRUE)
+            }
+            ## for(iNestedNl in seq_along(nlList[[1]]$nestedListGenList)){
+            ##   ## create cppInfo for any nested list classes 
+            ##   compileNimbleList(nlList[[1]][[names(nlList[[1]]$nestedListGenList)[iNestedNl]]], initialTypeInferenceOnly = TRUE, alreadyAdded = TRUE)
+            ## }
+            cppClass <- buildNimbleListCompilationInfo(nlList, initialTypeInferenceOnly = initialTypeInferenceOnly)
+            
 
-                                     if(!exists('name', envir = nf_getRefClassObject(funList[[1]]), inherits = FALSE)) stop('Something is wrong if by this point in compileNimbleFunction there is no name.', call. = FALSE)
-                                     cppClass <- buildNimbleFunctionCompilationInfo(funList, isNode = isNode, initialTypeInferenceOnly = initialTypeInferenceOnly, control = control, where = where, fromModel = fromModel)
-                                     if(initialTypeInferenceOnly || returnCppClass) return(cppClass) ## cppClass is an nfProc in this case
+            
+            if(initialTypeInferenceOnly || returnCppClass) return(cppClass)
+            message('Remaining compileNimbleList is not yet adapted')
+            if(!nlCompInfos[[className]]$written && control$writeFiles) {
+                cppProj <- cppProjectClass(dirName = dirName)
+                cppProjects[[ className ]] <<- cppProj
+                if(is.null(filename)) filename <- paste0(projectName, '_', Rname2CppName(className))
+                cppProj$addClass(cppClass, className, filename)
+                cppProj$writeFiles(filename)
+                nlCompInfos[[className]]$written <<- TRUE
+            } else {
+                if(!control$writeFiles) return(cppProj)
+                cppProj <- cppProjects[[ className ]]
+            }
+            if(!nlCompInfos[[className]]$cppCompiled && control$compileCpp) {
+                if(control$compileCpp) {
+                    cppProj$compileFile(filename)
+                    nlCompInfos[[className]]$cppCompiled <<- TRUE
+                } else writeLines('Skipping compilation because control$compileCpp is FALSE')
+            } else {if(!control$compileCpp) return(cppProj)}#writeLines('Using previously compiled C++ code.')
+            if(!nlCompInfos[[className]]$loaded && control$loadSO) {
+                cppProj$loadSO(filename)
+                nlCompInfos[[className]]$loaded <<- TRUE
+            } else{if(!control$loadSO) return(cppProj)}# writeLines('Using previously loaded compilation unit.')
+            
+            ans <- vector('list', length(nlList))
 
-                                     ## At this point we are ready to write, compile, load and instantiate.
-                                     ## However the system for tracking these steps is not perfect.
-                                     ## Specifically, if another nimbleFunction containing an object of the current nimbleFunction
-                                     ## has already been compiled, then the files for the current one will have been written and
-                                     ## compiled, but that status is not recorded in its nfCompInfos object.
-                                     ## Also there could be other objects in the current funList that have not been instantiated.
-                                     ## As a kludgy fix, we determine whether any of the objects already have a .CobjectInterface
-                                     ## If they do, we skip over writing, compiling and loading steps.
-                                     hasCobjectInterface <- unlist(lapply(funList, function(x) {
-                                         RCO <- nf_getRefClassObject(x)
-                                         !(class(RCO$.CobjectInterface) == 'uninitializedField' || is.null(RCO$.CobjectInterface))
-                                     }))
+            for(i in seq_along(nlList)) {
+                ans[[i]] <- nlCompInfos[[className]]$cppDef$buildCallable(nlList[[i]], cppProj$dll, asTopLevel = TRUE)
+            }
+            if(length(ans) == 1) ans[[1]] else ans
+        },
+        
+        ## nimbleFunction functions
+        getNimbleFunctionCppDef = function(generatorName, nfProc) {
+            if(missing(generatorName)) {
+                if(missing(nfProc)) stop('No good information provided to getNimbleFunctionCppDef', call. = FALSE)
+                generatorName <- environment(nfProc$nfGenerator)[['name']]
+                if(is.null(generatorName)) stop('Invalid generatorName', call. = FALSE)
+            }
+            if(is.null(nfCompInfos[[generatorName]])){
+                 return(NULL)
+           }
+            ans <- nfCompInfos[[generatorName]]$cppDef
+            if(inherits(ans, 'uninitializedField') )  return(NULL)                                     	 
+            ans
+        },
+        getNimbleFunctionNFproc = function(fun) {
+            generatorName <- nfGetDefVar(fun, 'name')
+            if(is.null(nfCompInfos[[generatorName]])) return(NULL)
+            ans <- nfCompInfos[[generatorName]]$nfProc
+            if(inherits(ans, 'uninitializedField')) return(NULL)
+            ans
+        },
+        getNimbleListCppDef = function(generatorName, nlProc) {
+          if(missing(generatorName)) {
+            if(missing(nlProc)) stop('No good information provided to getNimbleListCppDef', call. = FALSE)
+            generatorName <- nlProc$nimbleListObj$className
+            if(is.null(generatorName)) stop('Invalid generatorName', call. = FALSE)
+          }
+          if(is.null(nlCompInfos[[generatorName]])){
+            return(NULL)
+          }
+          ans <- nlCompInfos[[generatorName]]$cppDef
+          if(inherits(ans, 'uninitializedField') )  return(NULL)                                     	 
+          ans
+        },
+        getNimbleListNLproc = function(fun) {
+          generatorName <- fun$name
+          if(is.null(nlCompInfos[[generatorName]])) return(NULL)
+          ans <- nlCompInfos[[generatorName]]$nlProc
+          if(inherits(ans, 'uninitializedField')) return(NULL)
+          ans
+        },
+        buildVirtualNimbleFunctionCompilationInfo = function(vfun, initialTypeInferenceOnly = FALSE, control = list(debug = FALSE, debugCpp = FALSE)) {
+            if(!is.character(vfun)) {
+                if(!is.nfGenerator(vfun)) stop("Something provided as a nimbleFunctionVirtual does not appear to be correct.", call. = FALSE)
+                if(!(environment(vfun)$virtual)) stop("Something provided as a nimbleFunctionVirtual is an nfGenerator but not a virtual one.", call. = FALSE)
+                if(initialTypeInferenceOnly) stop("Can't do initialTypeInferenceOnly on a virtualNimbleFunction", call. = FALSE)
+                generatorName <- environment(vfun)$name
+            } else {
+                generatorName <- vfun
+            }
+            if(is.null(nfCompInfos[[generatorName]])) stop("It doesn't look like nfCompInfos was set up for this generator.  Call setupVirtualNimbleFunction first.", call. = FALSE) 
+            if(inherits(nfCompInfos[[generatorName]]$nfProc, 'uninitializedField')) {## might always be FALSE by this point in processing
+                if(is.character(vfun)) stop("vfun given as character but nfProc doesn't exist yet", call. = FALSE)
+                nfCompInfos[[generatorName]]$nfProc <<- virtualNFprocessing$new(vfun, generatorName, project = .self)
+            }
+            if(!nfCompInfos[[generatorName]]$Rcompiled) {
+                nfCompInfos[[generatorName]]$nfProc$process(control = control)
+                nfCompInfos[[generatorName]]$Rcompiled <<- TRUE
+            }
+            if(inherits(nfCompInfos[[generatorName]]$cppDef, 'uninitializedField')) {
+                newCppClass <- cppVirtualNimbleFunctionClass(name = generatorName,
+                                                             nfProc = nfCompInfos[[generatorName]]$nfProc,
+                                                             project = .self)
+                nfCompInfos[[generatorName]]$cppDef <<- newCppClass
+                newCppClass ## possible return value
+            } else {
+                nfCompInfos[[generatorName]]$cppDef ## return value if already exists
+            }
+        },
+        buildNimbleFunctionCompilationInfo = function(funList = NULL, generatorName, initialTypeInferenceOnly = FALSE,
+            isNode = FALSE, control = list(debug = FALSE, debugCpp = FALSE), where = globalenv(), fromModel = FALSE) {
+            ## like old makeCppNIMBLEfunction
+            ## check of make new nfCompInfos item
+            ## ensure it is build up to the cppNimbleFunctionClass
+            if(!is.null(funList)) {
+                generatorName <- nfGetDefVar(funList[[1]], 'name')
+                name <- nf_getRefClassObject(funList[[1]])$name
+                Cname <- nf_getRefClassObject(funList[[1]])$Cname
+                if(is.null(nfCompInfos[[generatorName]])) stop("Requested buildNimbleFunctionCompilationInfo for a generator for which no specialized NF has been added to the project", call. = FALSE)
+                if(inherits(nfCompInfos[[generatorName]]$nfProc, 'uninitializedField')) 
+                    nfCompInfos[[generatorName]]$nfProc <<- nfProcessing(funList, generatorName, fromModel = fromModel, project = .self, isNode = isNode)
+            } else {
+                if(missing(generatorName)) stop("If funList is omitted, a generator name must be provided to buildNimbleFunctionCompilationInfo", call. = FALSE)
+                if(inherits(nfCompInfos[[generatorName]]$nfProc, 'uninitializedField')) stop("buildNimbleFunctionCompilationInfo was called with only a generatorName (probably from genNeededTypes), but the nfProc is missing.", call. = FALSE)
+            }
+            if(initialTypeInferenceOnly) {
+                if(!nfCompInfos[[generatorName]]$RinitTypesProcessed) {
+                    nfCompInfos[[generatorName]]$nfProc$setupTypesForUsingFunction() 
+                    nfCompInfos[[generatorName]]$RinitTypesProcessed <<- TRUE
+                }
+                return(nfCompInfos[[generatorName]]$nfProc)
+            }
+            if(!nfCompInfos[[generatorName]]$Rcompiled) {
+                nfCompInfos[[generatorName]]$nfProc$process(control = control)
+                nfCompInfos[[generatorName]]$Rcompiled <<- TRUE
+            }
+            if(inherits(nfCompInfos[[generatorName]]$cppDef, 'uninitializedField')) {
+                newCppClass <- cppNimbleFunctionClass(name = generatorName,
+                                                      nfProc = nfCompInfos[[generatorName]]$nfProc,
+                                                      isNode = isNode,
+                                                      debugCpp = control$debugCpp,
+                                                      project = .self,
+                                                      fromModel = fromModel
+                                                      )
+                newCppClass$buildAll(where = where)
+                nfCompInfos[[generatorName]]$cppDef <<- newCppClass
+                newCppClass ## possible return value
+            } else {
+                nfCompInfos[[generatorName]]$cppDef ## return value if already exists
+            }
+        },
+        buildNimbleListCompilationInfo = function(listList = NULL, className, initialTypeInferenceOnly = FALSE, 
+                                                    control = list(debug = FALSE, debugCpp = FALSE), where = globalenv(), fromModel = FALSE
+                                                  ) {
+            if(!is.null(listList)) {
+                ## check for nimbleListGen and get className
+                if(is.nlGenerator(listList)) {
+                    className <- nl.getListDef(listList)$className
+                } else {
+                    className <- listList[[1]]$nimbleListDef$className
+                    name <- listList[[1]]$name
+                    Cname <- listList[[1]]$Cname
+                }
+                if(is.null(nlCompInfos[[className]])) stop("Requested buildNimbleListCompilationInfo for a generator that has not been added to the project", call. = FALSE)
+                if(inherits(nlCompInfos[[className]]$nlProc, 'uninitializedField')) 
+                    nlCompInfos[[className]]$nlProc <<- nlProcessing(listList, className, project = .self)
+            } else {
+                if(missing(className)) stop("If listList is omitted, a class name must be provided to buildNimbleListCompilationInfo", call. = FALSE)
+                if(inherits(nlCompInfos[[className]]$nlProc, 'uninitializedField')) stop("buildNimbleListCompilationInfo was called with only a className (probably from genNeededTypes), but the nfProc is missing.", call. = FALSE)
+            }
+            if(initialTypeInferenceOnly) {
+                if(!nlCompInfos[[className]]$RinitTypesProcessed) {
+              nlCompInfos[[className]]$nlProc$setupTypesForUsingFunction() 
+              nlCompInfos[[className]]$RinitTypesProcessed <<- TRUE
+            }
+            return(nlCompInfos[[className]]$nlProc)
+          }
+          if(!nlCompInfos[[className]]$Rcompiled) {
+            nlCompInfos[[className]]$nlProc$process(control = control)
+            nlCompInfos[[className]]$Rcompiled <<- TRUE
+          }
+          if(inherits(nlCompInfos[[className]]$cppDef, 'uninitializedField')) {
+            newCppClass <- cppNimbleListClass(name = className,
+                                              nimCompProc = nlCompInfos[[className]]$nlProc,
+                                              debugCpp = control$debugCpp,
+                                              project = .self
+            )
+            newCppClass$buildAll(where = where)
+            nlCompInfos[[className]]$cppDef <<- newCppClass
+            newCppClass ## possible return value
+          } else {
+            nfCompInfos[[className]]$cppDef ## return value if already exists
+          }
+        },
+        instantiateNimbleList = function(nl, dll, asTopLevel = TRUE) { ## called by cppInterfaces_models and cppInterfaces_nimbleFunctions
+          ## to instantiate neededObjects
+          for(nestedNL in names(nl$nestedListGenList)) {
+            nestedAns <- instantiateNimbleList(nl[[nestedNL]], dll, asTopLevel)
+          }
 
-                                     if(!any(hasCobjectInterface)) {
-                                         if(!nfCompInfos[[generatorName]]$written && control$writeFiles) {
-                                             cppProj <- cppProjectClass(dirName = dirName)
-                                             cppProjects[[ generatorName ]] <<- cppProj
-                                             if(is.null(filename)) filename <- paste0(projectName, '_', Rname2CppName(generatorName))
-                                             cppProj$addClass(cppClass, generatorName, filename)
-                                             cppProj$writeFiles(filename)
-                                             nfCompInfos[[generatorName]]$written <<- TRUE
-                                         } else {
-                                             if(!control$writeFiles) return(cppProj)
-                                             cppProj <- cppProjects[[ generatorName ]]
-                                         }
-                                         if(!nfCompInfos[[generatorName]]$cppCompiled && control$compileCpp) {
-                                             if(control$compileCpp) {
-                                                 cppProj$compileFile(filename, showCompilerOutput)
-                                                 nfCompInfos[[generatorName]]$cppCompiled <<- TRUE
-                                             } else writeLines('Skipping compilation because control$compileCpp is FALSE')
-                                         } else {if(!control$compileCpp) return(cppProj)}#writeLines('Using previously compiled C++ code.')
-                                         if(!nfCompInfos[[generatorName]]$loaded && control$loadSO) {
-                                             cppProj$loadSO(filename)
-                                             nfCompInfos[[generatorName]]$loaded <<- TRUE
-                                         } else{if(!control$loadSO) return(cppProj)}# writeLines('Using previously loaded compilation unit.')
-                                     }
-                                     ans <- vector('list', length(funList))
-                                     
-                                     for(i in seq_along(funList)) {
-                                         if(!(hasCobjectInterface[i]))
-                                             ans[[i]] <- nfCompInfos[[generatorName]]$cppDef$buildCallable(funList[[i]], cppProj$dll, asTopLevel = TRUE)
-                                         else {
-                                             ## A curious possibility: If a nf was built first nested in another nf,
-                                             ## its interface may be a Cmulti interface, which is not directly user friendly
-                                             ## But if we are here via compileNimbleFunction, the user has included it in the compile request and wants
-                                             ## a full interface
-                                             ## Hence we call promote interface which checks and builds a new one if needed
-                                             ans[[i]] <- nfCompInfos[[generatorName]]$cppDef$promoteCallable(funList[[i]]) ##nf_getRefClassObject(funList[[i]])$.CobjectInterface
-                                         }
-                                     }
-                                     ##if(length(ans) == 1) ans[[1]] else ans
-                                     ans
-                                 }
-                                 )
-                             )
+          if(!is.nl(nl)) stop("Can't instantiateNimbleList, nl is not a nimbleList")
+          className <- nl$nimbleListDef$className
+          nlCppDef <- getNimbleListCppDef(generatorName = className)
+            ok <- TRUE
+            dllToUse <- if(isTRUE(nl.getDefinitionContent(nl.getGenerator(nl), 'predefined')))
+                            nimbleUserNamespace$sessionSpecificDll
+                        else dll
+          if(asTopLevel) {
+            if(is.null(nlCppDef$Rgenerator)) ok <- FALSE
+            else ans <- nlCppDef$Rgenerator(nl, dll = dllToUse, project = .self)
+          } else {
+            if(is.null(nlCppDef$CmultiInterface)) ok <- FALSE
+            else ans <- nlCppDef$CmultiInterface$addInstance(nl, dll = dllToUse)
+          }
+          if(!ok) stop("Oops, there is something in this compilation job that doesn\'t fit together.  This can happen in some cases if you are trying to compile new pieces into an exising project.  If that is the situation, please try including \"resetFunctions = TRUE\" as an argument to compileNimble.  Alternatively please try rebuilding the project from the beginning with more pieces in the same call to compileNimble.  For example, if you are compiling multiple algorithms for the same model in multiple calls to compileNimble, try compiling them all with one call.", call. = FALSE) 
+          ans
+        },
+        instantiateNimbleFunction = function(nf, dll, asTopLevel = TRUE) { ## called by cppInterfaces_models and cppInterfaces_nimbleFunctions
+            ## to instantiate neededObjects
+            if(!is.nf(nf)) stop("Can't instantiateNimbleFunction, nf is not a nimbleFunction")
+            generatorName <- nfGetDefVar(nf, 'name')
+
+            nfCppDef <- getNimbleFunctionCppDef(generatorName = generatorName)
+
+            ok <- TRUE
+            if(asTopLevel) {
+                if(is.null(nfCppDef$Rgenerator)) ok <- FALSE
+                else ans <- nfCppDef$Rgenerator(nf, dll = dll, project = .self)
+            } else {
+                if(is.null(nfCppDef$CmultiInterface)) ok <- FALSE
+                else ans <- nfCppDef$CmultiInterface$addInstance(nf, dll = dll)
+            }
+            if(!ok) stop("Oops, there is something in this compilation job that doesn\'t fit together.  This can happen in some cases if you are trying to compile new pieces into an exising project.  If that is the situation, please try including \"resetFunctions = TRUE\" as an argument to compileNimble.  Alternatively please try rebuilding the project from the beginning with more pieces in the same call to compileNimble.  For example, if you are compiling multiple algorithms for the same model in multiple calls to compileNimble, try compiling them all with one call.", call. = FALSE) 
+
+            ans
+        },
+        setupVirtualNimbleFunction = function(vfun, fromModel = FALSE) {
+            if(!is.nfGenerator(vfun)) stop('nimbleFunctionVirtual provided to project is not a nimbleFunction generator.', call. = FALSE)
+            if(!(environment(vfun)$virtual)) stop("Something provided as a nimbleFunctionVirtual is an nfGenerator but not a virtual one.", call. = FALSE)
+            
+            generatorName <- environment(vfun)$name
+            if(is.null(nfCompInfos[[generatorName]])) {
+                nfCompInfos[[generatorName]] <<- nfCompilationInfoClass(nfGenerator = vfun,
+                                                                        Rcompiled = FALSE, written = FALSE, cppCompiled = FALSE, loaded = FALSE,
+                                                                        RinitTypesProcessed = FALSE, virtual = TRUE, fromModel = fromModel)
+                nfCompInfos[[generatorName]]$labelMaker <<- NULL ## not needed?
+            }
+            if(inherits(nfCompInfos[[generatorName]]$nfProc, 'uninitializedField'))
+                nfCompInfos[[generatorName]]$nfProc <<- virtualNFprocessing$new(vfun, generatorName, project = .self)
+            if(!nfCompInfos[[generatorName]]$Rcompiled) { ## to support nimbleLists, this step goes here now, so by size processing the method symbol tables will be set up
+                nfCompInfos[[generatorName]]$nfProc$process(control = control) ## there is no need for an initialTypeInference flag because that is *all* that a virtual NF really does anyway
+                nfCompInfos[[generatorName]]$Rcompiled <<- TRUE
+            }
+            nfCompInfos[[generatorName]]$nfProc
+        },
+        compileNimbleFunctionMulti = function(funList, isNode = FALSE, filename = NULL, initialTypeInferenceOnly = FALSE,
+            control = list(debug = FALSE, debugCpp = FALSE, compileR = TRUE, writeFiles = TRUE, compileCpp = TRUE, loadSO = TRUE),
+            reset = FALSE, returnCppClass = FALSE, where = globalenv(), fromModel = FALSE, generatorFunNames = NULL, alreadyAdded = FALSE, showCompilerOutput = nimbleOptions('showCompilerOutput')) {
+            if(!is.list(funList)) stop('funList in compileNimbleFunctionMulti should be a list', call. = FALSE)
+            allGeneratorNames <- if(is.null(generatorFunNames)) lapply(funList, nfGetDefVar, 'name') else generatorFunNames
+            uniqueGeneratorNames <- unique(allGeneratorNames)
+            if(initialTypeInferenceOnly || returnCppClass) {
+                ans <- list()
+                if(initialTypeInferenceOnly) oldKnownGeneratorNames <- ls(nfCompInfos)	#names(nfCompInfos)
+            } else ans <- vector('list', length(funList))
+            for(uGN in uniqueGeneratorNames) {
+                thisBool <- allGeneratorNames == uGN
+                thisAns <- compileNimbleFunction( funList[ thisBool ], isNode = isNode, filename = filename,
+                                                 initialTypeInferenceOnly = initialTypeInferenceOnly,
+                                                 control = control, reset = reset, returnCppClass = returnCppClass, where = where,
+                                                 fromModel = fromModel, generatorName = uGN, alreadyAdded = alreadyAdded, showCompilerOutput = showCompilerOutput)
+                if(initialTypeInferenceOnly || returnCppClass) {
+                    
+                    if(initialTypeInferenceOnly) { ## return only new NFprocs in this case.
+                        thisGeneratorName <- environment(thisAns$nfGenerator)$name ## should be same as uGN
+                        if(!(thisGeneratorName %in% oldKnownGeneratorNames)) ans[[ thisGeneratorName ]] <- thisAns
+                    }
+                    else ## they should all be new in this case anyway
+                        ans[[ uGN ]] <- thisAns
+                } else {
+                    ans[thisBool] <- thisAns ##if(is.list(thisAns)) thisAns else list(thisAns)
+                }
+            }
+            ans
+        },
+        compileNimbleFunction = function(fun, isNode = FALSE, filename = NULL, initialTypeInferenceOnly = FALSE,
+            control = list(debug = FALSE, debugCpp = FALSE, compileR = TRUE, writeFiles = TRUE, compileCpp = TRUE, loadSO = TRUE),
+            reset = FALSE, returnCppClass = FALSE, where = globalenv(), fromModel = FALSE, generatorName = NULL, alreadyAdded = FALSE, showCompilerOutput = nimbleOptions('showCompilerOutput')) {
+          if(is.character(fun)) {
+                tmp <- nimbleFunctions[[fun]]
+                if(is.null(tmp)) stop(paste0("nimbleFunction name ", fun, " not recognized in this project."), call. = FALSE)
+                if(reset) {
+                    nf_getRefClassObject(tmp)$.CobjectInterface <- NULL
+                }
+                fun <- tmp
+                funList <- list(fun)
+                generatorName <- nfGetDefVar(fun, 'name')
+                if(reset) nfCompInfos[[generatorName]] <<- NULL
+            } else {
+                if(is.list(fun)) {
+                    if(length(fun) == 0) stop('Empty list provided to compileNimbleFunction', call. = FALSE)
+                    if(is.null(generatorName)) generatorName <- unique(unlist(lapply(fun, nfGetDefVar, 'name')))
+                    if(length(generatorName) != 1) stop(paste0('Not all elements in the fun list for compileNimbleFunction are specialized from the same nimbleFunction.  The generator names include:', paste(generatorName, collapse = ' ')), call. = FALSE)
+                    if(reset) nfCompInfos[[generatorName]] <<- NULL
+                    funList <- fun
+                } else {
+                    if(!is.nf(fun)) stop(paste0("fun argument provided is not a nimbleFunction."), call. = FALSE)
+                    funList <- list(fun)
+                    generatorName <- nfGetDefVar(fun, 'name')
+                    if(reset) nfCompInfos[[generatorName]] <<- NULL
+                }
+                if(!alreadyAdded) {
+                    for(i in seq_along(funList)) {
+                        addNF <- TRUE
+                        thisName <- nf_getRefClassObject(funList[[i]])[['name']] 
+                        if(!is.null(thisName)) {
+                            tmp <- nimbleFunctions[[thisName]]
+                            if(!is.null(tmp)) {
+                                if(reset) {
+                                    nimbleFunctions[[thisName]] <<- NULL
+                                } else {
+                                    if(!identical(funList[[i]], tmp)) stop('Trying to compile something with same name as previously added nimbleFunction that is not the same thing')
+                                    addNF <- FALSE
+                                }
+                            }
+                        }
+                        if(addNF) {
+                            addNimbleFunction(funList[[i]], fromModel = fromModel)
+                        }
+                    }
+                }
+            }
+              Cname <- nf_getRefClassObject(funList[[1]])$Cname
+
+            if(!exists('name', envir = nf_getRefClassObject(funList[[1]]), inherits = FALSE)) stop('Something is wrong if by this point in compileNimbleFunction there is no name.', call. = FALSE)
+            cppClass <- buildNimbleFunctionCompilationInfo(funList, isNode = isNode, initialTypeInferenceOnly = initialTypeInferenceOnly, control = control, where = where, fromModel = fromModel)
+            if(initialTypeInferenceOnly || returnCppClass) return(cppClass) ## cppClass is an nfProc in this case
+
+            ## At this point we are ready to write, compile, load and instantiate.
+            ## However the system for tracking these steps is not perfect.
+            ## Specifically, if another nimbleFunction containing an object of the current nimbleFunction
+            ## has already been compiled, then the files for the current one will have been written and
+            ## compiled, but that status is not recorded in its nfCompInfos object.
+            ## Also there could be other objects in the current funList that have not been instantiated.
+            ## As a kludgy fix, we determine whether any of the objects already have a .CobjectInterface
+            ## If they do, we skip over writing, compiling and loading steps.
+            hasCobjectInterface <- unlist(lapply(funList, function(x) {
+                RCO <- nf_getRefClassObject(x)
+                !(class(RCO$.CobjectInterface) == 'uninitializedField' || is.null(RCO$.CobjectInterface))
+            }))
+
+            if(!any(hasCobjectInterface)) {
+                if(!nfCompInfos[[generatorName]]$written && control$writeFiles) {
+                    cppProj <- cppProjectClass(dirName = dirName)
+                    cppProjects[[ generatorName ]] <<- cppProj
+                    if(is.null(filename)) filename <- paste0(projectName, '_', Rname2CppName(generatorName))
+                    cppProj$addClass(cppClass, generatorName, filename)
+                    cppProj$writeFiles(filename)
+                    nfCompInfos[[generatorName]]$written <<- TRUE
+                } else {
+                    if(!control$writeFiles) return(cppProj)
+                    cppProj <- cppProjects[[ generatorName ]]
+                }
+                if(!nfCompInfos[[generatorName]]$cppCompiled && control$compileCpp) {
+                    if(control$compileCpp) {
+                        cppProj$compileFile(filename, showCompilerOutput)
+                        nfCompInfos[[generatorName]]$cppCompiled <<- TRUE
+                    } else writeLines('Skipping compilation because control$compileCpp is FALSE')
+                } else {if(!control$compileCpp) return(cppProj)}#writeLines('Using previously compiled C++ code.')
+                if(!nfCompInfos[[generatorName]]$loaded && control$loadSO) {
+                    cppProj$loadSO(filename)
+                    nfCompInfos[[generatorName]]$loaded <<- TRUE
+                } else{if(!control$loadSO) return(cppProj)}# writeLines('Using previously loaded compilation unit.')
+            }
+            ans <- vector('list', length(funList))
+            
+            for(i in seq_along(funList)) {
+                if(!(hasCobjectInterface[i]))
+                    ans[[i]] <- nfCompInfos[[generatorName]]$cppDef$buildCallable(funList[[i]], cppProj$dll, asTopLevel = TRUE)
+                else {
+                    ## A curious possibility: If a nf was built first nested in another nf,
+                    ## its interface may be a Cmulti interface, which is not directly user friendly
+                    ## But if we are here via compileNimbleFunction, the user has included it in the compile request and wants
+                    ## a full interface
+                    ## Hence we call promote interface which checks and builds a new one if needed
+                    ans[[i]] <- nfCompInfos[[generatorName]]$cppDef$promoteCallable(funList[[i]]) ##nf_getRefClassObject(funList[[i]])$.CobjectInterface
+                }
+            }
+            ##if(length(ans) == 1) ans[[1]] else ans
+            ans
+        }
+    )
+)
 
 clearCompiled <- function(obj) { # for now just take one obj as input
     np <- getNimbleProject(obj)


### PR DESCRIPTION
This PR is merely cosmetic:
- Reindents `setRefClass` bodies to reduce gratuitous whitespace.
- Replaces `exprClass()` with `exprClass$new()` for consistency.
- Adds punctuation to a few comments.

## Caveats
Whitespace changes taint github's blame view, but you can still see the original blame using git on the command line: pass the `-w` flag to ignore whitespace:
```sh
git blame -w packages/nimble/R/RCfunction_compile.R
```