### PR TITLE
fix to autoBlock using new sampler defaults

### DIFF
--- a/packages/nimble/NEWS
+++ b/packages/nimble/NEWS
@@ -1,6 +1,11 @@
 
+USER LEVEL CHANGES
 
 -- Improved efficiency of MCMC conjugate samplers.
+
+BUG FIXES
+
+-- Fixed MCMC autoBlocking procedure, to work with new sampler default values system.
 
 
                            CHANGES IN VERSION 0.6-6 (July 2017)

--- a/packages/nimble/R/MCMC_autoBlock.R
+++ b/packages/nimble/R/MCMC_autoBlock.R
@@ -293,7 +293,7 @@ autoBlockClass <- setRefClass(
             for(i in seq_along(CmcmcList)) {
                 if(setSeed) set.seed(0)
                 abModel$resetCmodelInitialValues()
-                timingList[[i]] <- as.numeric(system.time(CmcmcList[[i]]$run(niter))[3])
+                timingList[[i]] <- as.numeric(system.time(CmcmcList[[i]]$run(niter, progressBar = FALSE))[3])
                 burnedSamples <- extractAndBurnSamples(CmcmcList[[i]])
                 essList[[i]] <- apply(burnedSamples, 2, effectiveSize)
                 essList[[i]] <- essList[[i]][essList[[i]] > 0]  ## exclude nodes with ESS=0 -- for discrete nodes which are fixed to a certain value; making work with discrete nodes

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -938,7 +938,7 @@ makeNewConfFromOldConf <- function(oldMCMCconf){
     newMCMCconf$thin2 <- oldMCMCconf$thin2
     newMCMCconf$samplerConfs <- oldMCMCconf$samplerConfs
     newMCMCconf$controlDefaults <- oldMCMCconf$controlDefaults
-    newMCMCconf$controlNamesLibrary <- oldMCMCconf$controlNamesLibrary
+    newMCMCconf$namedSamplerLabelMaker <- oldMCMCconf$namedSamplerLabelMaker
     newMCMCconf$mvSamples1Conf <- oldMCMCconf$mvSamples1Conf
     newMCMCconf$mvSamples2Conf <- oldMCMCconf$mvSamples2Conf
     return(newMCMCconf)	


### PR DESCRIPTION
Updated autoBlock system to correctly use new system with sampler control defaults.

Also, removed printing the MCMC progress bar, during the autoBlock preliminary runs.

Running this fix through all testing before merging.