### PR TITLE
reformat RCfunction_[core, compile].R to improve readability.

### DIFF
--- a/packages/nimble/R/RCfunction_compile.R
+++ b/packages/nimble/R/RCfunction_compile.R
@@ -1,116 +1,170 @@
 ## Small class for information on compilation of each nf method
-RCfunctionCompileClass <- setRefClass('RCfunctionCompileClass',
-                                      fields = list(
-                                          origRcode = 'ANY',
-                                          origLocalSymTab = 'ANY',
-                                          nimExpr = 'ANY',
-                                          newLocalSymTab = 'ANY',
-                                          returnSymbol = 'ANY',
-                                          newRcode = 'ANY',
-                                          typeEnv = 'ANY'	#environment
-                                          ),
-                                          methods = list(initialize = function(...){typeEnv <<- new.env(); callSuper(...)}
-                                          ))
+RCfunctionCompileClass <- setRefClass(
+    'RCfunctionCompileClass',
+    fields = list(
+        origRcode = 'ANY',
+        origLocalSymTab = 'ANY',
+        nimExpr = 'ANY',
+        newLocalSymTab = 'ANY',
+        returnSymbol = 'ANY',
+        newRcode = 'ANY',
+        typeEnv = 'ANY'	#environment
+    ),
+    methods = list(
+        initialize = function(...){
+            typeEnv <<- new.env()
+            callSuper(...)
+        }
+    ))
 
-RCvirtualFunProcessing <- setRefClass('RCvirtualFunProcessing',
-                                      fields = list(
-                                          name = 'ANY',		#character
-                                          RCfun = 'ANY', ##nfMethodRC
-                                          nameSubList = 'ANY',
-                                          compileInfo = 'ANY', ## RCfunctionCompileClass``
-                                          const = 'ANY',
-                                          neededRCfuns = 'ANY',
-                                          initialTypeInferenceDone = 'ANY'
-                                          ),
-                                      methods = list(
-                                          initialize = function(f = NULL, funName, const = FALSE) {
-                                              const <<- const
-                                              if(!is.null(f)) {
-                                                  if(missing(funName)) {
-                                                      sf <- substitute(f)
-                                                      name <<- Rname2CppName(deparse(sf))
-                                                  } else {
-                                                      name <<- funName
-                                                  }
-                                                  if(is.function(f)) {
-                                                      RCfun <<- nfMethodRC$new(f)
-                                                  } else {
-                                                      if(!inherits(f, 'nfMethodRC')) {
-                                                          stop('Error: f must be a function or an RCfunClass')
-                                                      }
-                                                      RCfun <<- f
-                                                  }
-                                                  compileInfo <<- RCfunctionCompileClass$new(origRcode = RCfun$code, newRcode = RCfun$code)
-                                              }
-                                              neededRCfuns <<- list()
-                                              initialTypeInferenceDone <<- FALSE
-                                          },
-                                          showCpp = function() {
-                                              writeCode(nimGenerateCpp(compileInfo$nimExpr, compileInfo$newLocalSymTab))
-                                          },
-                                          setupSymbolTables = function(parentST = NULL, neededTypes = NULL, nimbleProject = NULL) {
-                                              argInfoWithMangledNames <- RCfun$argInfo
-                                              numArgs <- length(argInfoWithMangledNames)
-                                              if(numArgs > 0) {
-                                                  argIsBlank <- unlist(lapply(RCfun$argInfo, identical, formals(function(a) {})[[1]]))
-                                                  ## it seems to be impossible to store the value of a blank argument, formals(function(a) {})[[1]], in a variable
-                                                  if(any(argIsBlank)) {
-                                                      stop(paste0("Type declaration missing for argument(s) ", paste(names(RCfun$argInfo)[argIsBlank], collapse = ", ")), call. = FALSE)
-                                                  }
-                                              }
-                                              argInfoWithMangledNames <- RCfun$argInfo
-                                              numArgs <- length(argInfoWithMangledNames)
-                                              if(numArgs>0) names(argInfoWithMangledNames) <- paste0("ARG", 1:numArgs, "_", Rname2CppName(names(argInfoWithMangledNames)),"_")
-                                              nameSubList <<- lapply(names(argInfoWithMangledNames), as.name)
-                                              names(nameSubList) <<- names(RCfun$argInfo)
+RCvirtualFunProcessing <- setRefClass(
+    'RCvirtualFunProcessing',
+    fields = list(
+        name = 'ANY',		##character
+        RCfun = 'ANY',          ##nfMethodRC
+        nameSubList = 'ANY',
+        compileInfo = 'ANY',    ## RCfunctionCompileClass``
+        const = 'ANY',
+        neededRCfuns = 'ANY',
+        initialTypeInferenceDone = 'ANY'
+    ),
+    methods = list(
+        initialize = function(f = NULL, funName, const = FALSE) {
+            const <<- const
+            if(!is.null(f)) {
+                if(missing(funName)) {
+                    sf <- substitute(f)
+                    name <<- Rname2CppName(deparse(sf))
+                } else {
+                    name <<- funName
+                }
+                if(is.function(f)) {
+                    RCfun <<- nfMethodRC$new(f)
+                } else {
+                    if(!inherits(f, 'nfMethodRC')) {
+                        stop('Error: f must be a function or an RCfunClass')
+                    }
+                    RCfun <<- f
+                }
+                compileInfo <<- RCfunctionCompileClass$new(
+                    origRcode = RCfun$code,
+                    newRcode = RCfun$code)
+            }
+            neededRCfuns <<- list()
+            initialTypeInferenceDone <<- FALSE
+        },
+        showCpp = function() {
+            writeCode(
+                nimGenerateCpp(compileInfo$nimExpr, compileInfo$newLocalSymTab)
+            )
+        },
+        setupSymbolTables = function(parentST = NULL,
+                                     neededTypes = NULL,
+                                     nimbleProject = NULL) {
+            argInfoWithMangledNames <- RCfun$argInfo
+            numArgs <- length(argInfoWithMangledNames)
+            if(numArgs > 0) {
+                argIsBlank <- unlist(
+                    lapply(RCfun$argInfo,
+                           identical,
+                           formals(function(a) {})[[1]])
+                )
+                ## N.B: It seems to be impossible to store the value of a blank argument, formals(function(a) {})[[1]], in a variable
+                if(any(argIsBlank)) {
+                    stop(paste0("Type declaration missing for argument(s) ",
+                                paste(names(RCfun$argInfo)[argIsBlank],
+                                      collapse = ", ")),
+                         call. = FALSE)
+                }
+            }
+            argInfoWithMangledNames <- RCfun$argInfo
+            numArgs <- length(argInfoWithMangledNames)
+            if(numArgs>0)
+                names(argInfoWithMangledNames) <-
+                    paste0("ARG",
+                           1:numArgs,
+                           "_",
+                           Rname2CppName(names(argInfoWithMangledNames)),"_")
+            nameSubList <<- lapply(names(argInfoWithMangledNames),
+                                   as.name)
+            names(nameSubList) <<- names(RCfun$argInfo)
+            
+            ## This will only handle basic types.
+            ## nimbleLists will be added below
+            compileInfo$origLocalSymTab <<-
+                argTypeList2symbolTable(argInfoWithMangledNames,
+                                        neededTypes,
+                                        names(RCfun$argInfo)) 
+            compileInfo$newLocalSymTab <<-
+                argTypeList2symbolTable(argInfoWithMangledNames,
+                                        neededTypes,
+                                        names(RCfun$argInfo))
 
-                                              ## This will only handle basic types.  nimbleLists will be added below
-                                              compileInfo$origLocalSymTab <<- argTypeList2symbolTable(argInfoWithMangledNames, neededTypes, names(RCfun$argInfo)) ## will be used for function args.  must be a better way.
-                                              compileInfo$newLocalSymTab <<- argTypeList2symbolTable(argInfoWithMangledNames, neededTypes, names(RCfun$argInfo))
+            ## This modifies the symTab and returns types needed for
+            ## input or return.
 
-                                              ## This modifies the symTab and returns types needed for input or return
-                                              ## Currently the only non-basic type resolves in this step would be nimbleLists
-                                              if(is.null(nimbleProject)) nimbleProject <- get('nimbleProject', envir = RCfun)
-                                              neededRCfuns <<- resolveUnknownTypes(compileInfo$origLocalSymTab, neededTypes, nimbleProject)
-                                              resolveUnknownTypes(compileInfo$newLocalSymTab, c(neededRCfuns, neededTypes), nimbleProject)
-                                              
-                                              if(!is.null(parentST)) {
-                                                  compileInfo$origLocalSymTab$setParentST(parentST)
-                                                  compileInfo$newLocalSymTab$setParentST(parentST)
-                                              }
-                                              compileInfo$returnSymbol <<- argType2symbol(RCfun$returnType, neededTypes, "return", "returnType")
-                                              updatedReturn <- resolveOneUnknownType(compileInfo$returnSymbol, c(neededRCfuns, neededTypes), nimbleProject)
-                                              compileInfo$returnSymbol <<- updatedReturn[[1]]
-                                              neededRCfuns <<- c(neededRCfuns, updatedReturn[[2]])
-                                          },
-                                          process = function(...) {
-                                              if(inherits(compileInfo$origLocalSymTab, 'uninitializedField')) {
-                                                  setupSymbolTables()
-                                              }
-                                          },
-                                          printCode = function() {
-                                              writeCode(nimDeparse(compileInfo$nimExpr))
-                                          }
-                                      )
-                                      )
+            ## Currently the only non-basic type resolved in this step
+            ## would be nimbleLists.
+            if(is.null(nimbleProject))
+                nimbleProject <- get('nimbleProject', envir = RCfun)
+            neededRCfuns <<-
+                resolveUnknownTypes(compileInfo$origLocalSymTab,
+                                    neededTypes,
+                                    nimbleProject)
+            resolveUnknownTypes(compileInfo$newLocalSymTab,
+                                c(neededRCfuns, neededTypes),
+                                nimbleProject)
+            
+            if(!is.null(parentST)) {
+                compileInfo$origLocalSymTab$setParentST(parentST)
+                compileInfo$newLocalSymTab$setParentST(parentST)
+            }
+            compileInfo$returnSymbol <<-
+                argType2symbol(RCfun$returnType,
+                               neededTypes,
+                               "return",
+                               "returnType")
+            updatedReturn <-
+                resolveOneUnknownType(compileInfo$returnSymbol,
+                                      c(neededRCfuns, neededTypes),
+                                      nimbleProject)
+            compileInfo$returnSymbol <<- updatedReturn[[1]]
+            neededRCfuns <<- c(neededRCfuns, updatedReturn[[2]])
+        },
+        process = function(...) {
+            if(inherits(compileInfo$origLocalSymTab, 'uninitializedField')) {
+                setupSymbolTables()
+            }
+        },
+        printCode = function() {
+            writeCode(nimDeparse(compileInfo$nimExpr))
+        }
+    )
+)
 
 RCfunction <- function(f, name = NA, returnCallable = TRUE, check) {
-    if(is.na(name)) name <- rcFunLabelMaker()
+    if(is.na(name))
+        name <- rcFunLabelMaker()
     nfm <- nfMethodRC$new(f, name, check = check)
-    if(returnCallable) nfm$generateFunctionObject(keep.nfMethodRC = TRUE) else nfm
+    if(returnCallable)
+        nfm$generateFunctionObject(keep.nfMethodRC = TRUE)
+    else
+        nfm
 }
 
 is.rcf <- function(x, inputIsName = FALSE) {
-    if(inputIsName) x <- get(x)
-    if(inherits(x, 'nfMethodRC')) return(TRUE)
+    if(inputIsName)
+        x <- get(x)
+    if(inherits(x, 'nfMethodRC'))
+        return(TRUE)
     if(is.function(x)) {
-        if(is.null(environment(x))) return(FALSE)
-        if(exists('nfMethodRCobject', envir = environment(x), inherits = FALSE)) return(TRUE)
+        if(is.null(environment(x)))
+            return(FALSE)
+        if(exists('nfMethodRCobject', envir = environment(x), inherits = FALSE))
+            return(TRUE)
     }
     FALSE
 }
-
-
 
 rcFunLabelMaker <- labelFunctionCreator('rcFun')
 
@@ -123,226 +177,303 @@ nf_substituteExceptFunctionsAndDollarSigns <- function(code, subList) {
     if(is.null(code)) return(code)
     if(is.name(code)) {
         maybeAns <- subList[[as.character(code)]]
-        return( if(is.null(maybeAns)) code else maybeAns )
+        return(
+            if(is.null(maybeAns))
+                code
+            else
+                maybeAns
+        )
     }
     if(is.call(code)) {
-        if(length(code) == 1) return(code)
-        else
-            if(is.call(code[[1]])) indexRange <- 1:length(code)
-            else
-                if(as.character(code[[1]])=='$') indexRange <- 2
+        if(length(code) == 1)
+            return(code)
+        else {
+            if(is.call(code[[1]]))
+                indexRange <- 1:length(code)
+            else {
+                if(as.character(code[[1]])=='$')
+                    indexRange <- 2
                 else 
                     indexRange <- 2:length(code)
-        for(i in indexRange) code[[i]] <- nf_substituteExceptFunctionsAndDollarSigns(code[[i]], subList)
+            }
+        }
+        for(i in indexRange)
+            code[[i]] <-
+                nf_substituteExceptFunctionsAndDollarSigns(code[[i]], subList)
         return(code)
     }
-    if(is.list(code)) { ## Keyword processing stage of compilation may have stuck lists into the argument list of a call (for maps)
-        code <- lapply(code, nf_substituteExceptFunctionsAndDollarSigns, subList)
+    if(is.list(code)) {
+        ## Keyword processing stage of compilation may have stuck
+        ## lists into the argument list of a call (for maps)
+        code <- lapply(code,
+                       nf_substituteExceptFunctionsAndDollarSigns,
+                       subList)
         return(code)
     }
     stop(paste("Error doing replacement for code ", deparse(code)))
 }
 
-RCfunProcessing <- setRefClass('RCfunProcessing',
-                               contains = 'RCvirtualFunProcessing',
-                               fields = list(),
-                                   methods = list(
-                                   process = function(debug = FALSE, debugCpp = FALSE, debugCppLabel = character(), doKeywords = TRUE, nimbleProject = NULL, initialTypeInferenceOnly = FALSE) {
-                                       if(!is.null(nimbleOptions()$debugRCfunProcessing)) {
-                                           if(nimbleOptions()$debugRCfunProcessing) {
-                                               debug <- TRUE
-                                               writeLines('Debugging RCfunProcessing (nimbleOptions()$debugRCfunProcessing is set to TRUE)') 
-                                           }
-                                       }
+RCfunProcessing <- setRefClass(
+    'RCfunProcessing',
+    contains = 'RCvirtualFunProcessing',
+    fields = list(),
+    methods = list(
+        process = function(debug = FALSE,
+                           debugCpp = FALSE,
+                           debugCppLabel = character(),
+                           doKeywords = TRUE,
+                           nimbleProject = NULL,
+                           initialTypeInferenceOnly = FALSE) {
+            if(!is.null(nimbleOptions()$debugRCfunProcessing)) {
+                if(nimbleOptions()$debugRCfunProcessing) {
+                    debug <- TRUE
+                    writeLines('Debugging RCfunProcessing (nimbleOptions()$debugRCfunProcessing is set to TRUE)') 
+                }
+            }
+            
+            if(debug) {
+                writeLines('**** READY to start RCfunProcessing::process *****')
+                browser()
+            }
+            
+            if(is.null(nimbleProject))
+                nimbleProject <- get('nimbleProject', envir = RCfun)
+            
+            if(!initialTypeInferenceDone) {
+                
+                if(!is.null(nimbleOptions()$debugCppLineByLine)) {
+                    if(nimbleOptions()$debugCppLineByLine) {
+                        debugCpp <- TRUE
+                        if(length(debugCppLabel) == 0) debugCppLabel <- name
+                    }
+                }
+                
+                if(doKeywords) {
+                    matchKeywords()
+                    processKeywords()
+                }
+                
+                if(inherits(compileInfo$origLocalSymTab,
+                            'uninitializedField')) {
+                    setupSymbolTables()
+                }
+                initialTypeInferenceDone <<- TRUE
+            }
+            if(initialTypeInferenceOnly)
+                return(NULL);
+            
+            if(debug) {
+                writeLines('**** READY FOR makeExprClassObjects *****')
+                browser()
+            }
+            if(length(nameSubList) > 0)
+                compileInfo$newRcode <<-
+                    nf_substituteExceptFunctionsAndDollarSigns(compileInfo$newRcode,
+                                                               nameSubList)
+            ## set up exprClass object
+            compileInfo$nimExpr <<- RparseTree2ExprClasses(compileInfo$newRcode)
+            
+            if(debug) {
+                print('nimDeparse(compileInfo$nimExpr)')
+                writeCode(nimDeparse(compileInfo$nimExpr))
+                writeLines('***** READY FOR processSpecificCalls *****')
+                browser()
+            }
+            
+            exprClasses_processSpecificCalls(compileInfo$nimExpr,
+                                             compileInfo$newLocalSymTab)
 
-                                       if(debug) {
-                                           writeLines('**** READY to start RCfunProcessing::process *****')
-                                           browser()
-                                       }
+            if(debug) {
+                print('nimDeparse(compileInfo$nimExpr)')
+                writeCode(nimDeparse(compileInfo$nimExpr))
+                writeLines('***** READY FOR buildInterms *****')
+                browser()
+            }
+            
+            ## build intermediate variables
+            exprClasses_buildInterms(compileInfo$nimExpr)
+            
+            if(debug) {
+                print('nimDeparse(compileInfo$nimExpr)')
+                writeCode(nimDeparse(compileInfo$nimExpr))
+                print('compileInfo$newLocalSymTab')
+                print(compileInfo$newLocalSymTab)
+                writeLines('***** READY FOR initSizes *****')
+                browser()
+            }
+            compileInfo$typeEnv <<-
+                exprClasses_initSizes(compileInfo$nimExpr,
+                                      compileInfo$newLocalSymTab,
+                                      returnSymbol = compileInfo$returnSymbol)
+            if(debug) {
+                print('ls(compileInfo$typeEnv)')
+                print(ls(compileInfo$typeEnv))
+                print('lapply(compileInfo$typeEnv, function(x) x$show())')
+                lapply(compileInfo$typeEnv, function(x) x$show())
+                writeLines('***** READY FOR setSizes *****')
+                browser()
+            }
+            
+            compileInfo$typeEnv[['neededRCfuns']] <<- list()
+            compileInfo$typeEnv[['.AllowUnknowns']] <<- TRUE ## will be FALSE for RHS recursion in setSizes
+            compileInfo$typeEnv[['.ensureNimbleBlocks']] <<- FALSE ## will be TRUE for LHS recursion after RHS sees rmnorm and other vector dist "r" calls.
+            compileInfo$typeEnv[['.nimbleProject']] <<- nimbleProject
+            passedArgNames <-
+                as.list(compileInfo$origLocalSymTab$getSymbolNames()) 
+            names(passedArgNames) <-
+                compileInfo$origLocalSymTab$getSymbolNames() 
+            compileInfo$typeEnv[['passedArgumentNames']] <<- passedArgNames ## only the names are used.
+            compileInfo$typeEnv[['nameSubList']] <<- nameSubList
 
-                                       if(is.null(nimbleProject)) nimbleProject <- get('nimbleProject', envir = RCfun)
-                                       
-                                       if(!initialTypeInferenceDone) {
-                                           
-                                           if(!is.null(nimbleOptions()$debugCppLineByLine)) {
-                                               if(nimbleOptions()$debugCppLineByLine) {
-                                                   debugCpp <- TRUE
-                                                   if(length(debugCppLabel) == 0) debugCppLabel <- name
-                                               }
-                                           }
-                                           
-                                           if(doKeywords) {
-                                               matchKeywords()
-                                               processKeywords()
-                                           }
-                                           
-                                           if(inherits(compileInfo$origLocalSymTab, 'uninitializedField')) {
-                                               setupSymbolTables()
-                                           }
-                                           initialTypeInferenceDone <<- TRUE
-                                       }
-                                       if(initialTypeInferenceOnly) return(NULL);
-                                      
-                                       if(debug) {
-                                           writeLines('**** READY FOR makeExprClassObjects *****')
-                                           browser()
-                                       }
-                                       if(length(nameSubList) > 0)
-                                           compileInfo$newRcode <<- nf_substituteExceptFunctionsAndDollarSigns(compileInfo$newRcode, nameSubList)
-                                       ## set up exprClass object
-                                       compileInfo$nimExpr <<- RparseTree2ExprClasses(compileInfo$newRcode)
-                                       
-                                       if(debug) {
-                                           print('nimDeparse(compileInfo$nimExpr)')
-                                           writeCode(nimDeparse(compileInfo$nimExpr))
-                                           writeLines('***** READY FOR processSpecificCalls *****')
-                                           browser()
-                                       }
-
-                                       exprClasses_processSpecificCalls(compileInfo$nimExpr, compileInfo$newLocalSymTab)
-
-                                       if(debug) {
-                                           print('nimDeparse(compileInfo$nimExpr)')
-                                           writeCode(nimDeparse(compileInfo$nimExpr))
-                                           writeLines('***** READY FOR buildInterms *****')
-                                           browser()
-                                       }
-                                       
-                                       ## build intermediate variables
-                                       exprClasses_buildInterms(compileInfo$nimExpr)
-
-                                       if(debug) {
-                                           print('nimDeparse(compileInfo$nimExpr)')
-                                           writeCode(nimDeparse(compileInfo$nimExpr))
-                                           print('compileInfo$newLocalSymTab')
-                                           print(compileInfo$newLocalSymTab)
-                                           writeLines('***** READY FOR initSizes *****')
-                                           browser()
-                                       }
-                                       compileInfo$typeEnv <<- exprClasses_initSizes(compileInfo$nimExpr, compileInfo$newLocalSymTab, returnSymbol = compileInfo$returnSymbol)
-                                       if(debug) {
-                                           print('ls(compileInfo$typeEnv)')
-                                           print(ls(compileInfo$typeEnv))
-                                           print('lapply(compileInfo$typeEnv, function(x) x$show())')
-                                           lapply(compileInfo$typeEnv, function(x) x$show())
-                                           writeLines('***** READY FOR setSizes *****')
-                                           browser()
-                                       }
-
-                                       compileInfo$typeEnv[['neededRCfuns']] <<- list()
-                                       compileInfo$typeEnv[['.AllowUnknowns']] <<- TRUE ## will be FALSE for RHS recursion in setSizes
-                                       compileInfo$typeEnv[['.ensureNimbleBlocks']] <<- FALSE ## will be TRUE for LHS recursion after RHS sees rmnorm and other vector dist "r" calls.
-                                       compileInfo$typeEnv[['.nimbleProject']] <<- nimbleProject
-                                       passedArgNames <- as.list(compileInfo$origLocalSymTab$getSymbolNames()) 
-                                       names(passedArgNames) <- compileInfo$origLocalSymTab$getSymbolNames() 
-                                       compileInfo$typeEnv[['passedArgumentNames']] <<- passedArgNames ## only the names are used.
-                                       compileInfo$typeEnv[['nameSubList']] <<- nameSubList
-
-                                       ## exprClasses_setSizes contains lots of reticulated error trapping.
-                                       ## If options('error') is not NULL (typically options(error = recover)), let that take precedent for error trapping of exprClasses_setSizes.
-                                       ## Otherwise, wrap the setSizes call in our own error-trapping that outputs: any local message from a stop() inside a size handler,
-                                       ##    a message from here showing the larger block of code in which the error occurred, and, if nimbleOptions('verboseErrors') is TRUE, the call stack. 
-                                       if(!is.null(options('error'))) exprClasses_setSizes(compileInfo$nimExpr, compileInfo$newLocalSymTab, compileInfo$typeEnv)
-                                       else tryCatch(withCallingHandlers(exprClasses_setSizes(compileInfo$nimExpr, compileInfo$newLocalSymTab, compileInfo$typeEnv),
-                                                                         error = function(e) {
-                                                                             stack <- sapply(sys.calls(), deparse)
-                                                                             .GlobalEnv$.nimble.traceback <- capture.output(traceback(stack))
-                                                                         }),
-                                                     error = function(e) {
-                                                         eMessage <- if(!is.null(e$message)) paste0(as.character(e$message),"\n") else ""
-                                                         message <- paste(eMessage, 'There was some problem in the the setSizes processing step for this code:',
-                                                                          paste(deparse(compileInfo$origRcode), collapse = '\n'))
-                                                         if(getNimbleOption('verboseErrors')) {
-                                                             message <- paste(message,
-                                                                              'Internal Error:', e,
-                                                                              'Traceback:', paste0(.GlobalEnv$.nimble.traceback, collapse = '\n'),
-                                                                              sep = '\n')
-                                                         }
-                                                         stop(message, call. = FALSE)
-                                                     })
-                                       neededRCfuns <<- c(neededRCfuns, compileInfo$typeEnv[['neededRCfuns']])
-                                       if(debug) {
-                                           print('compileInfo$nimExpr$show(showType = TRUE) -- broken')
-                                           print('compileInfo$nimExpr$show(showAssertions = TRUE) -- possible broken')
-                                           writeLines('***** READY FOR insertAssertions *****')
-                                           browser()
-                                       }
-
-                                       if(nimbleOptions('experimentalNewSizeProcessing')) {
-                                           exprClasses_setToEigenize(compileInfo$nimExpr, compileInfo$newLocalSymTab, compileInfo$typeEnv)
-                                       }
-
-                                       tryResult <- try(exprClasses_insertAssertions(compileInfo$nimExpr))
-                                       if(inherits(tryResult, 'try-error')) {
-                                           stop(paste('There is some problem at the insertAdditions processing step for this code:\n', paste(deparse(compileInfo$origRcode), collapse = '\n'), collapse = '\n'), call. = FALSE)
-                                       }
-                                       
-                                       if(debug) {
-                                           print('compileInfo$nimExpr$show(showAssertions = TRUE)')
-                                           compileInfo$nimExpr$show(showAssertions = TRUE)
-                                           print('compileInfo$nimExpr$show(showToEigenize = TRUE)')
-                                           compileInfo$nimExpr$show(showToEigenize = TRUE)
-                                           print('nimDeparse(compileInfo$nimExpr)')
-                                           writeCode(nimDeparse(compileInfo$nimExpr))
-                                           writeLines('***** READY FOR labelForEigenization *****')
-                                           browser()
-                                       }
-                                       
-                                       tryResult <- try(exprClasses_labelForEigenization(compileInfo$nimExpr))
-                                       if(inherits(tryResult, 'try-error')) {
-                                           stop(paste('There is some problem at the Eigen labeling processing step for this code:\n', paste(deparse(compileInfo$origRcode), collapse = '\n'), collapse = '\n'), call. = FALSE)
-                                       }
-                                       if(debug) {
-                                           print('nimDeparse(compileInfo$nimExpr)')
-                                           writeCode(nimDeparse(compileInfo$nimExpr))
-                                           writeLines('***** READY FOR eigenize *****')
-                                           browser()
-                                       }
-
-                                       tryResult <- try(exprClasses_eigenize(compileInfo$nimExpr, compileInfo$newLocalSymTab, compileInfo$typeEnv))
-                                       if(inherits(tryResult, 'try-error')) {
-                                           stop(paste('There is some problem at the Eigen processing step for this code:\n', paste(deparse(compileInfo$origRcode), collapse = '\n'), collapse = '\n'), call. = FALSE)
-                                       }
-                                       if(debug) {
-                                           print('nimDeparse(compileInfo$nimExpr)')
-                                           writeCode(nimDeparse(compileInfo$nimExpr))
-                                           print('compileInfo$newLocalSymTab')
-                                           print(compileInfo$newLocalSymTab)
-                                           print('ls(compileInfo$typeEnv)')
-                                           print(ls(compileInfo$typeEnv))
-                                           
-                                           writeLines('***** READY FOR liftMaps*****')
-                                           browser()
-                                       }
-
-                                       exprClasses_liftMaps(compileInfo$nimExpr, compileInfo$newLocalSymTab, compileInfo$typeEnv)
-                                       if(debug) {
-                                           print('nimDeparse(compileInfo$nimExpr)')
-                                           writeCode(nimDeparse(compileInfo$nimExpr))
-                                           writeLines('***** READY FOR cppOutput*****')
-                                           browser()
-                                       }
-                                       
-                                       if(debugCpp) {
-                                           if(debug) writeLines('*** Inserting debugging')
-                                           exprClasses_addDebugMarks(compileInfo$nimExpr, paste(debugCppLabel, name))
-                                           if(debug) {
-                                               print('nimDeparse(compileInfo$nimExpr)')
-                                               writeCode(nimDeparse(compileInfo$nimExpr))
-                                               writeLines('***** READY FOR cppOutput*****')
-                                               browser()
-                                           }
-                                       }
-                                       if(debug & debugCpp) {
-                                           print('writeCode(nimGenerateCpp(compileInfo$nimExpr, newMethods$run$newLocalSymTab))')
-                                           writeCode(nimGenerateCpp(compileInfo$nimExpr, compileInfo$newLocalSymTab))
-                                       }
-                                   },
-                                   processKeywords = function(nfProc = NULL) {
-                                       compileInfo$newRcode <<- processKeywords_recurse(compileInfo$origRcode, nfProc)
-                                   },
-                                   matchKeywords = function(nfProc = NULL) {
-                                       compileInfo$origRcode <<- matchKeywords_recurse(compileInfo$origRcode, nfProc) ## nfProc needed for member functions of nf objects
-                                   }
-                                   )
-                               )
+            ## exprClasses_setSizes contains lots of reticulated error trapping.
+            ## If options('error') is not NULL (typically options(error = recover)), let that take precedent for error trapping of exprClasses_setSizes.
+            ## Otherwise, wrap the setSizes call in our own error-trapping that outputs: any local message from a stop() inside a size handler,
+            ##    a message from here showing the larger block of code in which the error occurred, and, if nimbleOptions('verboseErrors') is TRUE, the call stack. 
+            if(!is.null(options('error')))
+                exprClasses_setSizes(compileInfo$nimExpr,
+                                     compileInfo$newLocalSymTab,
+                                     compileInfo$typeEnv)
+            else tryCatch(
+                     withCallingHandlers(
+                         exprClasses_setSizes(compileInfo$nimExpr,
+                                              compileInfo$newLocalSymTab,
+                                              compileInfo$typeEnv),
+                         error = function(e) {
+                             stack <- sapply(sys.calls(), deparse)
+                             .GlobalEnv$.nimble.traceback <-
+                                 capture.output(traceback(stack))
+                         }),
+                     error = function(e) {
+                         eMessage <- if(!is.null(e$message))
+                                         paste0(as.character(e$message),"\n")
+                                     else ""
+                         message <-
+                             paste(eMessage,
+                                   'There was some problem in the the setSizes processing step for this code:',
+                                   paste(deparse(compileInfo$origRcode), collapse = '\n'))
+                         if(getNimbleOption('verboseErrors')) {
+                             message <- paste(message,
+                                              'Internal Error:',
+                                              e,
+                                              'Traceback:',
+                                              paste0(.GlobalEnv$.nimble.traceback, collapse = '\n'),
+                                              sep = '\n')
+                         }
+                         stop(message, call. = FALSE)
+                     })
+            neededRCfuns <<- c(neededRCfuns,
+                               compileInfo$typeEnv[['neededRCfuns']])
+            if(debug) {
+                print('compileInfo$nimExpr$show(showType = TRUE) -- broken')
+                print('compileInfo$nimExpr$show(showAssertions = TRUE) -- possible broken')
+                writeLines('***** READY FOR insertAssertions *****')
+                browser()
+            }
+            
+            if(nimbleOptions('experimentalNewSizeProcessing')) {
+                exprClasses_setToEigenize(compileInfo$nimExpr,
+                                          compileInfo$newLocalSymTab,
+                                          compileInfo$typeEnv)
+            }
+            
+            tryResult <- try(exprClasses_insertAssertions(compileInfo$nimExpr))
+            if(inherits(tryResult, 'try-error')) {
+                stop(
+                    paste('There is some problem at the insertAdditions processing step for this code:\n',
+                          paste(deparse(compileInfo$origRcode),
+                                collapse = '\n'),
+                          collapse = '\n'),
+                    call. = FALSE)
+            }
+            
+            if(debug) {
+                print('compileInfo$nimExpr$show(showAssertions = TRUE)')
+                compileInfo$nimExpr$show(showAssertions = TRUE)
+                print('compileInfo$nimExpr$show(showToEigenize = TRUE)')
+                compileInfo$nimExpr$show(showToEigenize = TRUE)
+                print('nimDeparse(compileInfo$nimExpr)')
+                writeCode(nimDeparse(compileInfo$nimExpr))
+                writeLines('***** READY FOR labelForEigenization *****')
+                browser()
+            }
+            
+            tryResult <- try(
+                exprClasses_labelForEigenization(compileInfo$nimExpr)
+            )
+            if(inherits(tryResult, 'try-error')) {
+                stop(
+                    paste('There is some problem at the Eigen labeling processing step for this code:\n',
+                          paste(deparse(compileInfo$origRcode),
+                                collapse = '\n'),
+                          collapse = '\n'),
+                    call. = FALSE)
+            }
+            if(debug) {
+                print('nimDeparse(compileInfo$nimExpr)')
+                writeCode(nimDeparse(compileInfo$nimExpr))
+                writeLines('***** READY FOR eigenize *****')
+                browser()
+            }
+            
+            tryResult <- try(
+                exprClasses_eigenize(compileInfo$nimExpr,
+                                     compileInfo$newLocalSymTab, compileInfo$typeEnv))
+            if(inherits(tryResult, 'try-error')) {
+                stop(
+                    paste('There is some problem at the Eigen processing step for this code:\n',
+                          paste(deparse(compileInfo$origRcode),
+                                collapse = '\n'),
+                          collapse = '\n'),
+                    call. = FALSE)
+            }
+            if(debug) {
+                print('nimDeparse(compileInfo$nimExpr)')
+                writeCode(nimDeparse(compileInfo$nimExpr))
+                print('compileInfo$newLocalSymTab')
+                print(compileInfo$newLocalSymTab)
+                print('ls(compileInfo$typeEnv)')
+                print(ls(compileInfo$typeEnv))
+                
+                writeLines('***** READY FOR liftMaps*****')
+                browser()
+            }
+            
+            exprClasses_liftMaps(compileInfo$nimExpr,
+                                 compileInfo$newLocalSymTab,
+                                 compileInfo$typeEnv)
+            if(debug) {
+                print('nimDeparse(compileInfo$nimExpr)')
+                writeCode(nimDeparse(compileInfo$nimExpr))
+                writeLines('***** READY FOR cppOutput*****')
+                browser()
+            }
+            
+            if(debugCpp) {
+                if(debug) writeLines('*** Inserting debugging')
+                exprClasses_addDebugMarks(compileInfo$nimExpr,
+                                          paste(debugCppLabel, name))
+                if(debug) {
+                    print('nimDeparse(compileInfo$nimExpr)')
+                    writeCode(nimDeparse(compileInfo$nimExpr))
+                    writeLines('***** READY FOR cppOutput*****')
+                    browser()
+                }
+            }
+            if(debug & debugCpp) {
+                print('writeCode(nimGenerateCpp(compileInfo$nimExpr, newMethods$run$newLocalSymTab))')
+                writeCode(
+                    nimGenerateCpp(compileInfo$nimExpr,
+                                   compileInfo$newLocalSymTab)
+                )
+            }
+        },
+        processKeywords = function(nfProc = NULL) {
+            compileInfo$newRcode <<-
+                processKeywords_recurse(compileInfo$origRcode, nfProc)
+        },
+        matchKeywords = function(nfProc = NULL) {
+            compileInfo$origRcode <<-
+                matchKeywords_recurse(compileInfo$origRcode, nfProc) ## nfProc needed for member functions of nf objects
+        }
+    )
+)

--- a/packages/nimble/R/RCfunction_core.R
+++ b/packages/nimble/R/RCfunction_core.R
@@ -38,126 +38,175 @@ nimKeyWords <- list(copy = 'nimCopy',
                     optimDefaultControl = 'nimOptimDefaultControl',
                     derivs = 'nimDerivs')
 
-nfMethodRCinterface <- setRefClass(Class = 'nfMethodRCinterface',
-                                   fields = list(
-                                       argInfo    = 'ANY',
-                                       arguments  = 'ANY',
-                                       returnType = 'ANY',
-                                       uniqueName = 'character'))
-nfMethodRC <- 
-    setRefClass(Class   = 'nfMethodRC',
-                contains = 'nfMethodRCinterface',
-                fields  = list(
-                    template   = 'ANY',
-                    code       = 'ANY',
-                    neededRCfuns = 'ANY',		#list
-                    externalHincludes = 'ANY',
-                    externalCPPincludes = 'ANY'
-                ),
-                methods = list(
-                    initialize = function(method, name, check = FALSE, methodNames = NULL, setupVarNames = NULL) {
-                        if(!missing(name)) uniqueName <<- name ## only needed for a pure RC function. Not needed for a nimbleFunction method
-                        neededRCfuns <<- list()	
-                        argInfo <<- formals(method)
-                        code <<- nf_changeNimKeywords(body(method))  ## changes all nimble keywords, e.g. 'print' to 'nimPrint'; see 'nimKeyWords' list at bottom
-                        if(code[[1]] != '{')  code <<- substitute({CODE}, list(CODE=code))
-                        if(check && "package:nimble" %in% search()) # don't check nimble package nimbleFunctions
-                            nf_checkDSLcode(code, methodNames, setupVarNames)
-                        generateArgs()
-                        generateTemplate() ## used for argument matching
-                        removeAndSetReturnType()
-                        ## New system for external calls:
-                        externalHincludes <<- externalCPPincludes <<- list() ## to be populated by nimbleExternalCall
-                    },
-                    generateArgs = function() {
-                        argsList <- nf_createAList(names(argInfo))
-                        for(i in seq_along(argsList)) { if('default' %in% names(argInfo[[i]]))      argsList[[i]] <- argInfo[[i]]$default }
-                        arguments <<- as.pairlist(argsList)
-                    },
-                    generateTemplate = function() {
-                        functionAsList <- list(as.name('function'))
-                        functionAsList[2] <- list(NULL)
-                        if(!is.null(args)) functionAsList[[2]] <- arguments
-                        functionAsList[[3]] <- quote({})
-                        template <<- eval(as.call(functionAsList))
-                    },
-                    removeAndSetReturnType = function() {
-                        returnLineNum <- 0
-                        for(i in seq_along(code)) {
-                            if(length(code[[i]]) > 1) {
-                                if(is.name(code[[i]][[1]])) {
-                                    if(code[[i]][[1]] == 'returnType') {
-                                        returnLineNum <- i
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                        if(sum(all.names(code) == 'returnType') > 1) stop('multiple returnType() declarations in nimbleFunction method; only one allowed')
-                        if(returnLineNum == 0) {   ## no returnType() declaration found; default behavior
-                            returnTypeDeclaration <- quote(void())
-                        } else {                   ## returnType() declaration was found
-                            returnTypeDeclaration <- code[[returnLineNum]][[2]]
-                            code[returnLineNum] <<- NULL
-                        }
-                        ## a very patchy solution: switch nimInteger back to integer
-                        if(as.character(returnTypeDeclaration[[1]]) == 'nimInteger') returnTypeDeclaration[[1]] <- as.name('integer')
-                        if(as.character(returnTypeDeclaration[[1]]) == 'nimLogical') returnTypeDeclaration[[1]] <- as.name('logical')
-                        returnType <<- returnTypeDeclaration
-                    },
-                    generateFunctionObject = function(keep.nfMethodRC = FALSE) {
-                        functionAsList <- list(as.name('function'))
-                        functionAsList[2] <- list(NULL)
-                        if(!is.null(args)) functionAsList[[2]] <- arguments
-                        functionAsList[[3]] <- code
-                        ans <- eval(parse(text=deparse(as.call(functionAsList)), keep.source = FALSE)[[1]])
-                        environment(ans) <- new.env()
-                        if(keep.nfMethodRC) {environment(ans)$nfMethodRCobject <- .self}
-                        ans
-                    },
-                    getArgInfo       = function() { return(argInfo)    },
-                    getReturnType    = function() { return(returnType) })
-    )
+nfMethodRCinterface <- setRefClass(
+    Class = 'nfMethodRCinterface',
+    fields = list(
+        argInfo    = 'ANY',
+        arguments  = 'ANY',
+        returnType = 'ANY',
+        uniqueName = 'character'))
 
-
+nfMethodRC <- setRefClass(
+    Class   = 'nfMethodRC',
+    contains = 'nfMethodRCinterface',
+    fields  = list(
+        template   = 'ANY',
+        code       = 'ANY',
+        neededRCfuns = 'ANY',		#list
+        externalHincludes = 'ANY',
+        externalCPPincludes = 'ANY'
+    ),
+    methods = list(
+        initialize = function(method,
+                              name,
+                              check = FALSE,
+                              methodNames = NULL,
+                              setupVarNames = NULL) {
+            ## uniqueName is only needed for a pure RC function.
+            ## It is not needed for a nimbleFunction method.
+            if(!missing(name)) uniqueName <<- name 
+            neededRCfuns <<- list()	
+            argInfo <<- formals(method)
+             ## nf_changeNimKeywords changes all nimble keywords,
+             ## e.g. 'print' to 'nimPrint'; see 'nimKeyWords' list at
+             ## bottom
+            code <<- nf_changeNimKeywords(body(method)) 
+            if(code[[1]] != '{')
+                code <<- substitute({CODE}, list(CODE=code))
+            ## check all code except nimble package nimbleFunctions
+            if(check && "package:nimble" %in% search()) 
+                nf_checkDSLcode(code, methodNames, setupVarNames)
+            generateArgs()
+            generateTemplate() ## used for argument matching
+            removeAndSetReturnType()
+            ## Includes for .h and .cpp files when making external calls:
+            ## If needed, these will be populated by nimbleExternalCall
+            externalHincludes <<- externalCPPincludes <<- list() 
+        },
+        generateArgs = function() {
+            argsList <- nf_createAList(names(argInfo))
+            for(i in seq_along(argsList)) {
+                if('default' %in% names(argInfo[[i]]))
+                    argsList[[i]] <- argInfo[[i]]$default }
+            arguments <<- as.pairlist(argsList)
+        },
+        generateTemplate = function() {
+            functionAsList <- list(as.name('function'))
+            functionAsList[2] <- list(NULL)
+            if(!is.null(args)) functionAsList[[2]] <- arguments
+            functionAsList[[3]] <- quote({})
+            template <<- eval(as.call(functionAsList))
+        },
+        removeAndSetReturnType = function() {
+            returnLineNum <- 0
+            for(i in seq_along(code)) {
+                if(length(code[[i]]) > 1) {
+                    if(is.name(code[[i]][[1]])) {
+                        if(code[[i]][[1]] == 'returnType') {
+                            returnLineNum <- i
+                            break;
+                        }
+                    }
+                }
+            }
+            if(sum(all.names(code) == 'returnType') > 1)
+                stop('multiple returnType() declarations in nimbleFunction method; only one allowed')
+            if(returnLineNum == 0) {
+                ## no returnType() declaration was found;
+                ## create default behavior.
+                returnTypeDeclaration <- quote(void())
+            } else {
+                ## returnType() declaration was found
+                returnTypeDeclaration <- code[[returnLineNum]][[2]]
+                code[returnLineNum] <<- NULL
+            }
+            ## a very patchy solution: switch nimInteger back to integer
+            if(as.character(returnTypeDeclaration[[1]]) == 'nimInteger')
+                returnTypeDeclaration[[1]] <- as.name('integer')
+            if(as.character(returnTypeDeclaration[[1]]) == 'nimLogical')
+                returnTypeDeclaration[[1]] <- as.name('logical')
+            returnType <<- returnTypeDeclaration
+        },
+        generateFunctionObject = function(keep.nfMethodRC = FALSE) {
+            functionAsList <- list(as.name('function'))
+            functionAsList[2] <- list(NULL)
+            if(!is.null(args)) functionAsList[[2]] <- arguments
+            functionAsList[[3]] <- code
+            ans <- eval(
+                parse(text=deparse(as.call(functionAsList)),
+                      keep.source = FALSE)[[1]])
+            environment(ans) <- new.env()
+            if(keep.nfMethodRC) {
+                environment(ans)$nfMethodRCobject <- .self
+            }
+            ans
+        },
+        getArgInfo       = function() { return(argInfo)    },
+        getReturnType    = function() { return(returnType) })
+)
 
 nf_checkDSLcode <- function(code, methodNames, setupVarNames) {
-    validCalls <- c(names(sizeCalls), otherDSLcalls, names(specificCallReplacements), nimKeyWords, methodNames, setupVarNames)
-    calls <- setdiff(all.names(code), all.vars(code))
+    validCalls <- c(names(sizeCalls),
+                    otherDSLcalls,
+                    names(specificCallReplacements),
+                    nimKeyWords,
+                    methodNames,
+                    setupVarNames)
+    calls <- setdiff(all.names(code),
+                     all.vars(code))
     
-    # find cases of x$y() and x[]$y() and x[[]]$y() (this also unnecessarily finds x$y, x[]$y, x[[]]$y)
-    # this relies on all.names returning symbols from parse tree in particular order
+    ## Find cases of x$y() and x[]$y() and x[[]]$y().
+    ##
+    ## (This also unnecessarily finds x$y, x[]$y, x[[]]$y.)
+    ##
+    ## This step relies on all.names returning symbols from parse tree
+    ## in particular order
     names <- all.names(code)
     dollarsLhs <- dollarsRhs <- NULL
     dollars <- which(names == "$")
     if(length(dollars)) {
         dollarsLhs <- dollars+1
         dollarsRhs <- dollars+2
-        dollarsRhs[names[dollarsLhs] %in% c('[', '[[')] <- dollarsRhs[names[dollarsLhs] %in% c('[', '[[')] + 1 # account for index
+        dollarsRhs[names[dollarsLhs] %in% c('[', '[[')] <-
+            dollarsRhs[names[dollarsLhs] %in% c('[', '[[')] + 1 # account for index
         while(sum(names[dollarsLhs] %in% c('[', '[['))) {
-            # bracket appears between $ and the lhs,rhs of the $
-            dollarsRhs[names[dollarsLhs] %in% c('[', '[[')] <- dollarsRhs[names[dollarsLhs] %in% c('[', '[[')] + 1
-            dollarsLhs[names[dollarsLhs] %in% c('[', '[[')] <- dollarsLhs[names[dollarsLhs] %in% c('[', '[[')] + 1
+            ## bracket appears between $ and the lhs,rhs of the $
+            dollarsRhs[names[dollarsLhs] %in% c('[', '[[')] <-
+                dollarsRhs[names[dollarsLhs] %in% c('[', '[[')] + 1
+            dollarsLhs[names[dollarsLhs] %in% c('[', '[[')] <-
+                dollarsLhs[names[dollarsLhs] %in% c('[', '[[')] + 1
         }
         dollarsLhs <- unique(names[dollarsLhs[dollarsLhs <= length(names)]])
         dollarsRhs <- unique(names[dollarsRhs[dollarsRhs <= length(names)]])
     } 
-
-    # don't check RHS of $ to ensure it is a valid nf method because no current way to easily find the methods of nf's defined in setup code
+    
+    ## don't check RHS of $ to ensure it is a valid nf method because no current way to easily find the methods of nf's defined in setup code
     nonDSLcalls <- calls[!(calls %in% c(validCalls, dollarsRhs))]
     if(length(nonDSLcalls)) {
         objInR <- sapply(nonDSLcalls, exists)
         nonDSLnonR <- nonDSLcalls[!objInR]
         nonDSLinR <- nonDSLcalls[objInR]
         if(length(nonDSLinR))
-            # nf and nimbleFunctionList cases probably will never occur as these need to be passed as setup args or created in setup
-            # problem with passing inputIsName when run through roxygen...
-            nonDSLinR <- nonDSLinR[!(sapply(nonDSLinR, function(x) is.nf(x, inputIsName = TRUE)) |
-                                     sapply(nonDSLinR, function(x) is(get(x), 'nimbleFunctionList')) |
-                                     sapply(nonDSLinR, function(x) is.rcf(x, inputIsName = TRUE)) |
-                                     sapply(nonDSLinR, function(x) is.nlGenerator(x, inputIsName = TRUE)))]
+            ## nf and nimbleFunctionList cases probably will never
+            ## occur as these need to be passed as setup args or
+            ## created in setup
+            ##
+            ## problem with passing inputIsName when run through roxygen...
+            nonDSLinR <-
+                nonDSLinR[!(sapply(nonDSLinR,
+                                   function(x)
+                                       is.nf(x, inputIsName = TRUE)) |
+                            sapply(nonDSLinR,
+                                   function(x)
+                                       is(get(x), 'nimbleFunctionList')) |
+                            sapply(nonDSLinR,
+                                   function(x)
+                                       is.rcf(x, inputIsName = TRUE)) |
+                            sapply(nonDSLinR,
+                                   function(x)
+                                       is.nlGenerator(x, inputIsName = TRUE)))]
         if(length(nonDSLinR))
-           warning(paste0("Detected possible use of R functions in nimbleFunction run code. For this nimbleFunction to compile, these objects must be defined as nimbleFunctions, nimbleFunctionLists, or nimbleLists: ", paste(nonDSLinR, collapse = ', '), "."), call. = FALSE)
+            warning(paste0("Detected possible use of R functions in nimbleFunction run code. For this nimbleFunction to compile, these objects must be defined as nimbleFunctions, nimbleFunctionLists, or nimbleLists: ", paste(nonDSLinR, collapse = ', '), "."), call. = FALSE)
         if(length(nonDSLnonR))
             warning(paste0("For this nimbleFunction to compile, these objects must be defined as nimbleFunctions, nimbleFunctionLists, or nimbleLists before compilation: ", paste(nonDSLnonR, collapse = ', '), "."), call. = FALSE)
     }


### PR DESCRIPTION
This PR is a step in our plan to gradually improve code formatting for readability.  In this one I’ve modified RCfunction_core.R and RCfunction_compile.R.  Changes include:

- Reduced white space on left
- Splitting long lists of arguments and nested function calls with carriage returns for vertically arranged visual ease.
- Using said splitting to avoid lines > 80 characters.
- Some cleaning up of comments.

