### PR TITLE
Fixes #529: Use Rname2CppName for names passed to `compileFile`

### DIFF
--- a/packages/nimble/R/cppDefs_cppProject.R
+++ b/packages/nimble/R/cppDefs_cppProject.R
@@ -240,6 +240,7 @@ cppProjectClass <- setRefClass('cppProjectClass',
                                    },
                                    compileFile = function(names, showCompilerOutput = nimbleOptions('showCompilerOutput'),
                                                           .useLib = UseLibraryMakevars) {
+                                       names <- Rname2CppName(names)
                                        isWindows = (.Platform$OS.type == "windows")
 
                                        includes <- character()


### PR DESCRIPTION
Fixes #529 

This is a simple band-aid to ensure that when the compiler is invoked, any file names are mangled identically to when the files are written.  This has not turned up before because the mangling usually does nothing.  But if a nimbleFunction has a “.” in its name, the name mangling to “_dot_” for the file does need to be consistent.