### PR TITLE
removed extra "param" from conjugate samplers "neededParamsForPosterior"

### DIFF
--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -821,7 +821,11 @@ dependentClass <- setRefClass(
         },
         initialize_neededParamsForPosterior = function() {
             posteriorVars <- unique(unlist(lapply(contributionExprs, all.vars)))
-            neededParamsForPosterior <<- unique(c(param, posteriorVars[!(posteriorVars %in% c('value', 'coeff', 'offset'))]))
+            ## Formerly, we always included the target 'param' in 'neededParamsForPosterior'.
+            ## Not certain why, it wasn't necessary in many cases, e.g., dbeta-dbinom conjugacy.  Excluding it now.
+            ## -DT, August 2017
+            ##neededParamsForPosterior <<- unique(c(param, posteriorVars[!(posteriorVars %in% c('value', 'coeff', 'offset'))]))
+            neededParamsForPosterior <<- setdiff(posteriorVars, c('value', 'coeff', 'offset'))
         }
     )
 )


### PR DESCRIPTION
Do not merge; waiting for testing to run.

Fixes #557.

Not sure why we always (formerly) included the target `param` in the conjugate samplers' `neededParamsForPosterior`, which drives variable creation in the conjugate samplers.  This may be a precautionary oversight, dating back to the creation of the conjugacy system.  This PR removes it.  It has already passed all testing for me, locally.

I have included a few lines of commented "history" here.  Sorry, everyone.  It helps me keep things straight.