### PR TITLE
Formatting parts of genCpp_[operatorLists, sizeProcess, toEigenize] for readability

### DIFF
--- a/packages/nimble/R/genCpp_operatorLists.R
+++ b/packages/nimble/R/genCpp_operatorLists.R
@@ -1,6 +1,8 @@
-## This takes a character vector as the first argument and length-1 character vector as the second argument.
-## It returns a list with the first vector as names and the second argument as the value of each element.
-## E.g. makeCallList(c('A','B'), 'foo') is equivalent to list(A = 'foo', B = 'foo')
+## This takes a character vector as the first argument and length-1
+## character vector as the second argument.  It returns a list with
+## the first vector as names and the second argument as the value of
+## each element.  E.g. makeCallList(c('A','B'), 'foo') is equivalent
+## to list(A = 'foo', B = 'foo')
 makeCallList <- function(opList, call) {
     ans <- rep(list(call), length(opList))
     names(ans) <- opList
@@ -9,33 +11,67 @@ makeCallList <- function(opList, call) {
 
 ifOrWhile <- c('if','while')
 
-## Following are a set of operators organized into categories that various processing steps use
+## Following are a set of operators organized into categories that
+## various processing steps use
 binaryMidLogicalOperatorsLogical <- c('&','|')
 binaryMidLogicalOperatorsComparison <- c('==','!=','<=','>=','<','>')
-binaryMidLogicalOperators <- c(binaryMidLogicalOperatorsLogical, binaryMidLogicalOperatorsComparison)
+binaryMidLogicalOperators <- c(binaryMidLogicalOperatorsLogical,
+                               binaryMidLogicalOperatorsComparison)
 
 binaryMidDoubleOperators <- c('/', '^')
 binaryMidPromoteNoLogicalOperators <- c('*','%%')
-binaryMidOperators <- c(binaryMidDoubleOperators, binaryMidPromoteNoLogicalOperators)
+binaryMidOperators <- c(binaryMidDoubleOperators,
+                        binaryMidPromoteNoLogicalOperators)
 
 binaryLeftDoubleOperators <- c('pow','nimMod')
 binaryLeftPromoteOperators <- c('pmin','pmax','pairmin','pairmax')
 binaryLeftLogicalOperators <- c( 'nimEquals')
-binaryLeftOperators <- c(binaryLeftDoubleOperators, binaryLeftPromoteOperators, binaryLeftLogicalOperators)
+binaryLeftOperators <- c(binaryLeftDoubleOperators,
+                         binaryLeftPromoteOperators,
+                         binaryLeftLogicalOperators)
 
-binaryOperators <- c(binaryMidOperators, binaryLeftOperators)
+binaryOperators <- c(binaryMidOperators,
+                     binaryLeftOperators)
 
 binaryOrUnaryOperators <- c('+','-')
 unaryPromoteNoLogicalOperators <- c('abs','cube')
 unaryIntegerOperators <- 'nimStep'
 unaryLogicalOperators <- '!'
-unaryDoubleOperators <- c('exp','log', 'logit','ilogit','probit','iprobit', 'sqrt', ## these do not go directly into cppOutputCalls.  They should be direct C++ names or go through eigProxyCalls or eigProxyCallsExternalUnary
-                    'gammafn','lgammafn',                    ## these also do not go direclty into eigenizeCalls but rather should be entered directly there for eigenize_cWiseUnaryEither, eigenize_cWiseUnaryArray or eigenize_cWiseUnaryMatrix
-                    ## 'lgamma1p',
-                    'log1p', 'lfactorial', 'factorial', 'cloglog', 'icloglog',
-                    'nimRound','ftrunc','ceil','floor', 
-                    'cos', 'sin', 'tan', 'acos', 'asin', 'atan', 'cosh', 'sinh', 'tanh', 'acosh', 'asinh', 'atanh')
-unaryOperators <- c(unaryPromoteNoLogicalOperators, unaryIntegerOperators, unaryDoubleOperators, unaryLogicalOperators)
+unaryDoubleOperators <- c('exp',
+                          'log',
+                          'logit',
+                          'ilogit',
+                          'probit',
+                          'iprobit',
+                          'sqrt', ## these do not go directly into cppOutputCalls.  They should be direct C++ names or go through eigProxyCalls or eigProxyCallsExternalUnary
+                          'gammafn',
+                          'lgammafn',                    ## these also do not go direclty into eigenizeCalls but rather should be entered directly there for eigenize_cWiseUnaryEither, eigenize_cWiseUnaryArray or eigenize_cWiseUnaryMatrix
+                          ## 'lgamma1p',
+                          'log1p',
+                          'lfactorial',
+                          'factorial',
+                          'cloglog',
+                          'icloglog',
+                          'nimRound',
+                          'ftrunc',
+                          'ceil',
+                          'floor', 
+                          'cos',
+                          'sin',
+                          'tan',
+                          'acos',
+                          'asin',
+                          'atan',
+                          'cosh',
+                          'sinh',
+                          'tanh',
+                          'acosh',
+                          'asinh',
+                          'atanh')
+unaryOperators <- c(unaryPromoteNoLogicalOperators,
+                    unaryIntegerOperators,
+                    unaryDoubleOperators,
+                    unaryLogicalOperators)
 unaryOrNonaryOperators <- list() 
 assignmentOperators <- c('<-','<<-','=')
 
@@ -43,23 +79,49 @@ reductionUnaryDoubleOperatorsEither <- c('mean', 'prod','squaredNorm')
 reductionUnaryPromoteOperatorsEither <-  c('min','max', 'sum')
 reductionUnaryLogicalOperatorsEither <- c('any','all')
 
-reductionUnaryOperatorsEither <- c(reductionUnaryDoubleOperatorsEither, reductionUnaryPromoteOperatorsEither, reductionUnaryLogicalOperatorsEither)  # removed norm as not consistent between R and C
+reductionUnaryOperatorsEither <- c(reductionUnaryDoubleOperatorsEither,
+                                   reductionUnaryPromoteOperatorsEither,
+                                   reductionUnaryLogicalOperatorsEither)  # removed norm as not consistent between R and C
 
 reductionUnaryOperatorsArray <- c('sd','var')
-reductionUnaryOperators <- c(reductionUnaryOperatorsEither, reductionUnaryOperatorsArray)
+reductionUnaryOperators <- c(reductionUnaryOperatorsEither,
+                             reductionUnaryOperatorsArray)
 matrixSquareReductionOperators <- c('det','logdet','trace')
 reductionBinaryOperatorsEither <- c('inprod')
 reductionBinaryOperators <- reductionBinaryOperatorsEither
 
-coreRnonSeqBlockCalls <- c('nimNonseqIndexedd','nimNonseqIndexedi', 'nimNonseqIndexedb')
-coreRmanipulationCalls <- c('nimC','nimRepd','nimRepi','nimRepb',
-                            'nimSeqByD','nimSeqLenD','nimSeqByLenD','nimSeqByI','nimSeqLenI', 'nimSeqByLenI', 'nimDiagonalD','nimDiagonalI','nimDiagonalB', 'nimNewMatrixD','nimNewMatrixI','nimNewMatrixB')
-nonNativeEigenCalls <- c('logdet','sd','var','inprod', coreRmanipulationCalls, coreRnonSeqBlockCalls)
+coreRnonSeqBlockCalls <- c('nimNonseqIndexedd',
+                           'nimNonseqIndexedi',
+                           'nimNonseqIndexedb')
+coreRmanipulationCalls <- c('nimC',
+                            'nimRepd',
+                            'nimRepi',
+                            'nimRepb',
+                            'nimSeqByD',
+                            'nimSeqLenD',
+                            'nimSeqByLenD',
+                            'nimSeqByI',
+                            'nimSeqLenI',
+                            'nimSeqByLenI',
+                            'nimDiagonalD',
+                            'nimDiagonalI',
+                            'nimDiagonalB',
+                            'nimNewMatrixD',
+                            'nimNewMatrixI',
+                            'nimNewMatrixB')
+nonNativeEigenCalls <- c('logdet',
+                         'sd',
+                         'var',
+                         'inprod',
+                         coreRmanipulationCalls,
+                         coreRnonSeqBlockCalls)
 
 matrixMultOperators <- c('%*%')
 matrixFlipOperators <- c('t')
 matrixSquareOperators <- c('chol','inverse')
-nimbleListReturningOperators <- c('nimEigen', 'nimSvd', 'getDerivs')  ## These use sizeNimbleListReturningFunction. Note that nimOptim is handled separately.
+nimbleListReturningOperators <- c('nimEigen',
+                                  'nimSvd',
+                                  'getDerivs')  ## These use sizeNimbleListReturningFunction. Note that nimOptim is handled separately.
 matrixSolveOperators <- c('solve','forwardsolve','backsolve')
 passThroughOperators <- c('return')
 
@@ -70,39 +132,91 @@ returnTypeCodes <- list(
     promote = 4L,
     promoteNoLogical = 5L)
 
-returnTypeHandling <- with(returnTypeCodes,
-                           c(list('(' = promote),
-                             makeCallList(binaryMidLogicalOperators, logical),
-                             makeCallList(binaryMidDoubleOperators, double),
-                             makeCallList(binaryMidPromoteNoLogicalOperators, promoteNoLogical),
-                             makeCallList(binaryLeftDoubleOperators, double),
-                             makeCallList(binaryLeftPromoteOperators, promoteNoLogical),
-                             makeCallList(binaryLeftLogicalOperators, logical),
-                             makeCallList(binaryOrUnaryOperators, promoteNoLogical),
-                             makeCallList(unaryPromoteNoLogicalOperators, promoteNoLogical),
-                             makeCallList(unaryLogicalOperators, logical),
-                             makeCallList(unaryIntegerOperators, integer),
-                             makeCallList(unaryDoubleOperators, double),
-                             makeCallList(reductionUnaryDoubleOperatorsEither, double),
-                             makeCallList(reductionUnaryPromoteOperatorsEither, promoteNoLogical),
-                             makeCallList(reductionUnaryLogicalOperatorsEither, logical),
-                             makeCallList(reductionUnaryOperatorsArray, double),
-                             makeCallList(matrixSquareReductionOperators, double),
-                             makeCallList(reductionBinaryOperatorsEither, promoteNoLogical),
-                             makeCallList(c(matrixMultOperators, matrixSquareOperators, matrixSolveOperators), double)))
+returnTypeHandling <- with(
+    returnTypeCodes,
+    c(list('(' = promote),
+      makeCallList(binaryMidLogicalOperators, logical),
+      makeCallList(binaryMidDoubleOperators, double),
+      makeCallList(binaryMidPromoteNoLogicalOperators, promoteNoLogical),
+      makeCallList(binaryLeftDoubleOperators, double),
+      makeCallList(binaryLeftPromoteOperators, promoteNoLogical),
+      makeCallList(binaryLeftLogicalOperators, logical),
+      makeCallList(binaryOrUnaryOperators, promoteNoLogical),
+      makeCallList(unaryPromoteNoLogicalOperators, promoteNoLogical),
+      makeCallList(unaryLogicalOperators, logical),
+      makeCallList(unaryIntegerOperators, integer),
+      makeCallList(unaryDoubleOperators, double),
+      makeCallList(reductionUnaryDoubleOperatorsEither, double),
+      makeCallList(reductionUnaryPromoteOperatorsEither, promoteNoLogical),
+      makeCallList(reductionUnaryLogicalOperatorsEither, logical),
+      makeCallList(reductionUnaryOperatorsArray, double),
+      makeCallList(matrixSquareReductionOperators, double),
+      makeCallList(reductionBinaryOperatorsEither, promoteNoLogical),
+      makeCallList(c(matrixMultOperators, matrixSquareOperators, matrixSolveOperators), double)))
 ## deliberately omitted (so they just return same type as input):
 ## matrixFlipOperators ('t')
 
 
-midOperators <- as.list(paste0(' ',c(binaryMidOperators,  binaryMidLogicalOperators, binaryOrUnaryOperators, assignmentOperators),' '))
-names(midOperators) <- c(binaryMidOperators, binaryMidLogicalOperators, binaryOrUnaryOperators, assignmentOperators)
-midOperators <- c(midOperators, list('$' = '$', '%*%' = ' %*% ', ':' = ':', '%o%' = '%o%'))
+midOperators <- as.list(
+    paste0(' ',
+           c(binaryMidOperators,
+             binaryMidLogicalOperators,
+             binaryOrUnaryOperators,
+             assignmentOperators),
+           ' ')
+)
 
-brackOperators <- list('[' = c('[',']'), '[[' = c('[[',']]'))
+names(midOperators) <- c(binaryMidOperators,
+                         binaryMidLogicalOperators,
+                         binaryOrUnaryOperators,
+                         assignmentOperators)
+midOperators <- c(midOperators,
+                  list('$' = '$', '%*%' = ' %*% ', ':' = ':', '%o%' = '%o%'))
+
+brackOperators <- list('[' = c('[',']'),
+                       '[[' = c('[[',']]'))
 
 ## see distributions_processInputList for some relevant lists of distributions functions 
 
-callToSkipInEigenization <- c('copy','setValues', 'setValuesIndexRange', 'getValues', 'getValuesIndexRange', 'setSize', 'resize', 'getsize', 'size', 'resizeNoPtr','assert', 'return', 'blank', 'rankSample', 'nimArr_dmnorm_chol', 'nimArr_dmvt_chol', 'nimArr_dwish_chol', 'nimArr_dinvwish_chol', 'nimArr_dcar_normal', 'nimArr_dmulti', 'nimArr_dcat', 'nimArr_dinterval', 'nimArr_ddirch', 'nimArr_rmnorm_chol', 'nimArr_rmvt_chol', 'nimArr_rwish_chol', 'nimArr_rinvwish_chol', 'nimArr_rcar_normal', 'nimArr_rmulti', 'nimArr_rcat', 'nimArr_rinterval', 'nimArr_rdirch', 'calculate', 'calculateDiff', 'simulate', 'getLogProb', 'nimEquals', 'startNimbleTimer', 'endNimbleTimer')
+callToSkipInEigenization <- c('copy',
+                              'setValues',
+                              'setValuesIndexRange',
+                              'getValues',
+                              'getValuesIndexRange',
+                              'setSize',
+                              'resize',
+                              'getsize',
+                              'size',
+                              'resizeNoPtr',
+                              'assert',
+                              'return',
+                              'blank',
+                              'rankSample',
+                              'nimArr_dmnorm_chol',
+                              'nimArr_dmvt_chol',
+                              'nimArr_dwish_chol',
+                              'nimArr_dinvwish_chol',
+                              'nimArr_dcar_normal',
+                              'nimArr_dmulti',
+                              'nimArr_dcat',
+                              'nimArr_dinterval',
+                              'nimArr_ddirch',
+                              'nimArr_rmnorm_chol',
+                              'nimArr_rmvt_chol',
+                              'nimArr_rwish_chol',
+                              'nimArr_rinvwish_chol',
+                              'nimArr_rcar_normal',
+                              'nimArr_rmulti',
+                              'nimArr_rcat',
+                              'nimArr_rinterval',
+                              'nimArr_rdirch',
+                              'calculate',
+                              'calculateDiff',
+                              'simulate',
+                              'getLogProb',
+                              'nimEquals',
+                              'startNimbleTimer',
+                              'endNimbleTimer')
 
 ## used for cppOutputs
 ## things here should have the inverse listing in the eigenizeTranslate list
@@ -139,10 +253,15 @@ eigProxyTranslate[['eigpmin']] <- 'min'
 
 newEPT <- reductionBinaryOperators
 names(newEPT) <- paste0('eig', reductionBinaryOperators)
-eigProxyTranslate <- c(eigProxyTranslate, newEPT)
+eigProxyTranslate <- c(eigProxyTranslate,
+                       newEPT)
 
-newEPT <- c(coreRmanipulationCalls, coreRnonSeqBlockCalls)
-names(newEPT) <- paste0('eig', c(coreRmanipulationCalls, coreRnonSeqBlockCalls))
+newEPT <- c(coreRmanipulationCalls,
+            coreRnonSeqBlockCalls)
+names(newEPT) <- paste0('eig',
+                        c(coreRmanipulationCalls,
+                          coreRnonSeqBlockCalls)
+                        )
 eigProxyTranslate <- c(eigProxyTranslate, newEPT)
 
 newEPT <- matrixSquareReductionOperators
@@ -150,38 +269,45 @@ names(newEPT) <- paste0('eig', matrixSquareReductionOperators)
 eigProxyTranslate <- c(eigProxyTranslate, newEPT)
 eigProxyTranslate[['eigdet']] <- 'determinant'
 
-## nonNativeEigenProxyCalls should each appear in one of the other operatorLists feeding into eigProxyTranslate
-## Then they are removed from eigProxyCalls so that in cppOutputCalls the nonNativeEigenProxyCalls can be generated differently (as a function, not a member function)
+## nonNativeEigenProxyCalls should each appear in one of the other
+## operatorLists feeding into eigProxyTranslate Then they are removed
+## from eigProxyCalls so that in cppOutputCalls the
+## nonNativeEigenProxyCalls can be generated differently (as a
+## function, not a member function)
 nonNativeEigenProxyCalls <- paste0('eig', nonNativeEigenCalls)
 eigProxyCalls <- setdiff(names(eigProxyTranslate), nonNativeEigenProxyCalls)
 
-## things here should have the inverse entry in the eigenizeTranslate list.  Those are created automatically in genCpp_eigenization.R
-## The C++ name here is (unfortunately) also used supposed to match the DSL keyword to be included in eigenizeCalls correctly
-eigProxyTranslateExternalUnary <- list(eigAtan = c('atan', 'double', 'double'), ## (C++ name, arg type, return type, DSL name if different from C++ name) for std::ptr_fun<argtype, returntype>(fun name)
-                                       eigCosh = c('cosh', 'double', 'double'),
-                                       eigSinh = c('sinh', 'double', 'double'),
-                                       eigTanh = c('tanh', 'double', 'double'),
-                                       eigAcosh = c('acosh', 'double', 'double'),
-                                       eigAsinh = c('asinh', 'double', 'double'),
-                                       eigAtanh = c('atanh', 'double', 'double'),
-                                       eigLogit = c('logit', 'double', 'double'),
-                                       eigIlogit = c('ilogit', 'double', 'double'),
-                                       eigProbit = c('probit', 'double', 'double'),
-                                       eigIprobit = c('iprobit', 'double', 'double'),
-                                       eigGammafn = c('gammafn', 'double', 'double'),
-                                       eigLgammafn = c('lgammafn', 'double', 'double'),
-                                       eigLog1p = c('log1p', 'double', 'double'),
-                                       eigLfactorial = c('lfactorial', 'double', 'double'),
-                                       eigFactorial = c('factorial', 'double', 'double'),
-                                       eigCloglog = c('cloglog', 'double', 'double'),
-                                       eigIcloglog = c('icloglog', 'double', 'double'),
-                                       eigNimRound = c('nimRound', 'double', 'double'),
-                                       eigFtrunc = c('ftrunc', 'double', 'double'),
-                                       eigCeil = c('ceil', 'double', 'double'),
-                                       eigFloor = c('floor', 'double', 'double'),
-                                       eigNimStep = c('nimStep', 'double', 'int'),
-                                       'eig!' = c('nimNot','bool','bool', '!')
-                                       )
+## things here should have the inverse entry in the eigenizeTranslate
+## list.  Those are created automatically in genCpp_eigenization.R The
+## C++ name here is (unfortunately) also used supposed to match the
+## DSL keyword to be included in eigenizeCalls correctly
+eigProxyTranslateExternalUnary <- list(
+    ## (C++ name, arg type, return type, DSL name if different from C++ name) for std::ptr_fun<argtype, returntype>(fun name)
+    eigAtan = c('atan', 'double', 'double'), 
+    eigCosh = c('cosh', 'double', 'double'),
+    eigSinh = c('sinh', 'double', 'double'),
+    eigTanh = c('tanh', 'double', 'double'),
+    eigAcosh = c('acosh', 'double', 'double'),
+    eigAsinh = c('asinh', 'double', 'double'),
+    eigAtanh = c('atanh', 'double', 'double'),
+    eigLogit = c('logit', 'double', 'double'),
+    eigIlogit = c('ilogit', 'double', 'double'),
+    eigProbit = c('probit', 'double', 'double'),
+    eigIprobit = c('iprobit', 'double', 'double'),
+    eigGammafn = c('gammafn', 'double', 'double'),
+    eigLgammafn = c('lgammafn', 'double', 'double'),
+    eigLog1p = c('log1p', 'double', 'double'),
+    eigLfactorial = c('lfactorial', 'double', 'double'),
+    eigFactorial = c('factorial', 'double', 'double'),
+    eigCloglog = c('cloglog', 'double', 'double'),
+    eigIcloglog = c('icloglog', 'double', 'double'),
+    eigNimRound = c('nimRound', 'double', 'double'),
+    eigFtrunc = c('ftrunc', 'double', 'double'),
+    eigCeil = c('ceil', 'double', 'double'),
+    eigFloor = c('floor', 'double', 'double'),
+    eigNimStep = c('nimStep', 'double', 'int'),
+    'eig!' = c('nimNot','bool','bool', '!')
+)
 eigProxyCallsExternalUnary <- names(eigProxyTranslateExternalUnary)
 
 eigOtherMemberFunctionCalls <- c('cwiseSqrt', 'cwiseAbs')
@@ -201,7 +327,5 @@ operatorRank <- c(
     list('&' = 13,
          '|' = 14,
          '&&' = 13,
-         '||' = 14)                  
+         '||' = 14)
 )
-
-

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -13,6 +13,7 @@ assignmentAsFirstArgFuns <- c('nimArr_rmnorm_chol',
                               'assignVectorToNimArr',
                               'dimNimArr',
                               'assignNimArrToNimArr')
+
 setSizeNotNeededOperators <- c('setWhich',
                                'setRepVectorTimes',
                                'SEXP_2_NimArr',
@@ -23,93 +24,124 @@ operatorsAllowedBeforeIndexBracketsWithoutLifting <- c('map',
                                                        'mvAccessRow',
                                                        'nfVar')
 
-sizeCalls <- c(makeCallList(binaryOperators, 'sizeBinaryCwise'),
-               makeCallList(binaryMidLogicalOperators, 'sizeBinaryCwiseLogical'),
-               makeCallList(binaryOrUnaryOperators, 'sizeBinaryUnaryCwise'),
-               makeCallList(unaryOperators, 'sizeUnaryCwise'), 
-               makeCallList(unaryOrNonaryOperators, 'sizeUnaryNonaryCwise'),
-               makeCallList(assignmentOperators, 'sizeAssign'), 
-               makeCallList(reductionUnaryOperators, 'sizeUnaryReduction'), 
-               makeCallList(matrixSquareReductionOperators, 'sizeMatrixSquareReduction'),
-               makeCallList(reductionBinaryOperators, 'sizeBinaryReduction'),
-               makeCallList(matrixMultOperators, 'sizeMatrixMult'), 
-               makeCallList(matrixFlipOperators, 'sizeTranspose'),
-               makeCallList(matrixSolveOperators, 'sizeSolveOp'), 
-               makeCallList(matrixSquareOperators, 'sizeUnaryCwiseSquare'),
-               makeCallList(nimbleListReturningOperators, 'sizeNimbleListReturningFunction'),
-               nimOptim = 'sizeOptim',
-               nimOptimDefaultControl = 'sizeOptimDefaultControl',
-               list('debugSizeProcessing' = 'sizeProxyForDebugging',
-                    diag = 'sizeDiagonal',
-                    dim = 'sizeDim',
-                    RRtest_add = 'sizeRecyclingRule',
-                    which = 'sizeWhich',
-                    nimC = 'sizeConcatenate',
-                    nimRep = 'sizeRep',
-                    nimSeqBy = 'sizeSeq',
-                    nimSeqLen = 'sizeSeq',
-                    nimSeqByLen = 'sizeSeq',
-                    'return' = 'sizeReturn',
-                    'asRow' = 'sizeAsRowOrCol',
-                    'asCol' = 'sizeAsRowOrCol',
-                    makeNewNimbleListObject = 'sizeNewNimbleList',
-                    getParam = 'sizeGetParam',
-                    getBound = 'sizeGetBound',
-                    nimSwitch = 'sizeSwitch',
-##                    asDoublePtr = 'sizeasDoublePtr',
-                   '[' = 'sizeIndexingBracket',
-                   '[[' = 'sizeDoubleBracket', ## for nimbleFunctionList, this will always  go through chainedCall(nfList[[i]], 'foo')(arg1, arg2)
-                    chainedCall = 'sizeChainedCall',
-                    nfVar = 'sizeNFvar',
-                    map = 'sizemap', 
-                    ':' = 'sizeColonOperator',
-                    ##dim = 'sizeDimOperator',
-                    'if' = 'recurseSetSizes', ##OK
-                    'while' = 'recurseSetSizes',
-##                    callC = 'sizecallC', 
-                    'for' = 'sizeFor', 
-                    cppPointerDereference = 'sizeCppPointerDereference',
-                    values = 'sizeValues',
-                    '(' = 'sizeUnaryCwise',
-                    setSize = 'sizeSetSize', ## OK but not done for numericLists
-                    resizeNoPtr = 'sizeResizeNoPtr', ## may not be used any more 
-                    nimArr_rcat = 'sizeScalarRecurse',
-                    nimArr_rinterval = 'sizeScalarRecurse',
-                    nimPrint = 'sizeforceEigenize',
-                    nimDerivs = 'sizeNimDerivs',
-                    ##nimCat = 'sizeforceEigenize',
-                    as.integer = 'sizeUnaryCwise', ## Note as.integer and as.numeric will not work on a non-scalar yet
-                    as.numeric = 'sizeUnaryCwise',
-                    nimArrayGeneral = 'sizeNimArrayGeneral',
-                    setAll = 'sizeOneEigenCommand',
-                    voidPtr = 'sizeVoidPtr',
-                    run.time = 'sizeRunTime',
-                   PROTECT = 'sizePROTECT',
-                   NimArr_2_SEXP = 'sizePROTECT', ## same need
-                   Reval = 'sizeReval',
-                    nimbleConvert = 'sizeNimbleConvert',
-                   nimbleUnconvert = 'sizeNimbleUnconvert',
-                   asReturnSymbol = 'sizeAsReturnSymbol'),
-               makeCallList(scalar_distribution_dFuns, 'sizeRecyclingRule'),
-               makeCallList(scalar_distribution_pFuns, 'sizeRecyclingRule'),
-               makeCallList(scalar_distribution_qFuns, 'sizeRecyclingRule'),
-               makeCallList(scalar_distribution_rFuns, 'sizeRecyclingRuleRfunction'),
-               makeCallList(distributionFuns[!(distributionFuns %in% c(scalar_distribution_dFuns, scalar_distribution_pFuns, scalar_distribution_qFuns, scalar_distribution_rFuns))], 'sizeScalarRecurse'),
-               # R dist functions that are not used by NIMBLE but we allow in DSL
-               makeCallList(paste0(c('d','q','p'), 't'), 'sizeRecyclingRule'),
-               rt = 'sizeRecyclingRuleRfunction',
-               makeCallList(paste0(c('d','q','p'), 'exp'), 'sizeRecyclingRule'),
-               rexp = 'sizeRecyclingRuleRfunction',
-               makeCallList(c('isnan','ISNAN','ISNA'), 'sizeScalarRecurse'),
-               makeCallList(c('nimArr_dmnorm_chol', 'nimArr_dmvt_chol', 'nimArr_dwish_chol', 'nimArr_dinvwish_chol', 'nimArr_dcar_normal', 'nimArr_dmulti', 'nimArr_dcat', 'nimArr_dinterval', 'nimArr_ddirch'), 'sizeScalarRecurse'),
-               makeCallList(c('nimArr_rmnorm_chol', 'nimArr_rmvt_chol', 'nimArr_rwish_chol', 'nimArr_rinvwish_chol', 'nimArr_rcar_normal', 'nimArr_rmulti', 'nimArr_rdirch'), 'sizeRmultivarFirstArg'),
-               makeCallList(c('decide', 'size', 'getsize','getNodeFunctionIndexedInfo', 'endNimbleTimer'), 'sizeScalar'),
-               makeCallList(c('calculate','calculateDiff', 'getLogProb'), 'sizeScalarModelOp'),
-               simulate = 'sizeSimulate',
-               makeCallList(c('blank', 'nfMethod', 'getPtr', 'startNimbleTimer'), 'sizeUndefined') ##'nimFunListAccess'
-               )
+sizeCalls <- c(
+    makeCallList(binaryOperators, 'sizeBinaryCwise'),
+    makeCallList(binaryMidLogicalOperators, 'sizeBinaryCwiseLogical'),
+    makeCallList(binaryOrUnaryOperators, 'sizeBinaryUnaryCwise'),
+    makeCallList(unaryOperators, 'sizeUnaryCwise'), 
+    makeCallList(unaryOrNonaryOperators, 'sizeUnaryNonaryCwise'),
+    makeCallList(assignmentOperators, 'sizeAssign'), 
+    makeCallList(reductionUnaryOperators, 'sizeUnaryReduction'), 
+    makeCallList(matrixSquareReductionOperators, 'sizeMatrixSquareReduction'),
+    makeCallList(reductionBinaryOperators, 'sizeBinaryReduction'),
+    makeCallList(matrixMultOperators, 'sizeMatrixMult'), 
+    makeCallList(matrixFlipOperators, 'sizeTranspose'),
+    makeCallList(matrixSolveOperators, 'sizeSolveOp'), 
+    makeCallList(matrixSquareOperators, 'sizeUnaryCwiseSquare'),
+    makeCallList(nimbleListReturningOperators, 'sizeNimbleListReturningFunction'),
+    nimOptim = 'sizeOptim',
+    nimOptimDefaultControl = 'sizeOptimDefaultControl',
+    list('debugSizeProcessing' = 'sizeProxyForDebugging',
+         diag = 'sizeDiagonal',
+         dim = 'sizeDim',
+         RRtest_add = 'sizeRecyclingRule',
+         which = 'sizeWhich',
+         nimC = 'sizeConcatenate',
+         nimRep = 'sizeRep',
+         nimSeqBy = 'sizeSeq',
+         nimSeqLen = 'sizeSeq',
+         nimSeqByLen = 'sizeSeq',
+         'return' = 'sizeReturn',
+         'asRow' = 'sizeAsRowOrCol',
+         'asCol' = 'sizeAsRowOrCol',
+         makeNewNimbleListObject = 'sizeNewNimbleList',
+         getParam = 'sizeGetParam',
+         getBound = 'sizeGetBound',
+         nimSwitch = 'sizeSwitch',
+         '[' = 'sizeIndexingBracket',
+         '[[' = 'sizeDoubleBracket', ## for nimbleFunctionList, this will always  go through chainedCall(nfList[[i]], 'foo')(arg1, arg2)
+         chainedCall = 'sizeChainedCall',
+         nfVar = 'sizeNFvar',
+         map = 'sizemap', 
+         ':' = 'sizeColonOperator',
+         'if' = 'recurseSetSizes', ##OK
+         'while' = 'recurseSetSizes',
+         'for' = 'sizeFor', 
+         cppPointerDereference = 'sizeCppPointerDereference',
+         values = 'sizeValues',
+         '(' = 'sizeUnaryCwise',
+         setSize = 'sizeSetSize', 
+         resizeNoPtr = 'sizeResizeNoPtr', ## may not be used any more 
+         nimArr_rcat = 'sizeScalarRecurse',
+         nimArr_rinterval = 'sizeScalarRecurse',
+         nimPrint = 'sizeforceEigenize',
+         nimDerivs = 'sizeNimDerivs',
+         as.integer = 'sizeUnaryCwise', 
+         as.numeric = 'sizeUnaryCwise',
+         nimArrayGeneral = 'sizeNimArrayGeneral',
+         setAll = 'sizeOneEigenCommand',
+         voidPtr = 'sizeVoidPtr',
+         run.time = 'sizeRunTime',
+         PROTECT = 'sizePROTECT',
+         NimArr_2_SEXP = 'sizePROTECT', 
+         Reval = 'sizeReval',
+         nimbleConvert = 'sizeNimbleConvert',
+         nimbleUnconvert = 'sizeNimbleUnconvert',
+         asReturnSymbol = 'sizeAsReturnSymbol'),
+    makeCallList(scalar_distribution_dFuns, 'sizeRecyclingRule'),
+    makeCallList(scalar_distribution_pFuns, 'sizeRecyclingRule'),
+    makeCallList(scalar_distribution_qFuns, 'sizeRecyclingRule'),
+    makeCallList(scalar_distribution_rFuns, 'sizeRecyclingRuleRfunction'),
+    makeCallList(distributionFuns[
+        !(distributionFuns %in% c(scalar_distribution_dFuns,
+                                  scalar_distribution_pFuns,
+                                  scalar_distribution_qFuns,
+                                  scalar_distribution_rFuns))
+    ], 'sizeScalarRecurse'),
+    ## R dist functions that are not used by NIMBLE but we allow in DSL
+    makeCallList(paste0(c('d','q','p'), 't'), 'sizeRecyclingRule'),
+    rt = 'sizeRecyclingRuleRfunction',
+    makeCallList(paste0(c('d','q','p'), 'exp'), 'sizeRecyclingRule'),
+    rexp = 'sizeRecyclingRuleRfunction',
+    makeCallList(c('isnan','ISNAN','ISNA'), 'sizeScalarRecurse'),
+    makeCallList(c('nimArr_dmnorm_chol',
+                   'nimArr_dmvt_chol',
+                   'nimArr_dwish_chol',
+                   'nimArr_dinvwish_chol',
+                   'nimArr_dcar_normal',
+                   'nimArr_dmulti',
+                   'nimArr_dcat',
+                   'nimArr_dinterval',
+                   'nimArr_ddirch'), 'sizeScalarRecurse'),
+    makeCallList(c('nimArr_rmnorm_chol',
+                   'nimArr_rmvt_chol',
+                   'nimArr_rwish_chol',
+                   'nimArr_rinvwish_chol',
+                   'nimArr_rcar_normal',
+                   'nimArr_rmulti',
+                   'nimArr_rdirch'), 'sizeRmultivarFirstArg'),
+    makeCallList(c('decide',
+                   'size',
+                   'getsize',
+                   'getNodeFunctionIndexedInfo',
+                   'endNimbleTimer'), 'sizeScalar'),
+    makeCallList(c('calculate',
+                   'calculateDiff',
+                   'getLogProb'), 'sizeScalarModelOp'),
+    simulate = 'sizeSimulate',
+    makeCallList(c('blank',
+                   'nfMethod',
+                   'getPtr',
+                   'startNimbleTimer'), 'sizeUndefined') ##'nimFunListAccess'
+)
 
-scalarOutputTypes <- list(decide = 'logical', size = 'integer', isnan = 'logical', ISNA = 'logical', '!' = 'logical', getNodeFunctionIndexedInfo = 'double', endNimbleTimer = 'double')
+scalarOutputTypes <- list(decide = 'logical',
+                          size = 'integer',
+                          isnan = 'logical',
+                          ISNA = 'logical',
+                          '!' = 'logical',
+                          getNodeFunctionIndexedInfo = 'double',
+                          endNimbleTimer = 'double')
 
 ## exprClasses_setSizes fills in the type information of exprClass code
 ## code is an exprClas object
@@ -147,14 +179,24 @@ exprClasses_setSizes <- function(code, symTab, typeEnv) { ## input code is exprC
                     code$type <- 'unknown'
                     if(!typeEnv$.AllowUnknowns)
                         if(identical(code$name, 'pi')) { ## unique because it may be encountered anew on on RHS and be valid
-                            assign('pi', exprTypeInfoClass$new(nDim = 0, type = 'double', sizeExprs = list()), envir = typeEnv)
-                            symTab$addSymbol(symbolBasic(name = 'pi', type = 'double', nDim = 0))
+                            assign('pi',
+                                   exprTypeInfoClass$new(nDim = 0,
+                                                         type = 'double',
+                                                         sizeExprs = list()),
+                                   envir = typeEnv)
+                            symTab$addSymbol(
+                                symbolBasic(name = 'pi',
+                                            type = 'double',
+                                            nDim = 0))
                             code$nDim <- 0
                             code$type <- 'double'
                             code$sizeExprs <- list()
                             code$toEigenize <- 'maybe'
                         } else {
-                            warning(paste0("variable '",code$name,"' has not been created yet."), call.=FALSE) 
+                            warning(paste0("variable '",
+                                           code$name,
+                                           "' has not been created yet."),
+                                    call.=FALSE) 
                         }
                 }
             } else {
@@ -185,8 +227,10 @@ exprClasses_setSizes <- function(code, symTab, typeEnv) { ## input code is exprC
             ## recurse over lines
             for(i in seq_along(code$args)) {
                 if(inherits(code$args[[i]], 'exprClass')) {
-                    newAsserts <- exprClasses_setSizes(code$args[[i]], symTab, typeEnv)
-                    code$args[[i]]$assertions <- if(is.null(newAsserts)) list() else newAsserts
+                    newAsserts <-
+                        exprClasses_setSizes(code$args[[i]], symTab, typeEnv)
+                    code$args[[i]]$assertions <-
+                        if(is.null(newAsserts)) list() else newAsserts
                 }
             }
             return(invisible(NULL))
@@ -195,7 +239,12 @@ exprClasses_setSizes <- function(code, symTab, typeEnv) { ## input code is exprC
         if(!is.null(sizeCall)) {
             if(.nimbleOptions$debugSizeProcessing) {
                 browser()
-                eval(substitute(debugonce(XYZ), list(XYZ = as.name(sizeCall))))
+                eval(
+                    substitute(
+                        debugonce(XYZ),
+                        list(XYZ = as.name(sizeCall))
+                    )
+                )
             }
             test0 <- eval(call(sizeCall, code, symTab, typeEnv))
             return(test0)
@@ -210,12 +259,19 @@ exprClasses_setSizes <- function(code, symTab, typeEnv) { ## input code is exprC
             if(is.rcf(obj)) { ## it is an RC function
                 nfmObj <- environment(obj)$nfMethodRCobject
                 uniqueName <- nfmObj$uniqueName
-                if(length(uniqueName)==0) stop(exprClassProcessingErrorMsg(code, 'In size processing: A no-setup nimbleFunction with no internal name is being called.'), call. = FALSE)
+                if(length(uniqueName)==0)
+                    stop(
+                        exprClassProcessingErrorMsg(
+                            code,
+                            'In size processing: A no-setup nimbleFunction with no internal name is being called.'),
+                        call. = FALSE)
                 if(is.null(typeEnv$neededRCfuns[[uniqueName]])) {
                     typeEnv$neededRCfuns[[uniqueName]] <- nfmObj
                 }
                 ## new with nimbleLists: we need to initiate compilation here so we can get full returnType information, including of nimbleLists
-                RCfunProc <- typeEnv$.nimbleProject$compileRCfun(obj, initialTypeInference = TRUE)
+                RCfunProc <-
+                    typeEnv$.nimbleProject$compileRCfun(obj,
+                                                        initialTypeInference = TRUE)
                 return(sizeRCfunction(code, symTab, typeEnv, nfmObj, RCfunProc))
             }
         }

--- a/packages/nimble/R/genCpp_toEigenize.R
+++ b/packages/nimble/R/genCpp_toEigenize.R
@@ -1,7 +1,9 @@
 ## It is hoped substantial sets of these calls can be combined
 ## or implemented by a rule system.
 
-toEigenizeNoCalls <- c('dim', 'run.time','nimOptimDefaultControl')
+toEigenizeNoCalls <- c('dim',
+                       'run.time',
+                       'nimOptimDefaultControl')
 
 toEigenizeYesCalls <- c(paste0('nimDiagonal', c('D','I','B')),
                         'diagonal',
@@ -20,93 +22,89 @@ toEigenizeYesCalls <- c(paste0('nimDiagonal', c('D','I','B')),
                         )
 
 toEigenizeMaybeCalls <- c('map',
-                          c('decide', 'size', 'getsize','getNodeFunctionIndexedInfo', 'endNimbleTimer'),
-                          c('blank', 'nfMethod', 'getPtr', 'startNimbleTimer'))
+                          c('decide',
+                            'size',
+                            'getsize',
+                            'getNodeFunctionIndexedInfo',
+                            'endNimbleTimer'),
+                          c('blank',
+                            'nfMethod',
+                            'getPtr',
+                            'startNimbleTimer'))
 
 toEigenizeUseRuleCalls <- c('nimPrint')
 
-toEigenCalls <- c(makeCallList(binaryOperators, 'toEigenBinaryCwise'),             #ok
-                  makeCallList(binaryMidLogicalOperators, 'sizeBinaryCwiseLogical'),
-                  makeCallList(binaryOrUnaryOperators, 'toEigenBinaryUnaryCwise'), #ok
-                  makeCallList(unaryOperators, 'toEigenUnaryCwise'),               #ok
-                  makeCallList(unaryOrNonaryOperators, 'sizeUnaryNonaryCwise'),
-                  makeCallList(assignmentOperators, 'toEigenAssign'),              #ok
-                  makeCallList(reductionUnaryOperators, 'sizeUnaryReduction'),     # drafted
-                  makeCallList(matrixSquareReductionOperators, 'sizeMatrixSquareReduction'),
-                  makeCallList(reductionBinaryOperators, 'sizeBinaryReduction'),
-                  makeCallList(matrixMultOperators, 'toEigenMatrixMult'),          # drafted
-                  makeCallList(matrixFlipOperators, 'sizeTranspose'),
-                  makeCallList(matrixSolveOperators, 'sizeSolveOp'), 
-                  makeCallList(matrixSquareOperators, 'sizeUnaryCwiseSquare'),
-                  ##               makeCallList(nimbleListReturningOperators, 'sizeNimbleListReturningFunction'),
-                  nimOptim = 'toEigenOptim',
-                  ##nimOptimDefaultControl = 'sizeOptimDefaultControl',
-                  
-                  makeCallList(paste0('nimC',c('d','i','b')), 'toEigenConcatenate'),
-                  makeCallList(paste0('nimRep',c('d','i','b')), 'toEigenRep'),
-                  list('debugSizeProcessing' = 'sizeProxyForDebugging',
-                       ##      diag = 'toEigenYes',
-                       ##      dim = 'toEigenNo',
-                       ##       RRtest_add = 'toEigenYes', ## testing!
-                       ##      which = 'toEigenYes',
-                       
-                       nimRep = 'sizeRep',
-                       nimSeqBy = 'sizeSeq',
-                       nimSeqLen = 'sizeSeq',
-                       nimSeqByLen = 'sizeSeq',
-                       'return' = 'sizeReturn',
-                       ##  'asRow' = 'sizeAsRowOrCol',
-                       ##  'asCol' = 'sizeAsRowOrCol',
-                       makeNewNimbleListObject = 'toEigenNewNimbleList',
-                       getParam = 'toEigenGetParam',
-                       getBound = 'toEigenGetBound',
-                       ## nimSwitch = 'sizeSwitch', ## NEVER GETS MARKED WITH TOEIGENIZE
-                       asDoublePtr = 'toEigenIgnoreForNow',
-                       '[' = 'sizeIndexingBracket',
-                       ##'[[' = 'sizeDoubleBracket', ## for nimbleFunctionList, this will always  go through chainedCall(nfList[[i]], 'foo')(arg1, arg2) ## NEVER GETS MARKED WITH TOEIGENIZE
-                       chainedCall = 'toEigenChainedCall',
-                       ## nfVar = 'sizeNFvar', ## NEVER GETS MARKED WITH TOEIGENIZE
-                       ## map = 'sizemap',
-                       ':' = 'sizeColonOperator',
-                       ##dim = 'sizeDimOperator',
-                       'if' = 'recurseSetSizes', ##OK
-                       'while' = 'recurseSetSizes',
-                       callC = 'sizecallC', 
-                       'for' = 'toEigenFor', 
-                       cppPointerDereference = 'toEigenCppPointerDereference',
-                       values = 'toEigenValues',
-                       '(' = 'sizeUnaryCwise',
-                       setSize = 'toEigenSetSize', ## OK but not done for numericLists
-                       ## resizeNoPtr = 'sizeResizeNoPtr', ## may not be used any more 
-                       nimArr_rcat = 'toEigenScalarRecurse',
-                       nimArr_rinterval = 'toEigenScalarRecurse',
-                       ##nimPrint = 'sizeforceEigenize',
-                       ##nimCat = 'sizeforceEigenize',
-                       as.integer = 'sizeUnaryCwise', ## Note as.integer and as.numeric will not work on a non-scalar yet
-                       as.numeric = 'sizeUnaryCwise',
-                       nimArrayGeneral = 'toEigenNimArrayGeneral',
-                       ##setAll = 'sizeOneEigenCommand',
-                       voidPtr = 'sizeVoidPtr'
-                       ),
-                    ##run.time = 'sizeRunTime'),
-                  ##               makeCallList(scalar_distribution_dFuns, 'toEigenYes'),
-                  ##               makeCallList(scalar_distribution_pFuns, 'toEigenYes'),
-                  ##               makeCallList(scalar_distribution_qFuns, 'sizeRecyclingRule'),
-                  ##               makeCallList(scalar_distribution_rFuns, 'sizeRecyclingRuleRfunction'),
-                  makeCallList(distributionFuns[!(distributionFuns %in% c(scalar_distribution_dFuns, scalar_distribution_pFuns, scalar_distribution_qFuns, scalar_distribution_rFuns))], 'toEigenScalarRecurse'),
-                                        # R dist functions that are not used by NIMBLE but we allow in DSL
-                  ## makeCallList(paste0(c('d','q','p'), 't'), 'sizeRecyclingRule'),
-                  ## rt = 'sizeRecyclingRuleRfunction',
-                  ## makeCallList(paste0(c('d','q','p'), 'exp'), 'sizeRecyclingRule'),
-                  ## rexp = 'sizeRecyclingRuleRfunction',
-                  makeCallList(c('isnan','ISNAN','ISNA'), 'toEigenScalarRecurse'),
-                  makeCallList(c('nimArr_dmnorm_chol', 'nimArr_dmvt_chol', 'nimArr_dwish_chol', 'nimArr_dinvwish_chol', 'nimArr_dmulti', 'nimArr_dcat', 'nimArr_dinterval', 'nimArr_ddirch'), 'toEigenScalarRecurse'),
-                  makeCallList(c('nimArr_rmnorm_chol', 'nimArr_rmvt_chol', 'nimArr_rwish_chol', 'nimArr_rinvwish_chol', 'nimArr_rmulti', 'nimArr_rdirch'), 'sizeRmultivarFirstArg'),
-                  ##      makeCallList(c('decide', 'size', 'getsize','getNodeFunctionIndexedInfo', 'endNimbleTimer'), 'sizeScalar'),
-                  ## makeCallList(c('calculate','calculateDiff', 'getLogProb'), 'toEigenScalarModelOp'),
-                  simulate = 'toEigenIgnoreForNow'
-                  ##               makeCallList(c('blank', 'nfMethod', 'getPtr', 'startNimbleTimer'), 'sizeUndefined')
-                  )
+toEigenCalls <- c(
+    makeCallList(binaryOperators, 'toEigenBinaryCwise'),             
+    makeCallList(binaryMidLogicalOperators, 'sizeBinaryCwiseLogical'),
+    makeCallList(binaryOrUnaryOperators, 'toEigenBinaryUnaryCwise'), 
+    makeCallList(unaryOperators, 'toEigenUnaryCwise'),               
+    makeCallList(unaryOrNonaryOperators, 'sizeUnaryNonaryCwise'),
+    makeCallList(assignmentOperators, 'toEigenAssign'),              
+    makeCallList(reductionUnaryOperators, 'sizeUnaryReduction'),     
+    makeCallList(matrixSquareReductionOperators, 'sizeMatrixSquareReduction'),
+    makeCallList(reductionBinaryOperators, 'sizeBinaryReduction'),
+    makeCallList(matrixMultOperators, 'toEigenMatrixMult'),          
+    makeCallList(matrixFlipOperators, 'sizeTranspose'),
+    makeCallList(matrixSolveOperators, 'sizeSolveOp'), 
+    makeCallList(matrixSquareOperators, 'sizeUnaryCwiseSquare'),
+    nimOptim = 'toEigenOptim',
+    
+    makeCallList(paste0('nimC',c('d','i','b')), 'toEigenConcatenate'),
+    makeCallList(paste0('nimRep',c('d','i','b')), 'toEigenRep'),
+    list('debugSizeProcessing' = 'sizeProxyForDebugging',
+         nimRep = 'sizeRep',
+         nimSeqBy = 'sizeSeq',
+         nimSeqLen = 'sizeSeq',
+         nimSeqByLen = 'sizeSeq',
+         'return' = 'sizeReturn',
+         makeNewNimbleListObject = 'toEigenNewNimbleList',
+         getParam = 'toEigenGetParam',
+         getBound = 'toEigenGetBound',
+         asDoublePtr = 'toEigenIgnoreForNow',
+         '[' = 'sizeIndexingBracket',
+         chainedCall = 'toEigenChainedCall',
+         ':' = 'sizeColonOperator',
+         'if' = 'recurseSetSizes', 
+         'while' = 'recurseSetSizes',
+         callC = 'sizecallC', 
+         'for' = 'toEigenFor', 
+         cppPointerDereference = 'toEigenCppPointerDereference',
+         values = 'toEigenValues',
+         '(' = 'sizeUnaryCwise',
+         setSize = 'toEigenSetSize', 
+         nimArr_rcat = 'toEigenScalarRecurse',
+         nimArr_rinterval = 'toEigenScalarRecurse',
+         as.integer = 'sizeUnaryCwise', 
+         as.numeric = 'sizeUnaryCwise',
+         nimArrayGeneral = 'toEigenNimArrayGeneral',
+         voidPtr = 'sizeVoidPtr'
+         ),
+    makeCallList(distributionFuns[
+        !(distributionFuns %in% c(scalar_distribution_dFuns,
+                                  scalar_distribution_pFuns,
+                                  scalar_distribution_qFuns,
+                                  scalar_distribution_rFuns))
+    ], 'toEigenScalarRecurse'),
+    makeCallList(c('isnan',
+                   'ISNAN',
+                   'ISNA'), 'toEigenScalarRecurse'),
+    makeCallList(c('nimArr_dmnorm_chol',
+                   'nimArr_dmvt_chol',
+                   'nimArr_dwish_chol',
+                   'nimArr_dinvwish_chol',
+                   'nimArr_dmulti',
+                   'nimArr_dcat',
+                   'nimArr_dinterval',
+                   'nimArr_ddirch'), 'toEigenScalarRecurse'),
+    makeCallList(c('nimArr_rmnorm_chol',
+                   'nimArr_rmvt_chol',
+                   'nimArr_rwish_chol',
+                   'nimArr_rinvwish_chol',
+                   'nimArr_rmulti',
+                   'nimArr_rdirch'), 'sizeRmultivarFirstArg'),
+    simulate = 'toEigenIgnoreForNow'
+)
 
 
 exprClasses_setToEigenize <- function(code, symTab, typeEnv) { ## input code is exprClass
@@ -119,9 +117,14 @@ exprClasses_setToEigenize <- function(code, symTab, typeEnv) { ## input code is 
             ## recurse over lines
             for(i in seq_along(code$args)) {
                 if(inherits(code$args[[i]], 'exprClass')) {
-                    newAsserts <- exprClasses_setToEigenize(code$args[[i]], symTab, typeEnv)
-                    code$args[[i]]$assertions <- c(code$args[[i]]$assertions,
-                                                   if(is.null(newAsserts)) list() else newAsserts)
+                    newAsserts <-
+                        exprClasses_setToEigenize(code$args[[i]],
+                                                  symTab,
+                                                  typeEnv)
+                    code$args[[i]]$assertions <-
+                        c(code$args[[i]]$assertions,
+                          if(is.null(newAsserts)) list() else newAsserts
+                          )
                 }
             }
             return(invisible(NULL))
@@ -141,7 +144,9 @@ exprClasses_setToEigenize <- function(code, symTab, typeEnv) { ## input code is 
             if(is.rcf(obj)) { ## it is an RC function
                 message('figure out how to extract the RCfunProc that should already exist')
                 browser()
-                RCfunProc <- typeEnv$.nimbleProject$compileRCfun(obj, initialTypeInference = TRUE)
+                RCfunProc <-
+                    typeEnv$.nimbleProject$compileRCfun(obj,
+                                                        initialTypeInference = TRUE)
                 
                 return(toEigenRCfunction(code, symTab, typeEnv)) ## These additional arguments are not part of the function signature: ', nfmObj, RCfunProc))'
             }
@@ -156,7 +161,11 @@ recurseSetToEigenize <- function(code, symTab, typeEnv, useArgs = rep(TRUE, leng
     for(i in seq_along(code$args)) {
         if(useArgs[i]) {
             if(inherits(code$args[[i]], 'exprClass')) {
-                asserts <- c(asserts, exprClasses_setToEigenize(code$args[[i]], symTab, typeEnv))
+                asserts <- c(asserts,
+                             exprClasses_setToEigenize(code$args[[i]],
+                                                       symTab,
+                                                       typeEnv)
+                             )
             }
         }
     }
@@ -220,8 +229,12 @@ toEigenAssignLHS <- function(code, symTab, typeEnv, NoEigenizeMap = FALSE) {
                     if(RHS$toEigenize == 'unknown') 'no'
                     else {
                         if(RHS$toEigenize != 'yes' &
-                           (!(LHS$name %in% c('eigenBlock', 'diagonal', 'coeffSetter'))) &
-                           (RHS$nDim == 0 | RHS$isName | (RHS$name == 'map' & NoEigenizeMap)))
+                           (!(LHS$name %in% c('eigenBlock',
+                                              'diagonal',
+                                              'coeffSetter'))) &
+                           (RHS$nDim == 0 |
+                            RHS$isName |
+                            (RHS$name == 'map' & NoEigenizeMap)))
                             'no' ## if it is scalar or is just a name or a map, we will do it via NimArr operator= .  Used to have "| RHS$name == 'map'", but this allowed X[1:3] <- X[2:4], which requires eigen, with eval triggered, to get right
                         else 'yes' ## if it is 'maybe' and non-scalar and not just a name, default to 'yes'
                     }
@@ -244,9 +257,13 @@ toEigenAssignLHS <- function(code, symTab, typeEnv, NoEigenizeMap = FALSE) {
         if(RHS$nDim > 0) {
             if(!(RHS$name %in% setSizeNotNeededOperators)) {
                 if(LHS$isName | LHS$name == "nfVar") {
-                    assert <- substitute(setSize(LHS), list(LHS = nimbleGeneralParseDeparse(LHS)))
+                    assert <-
+                        substitute(setSize(LHS),
+                                   list(LHS = nimbleGeneralParseDeparse(LHS)))
                     for(i in seq_along(RHS$sizeExprs)) { ## N.B. RHS$sizeExprs may be modified by sizeAssignAfterRecursing
-                        test <- try(assert[[i + 2]] <- RHS$sizeExprs[[i]])
+                        test <- try(
+                            assert[[i + 2]] <- RHS$sizeExprs[[i]]
+                        )
                         if(inherits(test, 'try-error')) browser()
                     }
                     assert[[ length(assert) + 1]] <- 0 ## copyValues = false
@@ -259,16 +276,32 @@ toEigenAssignLHS <- function(code, symTab, typeEnv, NoEigenizeMap = FALSE) {
                         if(RHS$nDim == 2) {
                             if(is.numeric(RHS$sizeExprs[[1]])) {
                                 if(RHS$sizeExprs[[1]] == 1) {
-                                    newExpr <- insertExprClassLayer(code, 1, 'asRow', type = LHS$type)
+                                    newExpr <-
+                                        insertExprClassLayer(code,
+                                                             1,
+                                                             'asRow',
+                                                             type = LHS$type)
                                     newExpr$sizeExprs <- RHS$sizeExprs 
                                     newExpr$type <- LHS$type
                                     newExpr$nDim <- RHS$nDim
-                                    if(!is.numeric(LHS$sizeExprs[[1]]) | !is.numeric(RHS$sizeExprs[[2]])) {
-                                        assertMessage <- paste0("Run-time size error: expected ", deparse(LHS$sizeExprs[[1]]), " == ", deparse(RHS$sizeExprs[[2]]))
-                                        thisAssert <- identityAssert(LHS$sizeExprs[[1]], RHS$sizeExprs[[2]], assertMessage)
-                                        if(!is.null(thisAssert)) assert[[length(assert) + 1]] <- thisAssert 
+                                    if(!is.numeric(LHS$sizeExprs[[1]]) |
+                                       !is.numeric(RHS$sizeExprs[[2]])) {
+                                        assertMessage <-
+                                            paste0("Run-time size error: expected ",
+                                                   deparse(LHS$sizeExprs[[1]]), " == ",
+                                                   deparse(RHS$sizeExprs[[2]]))
+                                        thisAssert <-
+                                            identityAssert(LHS$sizeExprs[[1]],
+                                                           RHS$sizeExprs[[2]],
+                                                           assertMessage)
+                                        if(!is.null(thisAssert))
+                                            assert[[length(assert) + 1]] <-
+                                                thisAssert 
                                     } else {
-                                        if(LHS$sizeExprs[[1]] != RHS$sizeExprs[[2]]) stop(exprClassProcessingErrorMsg(code, paste0('In sizeAssignAfterRecursing: Fixed size mismatch.')), call. = FALSE)
+                                        if(LHS$sizeExprs[[1]] != RHS$sizeExprs[[2]])
+                                            stop(exprClassProcessingErrorMsg(code,
+                                                                             paste0('In sizeAssignAfterRecursing: Fixed size mismatch.')),
+                                                 call. = FALSE)
                                     }
                                 }
                             }
@@ -280,11 +313,15 @@ toEigenAssignLHS <- function(code, symTab, typeEnv, NoEigenizeMap = FALSE) {
     } else {
         if(inherits(RHS, 'exprClass')) {
             ## If we have A <- map(B, ...), we need to generate a setMap for the RHS, which will be done by sizeInsertIntermediate 
-            if(RHS$name == 'map') assert <- c(assert, toEigenInsertIntermediate(code, 2, symTab, typeEnv) )
+            if(RHS$name == 'map')
+                assert <- c(assert,
+                            toEigenInsertIntermediate(code, 2, symTab, typeEnv) )
         }
         if(inherits(LHS, 'exprClass')) {
                                         # ditto
-            if(LHS$name == 'map') assert <- c(assert, toEigenInsertIntermediate(code, 1, symTab, typeEnv) )
+            if(LHS$name == 'map')
+                assert <- c(assert,
+                            toEigenInsertIntermediate(code, 1, symTab, typeEnv) )
         }
     }
     assert
@@ -388,7 +425,8 @@ toEigenBinaryCwise <- function(code, symTab, typeEnv) {
     a2 <- code$args[[2]]
     if(inherits(a1, 'exprClass')) {
         if(a1$toEigenize == 'no') {
-            asserts <- c(asserts, toEigenInsertIntermediate(code, 1, symTab, typeEnv))
+            asserts <- c(asserts,
+                         toEigenInsertIntermediate(code, 1, symTab, typeEnv))
             a1 <- code$args[[1]]
         }
         a1DropNdim <- length(dropSingleSizes(a1$sizeExprs)$sizeExprs)
@@ -399,7 +437,8 @@ toEigenBinaryCwise <- function(code, symTab, typeEnv) {
     }
     if(inherits(a2, 'exprClass')) {
         if(a2$toEigenize == 'no') {
-            asserts <- c(asserts, toEigenInsertIntermediate(code, 2, symTab, typeEnv))
+            asserts <- c(asserts,
+                         toEigenInsertIntermediate(code, 2, symTab, typeEnv))
             a2 <- code$args[[2]]
         }
         a2DropNdim <- length(dropSingleSizes(a2$sizeExprs)$sizeExprs)
@@ -408,7 +447,9 @@ toEigenBinaryCwise <- function(code, symTab, typeEnv) {
         a2DropNdim <- 0
         a2toEigenize <- 'maybe'
     }
-    forceYesEigenize <- identical(a1toEigenize, 'yes') | identical(a2toEigenize, 'yes')
+    forceYesEigenize <-
+        identical(a1toEigenize, 'yes') |
+        identical(a2toEigenize, 'yes')
     code$toEigenize <- if(a1DropNdim == 0 & a2DropNdim == 0)
                            if(forceYesEigenize)
                                'yes'
@@ -424,7 +465,8 @@ toEigenUnaryCwise <- function(code, symTab, typeEnv) {
     ## lifting rule: lift if not eigenizable
     if(inherits(a1, 'exprClass')) {
         if(a1$toEigenize == 'no') {
-            asserts <- c(asserts, toEigenInsertIntermediate(code, 1, symTab, typeEnv))
+            asserts <- c(asserts,
+                         toEigenInsertIntermediate(code, 1, symTab, typeEnv))
             a1 <- code$args[[1]]
         }
     }


### PR DESCRIPTION
This PR is another step of reformatting some sections of code for readability.