### PR TITLE
Add first unit test of exprClass transformations

### DIFF
--- a/packages/nimble/inst/tests/test-genCpp.R
+++ b/packages/nimble/inst/tests/test-genCpp.R
@@ -3,22 +3,41 @@
 
 source(system.file(file.path('tests', 'test_utils.R'), package = 'nimble'))
 
-skip_if_not_installed('pryr')
-
 context("Unit tests of code transformations")
 
-RparseTree2ExprClasses <- nimble:::RparseTree2ExprClasses
-nimDeparse <- nimble:::nimDeparse
+# These wrappers help convert between exprClass and R parse trees.
+code_to_expr <- nimble:::RparseTree2ExprClasses
+expr_to_code <- function(expr) {
+    if (!inherits(expr, 'exprClass')) stop(paste('Expected an exprClass, got', class(expr)))
+    deparsed <- nimble:::nimDeparse(expr)
+    # nimDeparse returns a list rather than a character vector,
+    # and after parsing, the code is wrapped in expression(-).
+    code <- parse(text = as.character(deparsed))[[1]]
+    return(code)
+}
 
-test_that('nimDeparse roughly inverts RparseTree2ExprClasses', {
+test_that('Transform from code to expr and back', {
+    expected_code <- quote({
+        x <- rep(0, 4)
+        y <- sin(inprod(x, x))
+    })
+    expr <- code_to_expr(expected_code)
+    actual_code <- expr_to_code(expr)
+    expect_equal(actual_code, expected_code)
+})
+
+test_that('sin(inprod(x,x)) is transformed to sin(eigenInprod(x,x))', {
     code <- quote({
         x <- rep(0, 4)
         y <- sin(inprod(x, x))
     })
-    nimCode <- RparseTree2ExprClasses(code)
-    deparsed <- nimDeparse(nimCode)
-    # nimDeparse returns a list rather than a character vector,
-    # and the code is wrapped in expression(-).
-    actual_code <- parse(text = as.character(deparsed))[[1]]
+    # TODO(fritzo,perrydv) Refactor to expose compiler stages, e.g.
+    # - Try to avoid accessing mutable state.
+    # - Prefer pure functions over class methods with side-effects.
+    # - Add helpers to convert and compare exprClass instances.
+    skip('This does not work yet')
+    proc <- RCfunProcessing$new()
+    compileInfo <- nimble:::RCfunctionCompileClass$new(origRcode = code, newRcode = code)
+    expr <- code_to_expr(code)
     expect_equal(actual_code, code)
 })

--- a/packages/nimble/inst/tests/test-genCpp.R
+++ b/packages/nimble/inst/tests/test-genCpp.R
@@ -1,0 +1,24 @@
+# This file consists of unit tests of the code generation internals of NIMBLE, and
+# should never invoke a compiler.
+
+source(system.file(file.path('tests', 'test_utils.R'), package = 'nimble'))
+
+skip_if_not_installed('pryr')
+
+context("Unit tests of code transformations")
+
+RparseTree2ExprClasses <- nimble:::RparseTree2ExprClasses
+nimDeparse <- nimble:::nimDeparse
+
+test_that('nimDeparse roughly inverts RparseTree2ExprClasses', {
+    code <- quote({
+        x <- rep(0, 4)
+        y <- sin(inprod(x, x))
+    })
+    nimCode <- RparseTree2ExprClasses(code)
+    deparsed <- nimDeparse(nimCode)
+    # nimDeparse returns a list rather than a character vector,
+    # and the code is wrapped in expression(-).
+    actual_code <- parse(text = as.character(deparsed))[[1]]
+    expect_equal(actual_code, code)
+})


### PR DESCRIPTION
**Status:** Do not merge, for review only.

## User Story

A user files a bug like "`step(inprod(x,y))` does not compile". As a developer, I want to write a failing unit test for this bug. This test should exercise only the compiler stage responsible for this bug. But the only test I can currently write is an end-to-end test that parses, generates C++, and compiles. 

## Description

This PR starts to create infrastructure for **unit tests** of Nimble's compiler, i.e. small fast tests that exercise only one part of the compiler chain. This approach contrasts many of the existing **end-to-end tests** of the compiler, such as those in `test-math.R`.

The goal of these unit tests is to achieve more complete testing and reduced test latency. These goals can be achieved by factorizing our tests: Rather than running `N1 x N2 x ... x Nk` end-to-end tests of a `k`-stage compiler, we can run `N1 + N2 + ... + Nk` unit tests over components. However this forces us to specify the `k-1` intermediate representations between each stage. Most of these intermediate representations are just `exprClass` instances with various fields initialized.