### PR TITLE
initial benchmarking of building and compiling models and MCMCs

### DIFF
--- a/packages/nimble/inst/tests/test-benchmark-building-steps.R
+++ b/packages/nimble/inst/tests/test-benchmark-building-steps.R
@@ -32,7 +32,7 @@ timeSteps <- function(code, data = list(), constants = list(), inits = list()) {
     )[3]
     times['Build MCMC (No Conj)'] <- system.time(
         RMCMC <-
-            buildMCMC(MCMCconf)
+            buildMCMC(MCMCconfNoCon)
     )[3]
     times['Compile MCMC'] <- system.time(
         CMCMC <-

--- a/packages/nimble/inst/tests/test-benchmark-building-steps.R
+++ b/packages/nimble/inst/tests/test-benchmark-building-steps.R
@@ -32,7 +32,7 @@ timeSteps <- function(code, data = list(), constants = list(), inits = list()) {
     )[3]
     times['Build MCMC (No Conj)'] <- system.time(
         RMCMC <-
-            buildMCMC(MCMCconfNoCon)
+            buildMCMC(MCMCconfNoConj)
     )[3]
     times['Compile MCMC'] <- system.time(
         CMCMC <-

--- a/packages/nimble/inst/tests/test-benchmark-building-steps.R
+++ b/packages/nimble/inst/tests/test-benchmark-building-steps.R
@@ -1,0 +1,73 @@
+## This runs benchmarks of the steps of building a model, compiling
+## the model, configuring the MCMC, building the MCMC, and compiling
+## the MCMC.
+
+source(system.file(file.path('tests', 'test_utils.R'), package = 'nimble'))
+
+context('Benchmarking model and MCMC building and compiling steps')
+cat('\n')
+
+timeSteps <- function(code, data = list(), constants = list(), inits = list()) {
+    times <- numeric()
+    times['Build model'] <- system.time(
+        Rmodel <-
+            nimbleModel(code = code,
+                        data = data,
+                        constants = constants,
+                        inits = inits,
+                        check = FALSE,
+                        calculate = FALSE)
+    )[3]
+    times['Compile model'] <- system.time(
+        Cmodel <-
+            compileNimble(Rmodel)
+    )[3]
+    times['Configure MCMC'] <- system.time(
+        MCMCconf <-
+            configureMCMC(Rmodel)
+    )[3]
+    times['Configure MCMC (No Conj)'] <- system.time(
+        MCMCconfNoConj <-
+            configureMCMC(Rmodel, useConjugacy = FALSE)
+    )[3]
+    times['Build MCMC (No Conj)'] <- system.time(
+        RMCMC <-
+            buildMCMC(MCMCconf)
+    )[3]
+    times['Compile MCMC'] <- system.time(
+        CMCMC <-
+            compileNimble(RMCMC, project = Rmodel)
+    )[3]
+    times
+}
+
+test_that('Benchmarking model and MCMC building and compiling steps',
+{
+    caseNames <- character()
+
+    caseNames[1] <- 'theta->mu[1:1000]->y[1:1000]'
+    code1 <- nimbleCode({
+        theta ~ dnorm(0,1)
+        for(i in 1:1000) mu[i] ~ dnorm(theta, sd = 1)
+        for(i in 1:1000) y[i] ~ dnorm(mu[i], sd = 1)
+    })
+    y1 <- rnorm(1000, 0, 2)
+    
+    profile1 <- timeSteps(code = code1, data = list(y = y1))
+
+    caseNames[2] <- 'theta->mu[1:100]->y[1:100, 1:20]'
+    code2 <- nimbleCode({
+        theta ~ dnorm(0,1)
+        for(i in 1:100) mu[i] ~ dnorm(theta, sd = 1)
+        for(i in 1:100)
+            for(j in 1:20) y[i, j] ~ dnorm(mu[i], sd = 1)
+    })
+    y2 <- matrix(rnorm(2000, 0, 2), nrow = 100)
+    profile2 <- timeSteps(code = code2, data = list(y = y2))
+
+    results <- rbind(profile1, profile2)
+    rownames(results) <- caseNames
+
+    print(results)
+}
+)

--- a/run_tests.R
+++ b/run_tests.R
@@ -44,7 +44,8 @@ if (length(grep('^-', argv, invert = TRUE))) {
         'test-Math2.R',
         'test-Mcmc2.R',
         'test-Mcmc3.R',
-        'test-Filtering2.R')
+        'test-Filtering2.R',
+        'test-benchmark-building-steps.R')
     # Avoid running these tests since they test experimental features.
     blacklist <- c(
         blacklist,


### PR DESCRIPTION
This PR adds inst.test-benchmark-building-steps.R.

It benchmarks the steps of:

- building model (with check = FALSE and calculate = FALSE in first cases)
- compiling model
- configuring MCMC
- configuring MCMC without conjugate
- building MCMC (not allowing conjugacy, in the initial cases)
- compiling MCMC

It outputs a table with a row for each case and a column for the time used by each step.

Currently there are two cases: 

- a model with 1 top-level parameter, 1000 random effects, and 1000 data (each depending on 1 random effect).

- a model with 1 top level parameter, 100 random effects, and 2000 data (20 data depending on each random effect).

This is in the testing directory but is not needed as a test, so it is on the omission list of run-tests.R

It will be easy to expand to other cases and consideration of `check = TRUE`, `calculate = TRUE`, and use of conjugacy.
