### PR TITLE
Fixes #563: Incorrect handling of non-trivial expression in while() condition

### DIFF
--- a/packages/nimble/R/genCpp_exprClass.R
+++ b/packages/nimble/R/genCpp_exprClass.R
@@ -100,16 +100,6 @@ exprTypeInfoClass <- setRefClass('exprTypeInfoClass',
     )
 )
 
-updateCallersExprClass <- function(code) {
-    for(i in seq_along(code$args)) {
-        if(inherits(code$args[[i]], 'exprClass')) {
-            code$args[[i]]$caller <- code
-            updateCallersExprClass(code$args[[i]])
-        }
-    }
-    code
-}
-
 copyExprClass <- function(original) {
     result <- original$copy(shallow = TRUE)
     ## shallow=FALSE does not deep-copy on list elements, so it is

--- a/packages/nimble/R/genCpp_exprClass.R
+++ b/packages/nimble/R/genCpp_exprClass.R
@@ -100,6 +100,31 @@ exprTypeInfoClass <- setRefClass('exprTypeInfoClass',
     )
 )
 
+updateCallersExprClass <- function(code) {
+    for(i in seq_along(code$args)) {
+        if(inherits(code$args[[i]], 'exprClass')) {
+            code$args[[i]]$caller <- code
+            updateCallersExprClass(code$args[[i]])
+        }
+    }
+    code
+}
+
+copyExprClass <- function(original) {
+    result <- original$copy(shallow = TRUE)
+    ## shallow=FALSE does not deep-copy on list elements, so it is
+    ## useless for args list.  Another reason for shallow = TRUE
+    ## is we do not want to deep copy 'caller' here.  Instead it is
+    ## re-assigned below.
+    for(i in seq_along(result$args)) {
+        if(inherits(result$args[[i]], 'exprClass')) {
+            result$args[[i]] <- copyExprClass(result$args[[i]])
+            result$args[[i]]$caller <- result
+        }
+    }
+    result
+}
+
 ## Add indendation to every character() element in a list, doing so recursively for any nested list()
 addIndentToList <- function(x, indent) {
     if(is.list(x)) return(lapply(x, addIndentToList, indent))

--- a/packages/nimble/R/genCpp_insertAssertions.R
+++ b/packages/nimble/R/genCpp_insertAssertions.R
@@ -69,13 +69,16 @@ exprClasses_insertAssertions <- function(code) {
                 if(length(beforeContents) > 0) {
                     ## The "while" is now embedded in newExpr, so it is in a different place in the AST.
                     newWhileBody <- newBracketExpr(
-                        args = list(code$
-                                    args[[i]]$ ## entry in original {
-                                    args[[length(beforeContents)+1]]$ ## entry in newExpr {
-                                    args[[2]],  ## body of while clause
-                                    beforeContents) ## new piece
+                        args = c(code$
+                                 args[[i]]$ ## entry in original {
+                                 args[[length(beforeContents)+1]]$ ## entry in newExpr {
+                                 args[2],  ## body of while clause, as list
+                                 lapply(beforeContents, copyExprClass)) ## new piece
                     )
-                    setArg(code$args[[i]], 2, newWhileBody)
+                    setArg(
+                        code$args[[i]]$args[[length(beforeContents)+1]],
+                        2,
+                        newWhileBody)
                 }
             }
         }

--- a/packages/nimble/R/genCpp_insertAssertions.R
+++ b/packages/nimble/R/genCpp_insertAssertions.R
@@ -18,9 +18,11 @@ exprClasses_insertAssertions <- function(code) {
             if(code$args[[i]]$name == 'for') {
                 exprClasses_insertAssertions(code$args[[i]]$args[[3]])
             }
+            handleWhile <- FALSE
             if(code$args[[i]]$name %in% ifOrWhile) {
                 exprClasses_insertAssertions(code$args[[i]]$args[[2]])
                 if(length(code$args[[i]]$args) == 3) exprClasses_insertAssertions(code$args[[i]]$args[[3]])
+                handleWhile <- code$args[[i]]$name == 'while'
             }
             if(code$args[[i]]$name == '{') {
                 exprClasses_insertAssertions(code$args[[i]])
@@ -31,19 +33,50 @@ exprClasses_insertAssertions <- function(code) {
                         exprClasses_insertAssertions(code$args[[i]]$args[[j]])
                     }
             }
+            beforeContents <- afterContents <- list()
             if(length(code$args[[i]]$assertions) > 0) {
                 toInsert <- lapply(code$args[[i]]$assertions, function(x) if(inherits(x, 'exprClass')) x else RparseTree2ExprClasses(x))
                 before <- unlist(lapply(toInsert, function(x) {if(x$name == 'after') FALSE else TRUE}))
                 if(nimbleOptions('experimentalNewSizeProcessing')) code$args[[i]]$assertions <- list()  ## Clear assertions field so it can be used by later compiler stages
-                newExpr <- newBracketExpr(args = c(lapply(toInsert[before], ## assertions will be inserted recursively IF they are in {}
-                                                          function(z) {exprClasses_insertAssertions(z); z}),
+                beforeContents <- lapply(toInsert[before], ## assertions will be inserted recursively IF they are in {}
+                                         function(z) {
+                                             exprClasses_insertAssertions(z)
+                                             z
+                                         })
+                afterContents <- lapply(toInsert[!before],
+                                        function(x) {
+                                            lapply(x$args[1],
+                                                   function(z) {
+                                                       exprClasses_insertAssertions(z)
+                                                   }
+                                                   )
+                                            x$args[[1]]
+                                        }
+                                        )
+                newExpr <- newBracketExpr(args = c(beforeContents,
                                                    code$args[i],
-                                                   lapply(toInsert[!before],
-                                                          function(x) {lapply(x$args[1],
-                                                                              function(z) {exprClasses_insertAssertions(z)}
-                                                                              ); x$args[[1]]}
-                                                          )))
+                                                   afterContents))
                 setArg(code, i, newExpr)
+                newExpr <- NULL
+            }
+            ## For 'if' or 'while', recurse into the if/while clause and (possibly) else clause.
+            ## 'while' causes a special challenge.  Any assertions must go before the condition
+            ## and also at the end of the clause for execution.  Otherwise the assertions will be
+            ## done only once on the first time through.
+            if(handleWhile) {
+                if(length(afterContents) > 0)
+                    stop('Invalid conditional in while()')
+                if(length(beforeContents) > 0) {
+                    ## The "while" is now embedded in newExpr, so it is in a different place in the AST.
+                    newWhileBody <- newBracketExpr(
+                        args = list(code$
+                                    args[[i]]$ ## entry in original {
+                                    args[[length(beforeContents)+1]]$ ## entry in newExpr {
+                                    args[[2]],  ## body of while clause
+                                    beforeContents) ## new piece
+                    )
+                    setArg(code$args[[i]], 2, newWhileBody)
+                }
             }
         }
     }

--- a/packages/nimble/inst/tests/test-misc.R
+++ b/packages/nimble/inst/tests/test-misc.R
@@ -2,6 +2,32 @@ source(system.file(file.path('tests', 'test_utils.R'), package = 'nimble'))
 
 context("Testing of miscellaneous functionality.")
 
+## Regression test for Issue #563.
+test_that("while() works even when an intermediate variable is needed", {
+    mynf = nimbleFunction(
+    run=function(xi = double(1)) {
+        returnType(double(0))
+        newInd <- 1
+        n <- length(xi)
+        while(sum(xi == newInd) > 0 & newInd <= n){ 
+            newInd <- newInd+1
+        }
+        return(newInd)
+    })
+    cmynf=compileNimble(mynf)
+    expect_equal(mynf(c(1, 3, 4)),
+                 cmynf(c(1, 3, 4)),
+                 info = 'error in while() with intermediate-implemented expression')
+})
+
+test_that("copyExprClass works", {
+    testExpr <- nimble:::RparseTree2ExprClasses(quote(a <- foo(bar(b, 3, c) + 2) + 4))
+    testExprCopy <- nimble:::copyExprClass(testExpr)
+    expect_identical(capture.output(testExpr$show()),
+                     capture.output(testExprCopy$show()),
+                     info = 'incorrect copying of exprClass object')
+})
+
 test_that("Test of full model check", {
     oldmsg <- geterrmessage()
 


### PR DESCRIPTION
The problem in Issue #563 is the following oversight about handling `while`.  If we have `while(foo(x) > 0) {}`, and `foo(x)` turns out to be an expression for which we generate an intermediate variable in C++, then that intermediate variable was set once prior to the `while` rather than each time the `while` condition is evaluated.  In this example, we would get

```
Interm1 = foo(x);
while(Interm1 > 0) {
... // x might be updated, leaving Interm1 invalid during next iteration
}
```

The proposed solution is to insert all code for intermediates both before the `while` and at the end of the `while` body.  In this case:

```
Interm1 = foo(x);
while(Interm1 > 0) {
...
Interm1 = foo(x);
}
```

It seems a little clunky, but it should yield correct behavior.  Any cases where it won't?

Implementing this required a small utility function (`copyExprClass`) for copying `exprClass` objects while updating the upward link (`caller`) of their doubly-linked structure.

A regression test was added to `test-misc.R` for Issue #563.  A test of the new `copyExprClass` was also added.
