### PR TITLE
NodeFunctionVector as list

### DIFF
--- a/packages/nimble/R/types_nodeFxnVector.R
+++ b/packages/nimble/R/types_nodeFxnVector.R
@@ -4,57 +4,48 @@
 ## simulate(model_nodes)
 ## model_nodes$getNodeFunctions() returns a list of the nfRefClassObjets underlying the nodeFunctions
 
-nodeFunctionVector <- setRefClass(
-    Class = 'nodeFunctionVector',
-    fields = list(
-        model = 'ANY',
-        gids = 'ANY',
-        indexingInfo = 'ANY'
-                  ),
-               #   nodes = 'ANY'),
-               #   nodeFunctionRefClassObjects = 'ANY'),
-    methods = list(
-        initialize = function(model, nodeNames, excludeData = FALSE, sortUnique = TRUE, errorContext = "") { ##env = parent.frame()) {
-            model <<- model
-            if(length(nodeNames) == 0) {
-            	gids <<- numeric(0)
-                indexingInfo <<- list(declIDs = integer(), rowIndices = integer())
-            } else {
-                ## This is an old case no longer used
-                ## if(is.numeric(nodeNames)) { 		#In case we start with graph ids instead of names
-                ##     message("FOUND A CASE WHERE NODEFUNCTIONVECTOR IS CREATED WITH NUMERIC NODENAMES")
-                ##     temp_gids <- unique(sort(nodeNames, FALSE),
-                ##                                   FALSE,
-                ##                                   FALSE,
-                ##                                   NA) 
-    	        ## } else {
-                    if(sortUnique) {
-                        temp_gids <- unique(sort(model$modelDef$nodeName2GraphIDs(nodeNames), FALSE),
-                                            FALSE,
-                                            FALSE,
-                                            NA) ##unique( sort(model$modelDef$nodeName2GraphIDs(nodeNames)))
-                        if(excludeData == TRUE)
-                            temp_gids <- temp_gids[!model$isDataFromGraphID(temp_gids)]
-                    } else {
-                        temp_gids <- model$modelDef$nodeName2GraphIDs(nodeNames, unique = FALSE)
-                        if(length(temp_gids) != length(nodeNames)) stop(paste0("In nodeFunctionVector from a case like model$doSomething(nodes[i]) where nodes may not contain well-defined node names.  Context is ", errorContext))
-                        if(excludeData) {
-                            if(sum(model$isDataFromGraphID(temp_gids)) > 0) ## message uses includeData instead of excludeData b/c that's what users see as argument
-                                warning(paste0("In nodeFunctionVector, usage is of the form model$doSomething(nodes[i]) where nodes includes data nodes, but includeData is FALSE.  Set includeData = TRUE if you need to include data nodes in this case.  Context is ", errorContext))
-                        }
-                    }
-##                }
-                gids <<- temp_gids ## old nodeFun system
-                indexingInfo <<- model$modelDef$graphIDs2indexedNodeInfo(temp_gids) ## new nodeFun system
+nodeFunctionVector <-
+    function(model,
+             nodeNames,
+             excludeData = FALSE,
+             sortUnique = TRUE,
+             errorContext = "")
+{
+    ##        model <<- model
+    if(length(nodeNames) == 0) {
+        gids <- numeric(0)
+        indexingInfo <- list(declIDs = integer(), rowIndices = integer())
+    } else {
+        if(sortUnique) {
+            temp_gids <-
+                unique(
+                    sort(model$modelDef$nodeName2GraphIDs(nodeNames)),
+                    FALSE,
+                    FALSE,
+                    NA) 
+            if(excludeData == TRUE)
+                temp_gids <-
+                    temp_gids[!model$isDataFromGraphID(temp_gids)]
+        } else {
+            temp_gids <-
+                model$modelDef$nodeName2GraphIDs(nodeNames, unique = FALSE)
+            if(length(temp_gids) != length(nodeNames))
+                stop(paste0("In nodeFunctionVector from a case like model$doSomething(nodes[i]) where nodes may not contain well-defined node names.  Context is ",
+                            errorContext))
+            if(excludeData) {
+                if(sum(model$isDataFromGraphID(temp_gids)) > 0)
+                    ## message uses "includeData" instead of "excludeData" b/c that's what users see as argument
+                    warning(paste0("In nodeFunctionVector, usage is of the form model$doSomething(nodes[i]) where nodes includes data nodes, but includeData is FALSE.  Set includeData = TRUE if you need to include data nodes in this case.  Context is ",
+                                   errorContext))
             }
-        },
-        getNodeNames = function(){ ## not used anywhere. provided only for debugging/inspection
-        	model$expandNodeNames(gids)	
-        },
-        show = function() {
-            cat('nodeFunctionVector: \n')
-            print(cbind(indexingInfo$declIDs, indexingInfo$unrolledIndicesMatrixRows))
         }
-    )
-)
+        gids <- temp_gids
+        indexingInfo <-
+            model$modelDef$graphIDs2indexedNodeInfo(temp_gids)
+    }
+    structure(list(gids = gids,
+                   indexingInfo = indexingInfo,
+                   model = model),
+              class = "nodeFunctionVector")
+}
 

--- a/packages/nimble/inst/tests/test-benchmark-building-steps.R
+++ b/packages/nimble/inst/tests/test-benchmark-building-steps.R
@@ -32,7 +32,7 @@ timeSteps <- function(code, data = list(), constants = list(), inits = list()) {
     )[3]
     times['Build MCMC (No Conj)'] <- system.time(
         RMCMC <-
-            buildMCMC(MCMCconf)
+            buildMCMC(MCMCconfNoCon)
     )[3]
     times['Compile MCMC'] <- system.time(
         CMCMC <-

--- a/packages/nimble/inst/tests/test-benchmark-building-steps.R
+++ b/packages/nimble/inst/tests/test-benchmark-building-steps.R
@@ -32,7 +32,7 @@ timeSteps <- function(code, data = list(), constants = list(), inits = list()) {
     )[3]
     times['Build MCMC (No Conj)'] <- system.time(
         RMCMC <-
-            buildMCMC(MCMCconfNoCon)
+            buildMCMC(MCMCconfNoConj)
     )[3]
     times['Compile MCMC'] <- system.time(
         CMCMC <-

--- a/packages/nimble/inst/tests/test-benchmark-building-steps.R
+++ b/packages/nimble/inst/tests/test-benchmark-building-steps.R
@@ -1,0 +1,73 @@
+## This runs benchmarks of the steps of building a model, compiling
+## the model, configuring the MCMC, building the MCMC, and compiling
+## the MCMC.
+
+source(system.file(file.path('tests', 'test_utils.R'), package = 'nimble'))
+
+context('Benchmarking model and MCMC building and compiling steps')
+cat('\n')
+
+timeSteps <- function(code, data = list(), constants = list(), inits = list()) {
+    times <- numeric()
+    times['Build model'] <- system.time(
+        Rmodel <-
+            nimbleModel(code = code,
+                        data = data,
+                        constants = constants,
+                        inits = inits,
+                        check = FALSE,
+                        calculate = FALSE)
+    )[3]
+    times['Compile model'] <- system.time(
+        Cmodel <-
+            compileNimble(Rmodel)
+    )[3]
+    times['Configure MCMC'] <- system.time(
+        MCMCconf <-
+            configureMCMC(Rmodel)
+    )[3]
+    times['Configure MCMC (No Conj)'] <- system.time(
+        MCMCconfNoConj <-
+            configureMCMC(Rmodel, useConjugacy = FALSE)
+    )[3]
+    times['Build MCMC (No Conj)'] <- system.time(
+        RMCMC <-
+            buildMCMC(MCMCconf)
+    )[3]
+    times['Compile MCMC'] <- system.time(
+        CMCMC <-
+            compileNimble(RMCMC, project = Rmodel)
+    )[3]
+    times
+}
+
+test_that('Benchmarking model and MCMC building and compiling steps',
+{
+    caseNames <- character()
+
+    caseNames[1] <- 'theta->mu[1:1000]->y[1:1000]'
+    code1 <- nimbleCode({
+        theta ~ dnorm(0,1)
+        for(i in 1:1000) mu[i] ~ dnorm(theta, sd = 1)
+        for(i in 1:1000) y[i] ~ dnorm(mu[i], sd = 1)
+    })
+    y1 <- rnorm(1000, 0, 2)
+    
+    profile1 <- timeSteps(code = code1, data = list(y = y1))
+
+    caseNames[2] <- 'theta->mu[1:100]->y[1:100, 1:20]'
+    code2 <- nimbleCode({
+        theta ~ dnorm(0,1)
+        for(i in 1:100) mu[i] ~ dnorm(theta, sd = 1)
+        for(i in 1:100)
+            for(j in 1:20) y[i, j] ~ dnorm(mu[i], sd = 1)
+    })
+    y2 <- matrix(rnorm(2000, 0, 2), nrow = 100)
+    profile2 <- timeSteps(code = code2, data = list(y = y2))
+
+    results <- rbind(profile1, profile2)
+    rownames(results) <- caseNames
+
+    print(results)
+}
+)

--- a/run_tests.R
+++ b/run_tests.R
@@ -44,7 +44,8 @@ if (length(grep('^-', argv, invert = TRUE))) {
         'test-Math2.R',
         'test-Mcmc2.R',
         'test-Mcmc3.R',
-        'test-Filtering2.R')
+        'test-Filtering2.R',
+        'test-benchmark-building-steps.R')
     # Avoid running these tests since they test experimental features.
     blacklist <- c(
         blacklist,


### PR DESCRIPTION
This pull request changes `nodeFunctionVector` from a reference class to a list.  Its uses are simple, so the change was very simple to make.  Using a list avoids overhead of reference class object construction.  There is a `nodeFunctionVector` made every time a model method needs a vector of nodes.  Evaluation of the `newSetupCode` making these does not happen until compilation of MCMCs (or other algos).  On the two cases in benchmarking of model and MCMC building a compiling, this change reduces MCMC compilation time by an average of about 10%.