### PR TITLE
Fix #538 - step(inprod(a, b))

### DIFF
--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -2574,11 +2574,26 @@ sizeUnaryCwise <- function(code, symTab, typeEnv) {
     asserts <- recurseSetSizes(code, symTab, typeEnv)
     ## lift intermediates
     a1 <- code$args[[1]]
+    
     if(inherits(a1, 'exprClass')) {
         if(!nimbleOptions('experimentalNewSizeProcessing') ) {
-            if(a1$toEigenize == 'no') {
-                asserts <- c(asserts, sizeInsertIntermediate(code, 1, symTab, typeEnv))
-                a1 <- code$args[[1]]
+            if(a1$nDim == 0) {
+                ## Argument is scalar.
+                ## If it results from vector operation (e.g. inprod)
+                ## lift that to an intermediate
+                if(a1$toEigenize == 'yes') {
+                    asserts <- c(asserts, sizeInsertIntermediate(code, 1, symTab, typeEnv))
+                    a1 <- code$args[[1]]
+                }
+            } else {
+                ## Argument is non-scalar.  In this case, the
+                ## expression will be eigenized, so we must lift the
+                ## argument to an intermediate if it *can't* be
+                ## eigenized.
+                if(a1$toEigenize == 'no') {
+                    asserts <- c(asserts, sizeInsertIntermediate(code, 1, symTab, typeEnv))
+                    a1 <- code$args[[1]]
+                }
             }
         }
         code$nDim <- a1$nDim

--- a/packages/nimble/inst/tests/test-coreR.R
+++ b/packages/nimble/inst/tests/test-coreR.R
@@ -761,6 +761,29 @@ returnTests <- list(
          outputType = quote(double(1))) 
 )
 
+## Regression test for Issue #563
+test_that('unary_function( inprod(vector1, vector2) ) compiles and works', {
+    nfDef <- nimbleFunction(
+        setup = function() {},
+        run = function() {
+            a <- rep(0, 5)
+            b <- rep(0, 5)
+            c <- step(inprod(a, b))
+            return(c)
+            returnType(integer())
+        }
+    )
+    Rnf <- nfDef()
+    ## safe use of try followed by expectation of type
+    Cnf <- try(compileNimble(Rnf))
+    expect_false(inherits(Cnf, 'try-error'),
+                 info = 'step(inprod(a, b)) does not compile')
+    expect_equal(Cnf(),
+                 Rnf(),
+                 info = 'step(inprod(a, b)) compiles but gives wrong answer')
+}
+)
+
 cTestsResults <- test_coreRfeature_batch(cTests, 'cTests') ##lapply(cTests, test_coreRfeature)
 blockTestsResults <- test_coreRfeature_batch(blockTests, 'blockTests') ##lapply(blockTests, test_coreRfeature)
 repTestsResults <- test_coreRfeature_batch(repTests, 'repTests') ## lapply(repTests, test_coreRfeature)

--- a/packages/nimble/inst/tests/test-coreR.R
+++ b/packages/nimble/inst/tests/test-coreR.R
@@ -778,8 +778,8 @@ test_that('unary_function( inprod(vector1, vector2) ) compiles and works', {
     Cnf <- try(compileNimble(Rnf))
     expect_false(inherits(Cnf, 'try-error'),
                  info = 'step(inprod(a, b)) does not compile')
-    expect_equal(Cnf(),
-                 Rnf(),
+    expect_equal(Cnf$run(),
+                 Rnf$run(),
                  info = 'step(inprod(a, b)) compiles but gives wrong answer')
 }
 )


### PR DESCRIPTION
The problem with Issue #538 was in size processing of `step` and other unary functions that can handle scalar or non-scalar input (and operate component-wise on non-scalar input).  

For background, in a case like `step(foo(x))`, where `foo(x)` *cannot* be turned into eigen code, we put the result of `foo(x)` into an intermediate and then proceed to generate eigen code for `step(<Intermediate>)`.  That works fine.  

The missing case was somewhat opposite: `step( inprod(a, b))`, where `inprod(a, b)` can and should be turned into eigen code but then the scalar version of `step`, not its `eigen` version, should be used.  This was not being identified in `sizeUnaryCwise`, resulting in failure to eigenize `inprod(a, b)`.  

This bug impacted all unary functions. E.g., `exp(inprod(a, b))` also did not work.

In this pull request, logic has been added to `sizeUnaryCwise` to create an intermediate if the argument to the unary is marked for eigenization but returns a scalar.

A regression test has been added to `test-coreR.R`.
