### PR TITLE
Work around broken compiler flag plumbing of -DR_NO_REMAP

### DIFF
--- a/packages/nimble/R/cppDefs_cppProject.R
+++ b/packages/nimble/R/cppDefs_cppProject.R
@@ -10,7 +10,7 @@ cppCodeFileClass <- setRefClass('cppCodeFileClass',
                              	initialize = function(...){filename <<- character(); includes <<- character(); usings <<- character(); cppDefs <<- list(); callSuper(...)},
 
                                  writeIncludes = function(con = stdout()) {
-                                     writeLines('#define R_NO_REMAP', con)
+                                     writeLines(c('#ifndef R_NO_REMAP', '#define R_NO_REMAP', '#endif'), con)
                                      if(length(includes) > 0) writeLines(paste0('#include ', includes), con)
                                  },
                                  writeUsings = function(con = stdout()) {

--- a/packages/nimble/R/cppDefs_cppProject.R
+++ b/packages/nimble/R/cppDefs_cppProject.R
@@ -10,8 +10,8 @@ cppCodeFileClass <- setRefClass('cppCodeFileClass',
                              	initialize = function(...){filename <<- character(); includes <<- character(); usings <<- character(); cppDefs <<- list(); callSuper(...)},
 
                                  writeIncludes = function(con = stdout()) {
+                                     writeLines('#define R_NO_REMAP', con)
                                      if(length(includes) > 0) writeLines(paste0('#include ', includes), con)
-                                     writeLines('#undef eval', con) ## remove R headers' #define eval Rf_eval
                                  },
                                  writeUsings = function(con = stdout()) {
                                      if(length(usings) > 0) writeLines(paste0('using ', usings,';'), con)


### PR DESCRIPTION
This forces a line `-DR_NO_REMAP` at the top of each generated C++ file. This works around broken plumbing to pass the `-DR_NO_REMAP` flag to the compiler. `-DR_NO_REMAP` is needed for some of our new `Tensorflow`+`CppAD` integration, e.g. for #571 .