### PR TITLE
Correctly handle :: in Rname2CppName

### DIFF
--- a/packages/nimble/R/BUGS_utils.R
+++ b/packages/nimble/R/BUGS_utils.R
@@ -216,11 +216,15 @@ Rname2CppName <- function(rName, colonsOK = TRUE) {
     ## which were largely redundant
     if (!is.character(rName))
         rName <- deparse(rName)
-    if( colonsOK)
+
+    if( colonsOK) {
+        # Substitute single colons but preserve double colons.
+        rName <- gsub('::', '_DOUBLE_COLON_', rName)
         rName <- gsub(':', 'to', rName)  # replace colons with 'to'
-    else
-        if(grepl(':', rName))
-            stop(paste0('trying to do name mashup on expression with colon (\':\') from ', rName))
+        rName <- gsub('_DOUBLE_COLON_', '::', rName)
+    } else if(grepl(':', rName)) {
+        stop(paste0('trying to do name mashup on expression with colon (\':\') from ', rName))
+    }
     rName <- gsub(' ', '', rName)
     rName <- gsub('\\.', '_dot_', rName) 
     rName <- gsub("\"", "_quote_", rName)


### PR DESCRIPTION
Fixes #575 

Needed by #571

This is also needed for `test-ADfunctions.R` to pass.