### PR TITLE
only add check for zero contribution in conj sampler if variable is dynamically indexed

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -33,7 +33,7 @@ modelDefClass <- setRefClass('modelDefClass',
                                  ## the following are all set in setupModel()
                                  BUGScode = 'ANY',  ## original BUGS code, set in assignBUGScode()
                                  constantsEnv = 'ANY', ## environment with constants, set in assignConstants()
-                                 constantsList = 'ANY',  ## named list with constants, set in assignConsstants()
+                                 constantsList = 'ANY',  ## named list with constants, set in assignConstants()
                                  constantsNamesList = 'ANY', ## list of constants name objects, set in assignConstants()
                                  constantsScalarNamesList = 'ANY', ## could eventually replace constantsNamesList. added for newNodeFxns
                                  dimensionsList = 'ANY',		#list		   ## list of provided dimension information, set in assignDimensions()

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -203,11 +203,8 @@ print: A logical argument, specifying whether to print the ordered list of defau
                         if(useConjugacy) {
                             conjugacyResult <- conjugacyResultsAll[[node]]
                             if(!is.null(conjugacyResult)) {
-                                varName <- model$getVarNames(nodes = node)
                                 addConjugateSampler(conjugacyResult = conjugacyResult,
-                                                    dynamicallyIndexed = model$modelDef$varInfo[[varName]]$anyDynamicallyIndexed)
-                                next
-                            }
+                                                    dynamicallyIndexed = model$modelDef$varInfo[[model$getVarNames(nodes=node)]]$anyDynamicallyIndexed);     next }
                         }
                         if(nodeDist == 'dmulti')       { addSampler(target = node, type = 'RW_multinomial');     next }
                         if(nodeDist == 'ddirch')       { addSampler(target = node, type = 'RW_dirichlet');       next }
@@ -225,11 +222,8 @@ print: A logical argument, specifying whether to print the ordered list of defau
                     if(useConjugacy) {
                         conjugacyResult <- conjugacyResultsAll[[node]]
                         if(!is.null(conjugacyResult)) {
-                            varName <- model$getVarNames(nodes = node)
                             addConjugateSampler(conjugacyResult = conjugacyResult,
-                                                dynamicallyIndexed = model$modelDef$varInfo[[varName]]$anyDynamicallyIndexed)
-                            next
-                        }
+                                                dynamicallyIndexed = model$modelDef$varInfo[[model$getVarNames(nodes=node)]]$anyDynamicallyIndexed);     next }
                     }
                     
                     ## if node is discrete 0/1 (binary), assign 'binary' sampler
@@ -803,9 +797,9 @@ print: Logical argument (default = FALSE).  If TRUE, the resulting ordered list 
             addRule(quote(isEndNode), 'posterior_predictive')
             
 	    ## conjugate nodes
-            ## FIXME: CJP not sure how to modify this to include the new 'dynamicallyIndexed' argument here
             addRule(quote(useConjugacy && isConjugate),
-                    quote(addConjugateSampler(conjugacyResultsAll[[node]])))
+                    quote(addConjugateSampler(conjugacyResult = conjugacyResultsAll[[node]],
+                                              dynamicallyIndexed = model$modelDef$varInfo[[model$getVarNames(nodes=node)]]$anyDynamicallyIndexed)))
             
 	    ## multinomial
             addRule(quote(nodeDistribution == 'dmulti'), 'RW_multinomial')

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -204,7 +204,6 @@ print: A logical argument, specifying whether to print the ordered list of defau
                             conjugacyResult <- conjugacyResultsAll[[node]]
                             if(!is.null(conjugacyResult)) {
                                 varName <- model$getVarNames(nodes = node)
-                                if(length(varName) > 1) stop("MCMCconf: conjugate sampler for more than one variable: ", node, ".")
                                 addConjugateSampler(conjugacyResult = conjugacyResult,
                                                     dynamicallyIndexed = model$modelDef$varInfo[[varName]]$anyDynamicallyIndexed)
                                 next
@@ -227,7 +226,6 @@ print: A logical argument, specifying whether to print the ordered list of defau
                         conjugacyResult <- conjugacyResultsAll[[node]]
                         if(!is.null(conjugacyResult)) {
                             varName <- model$getVarNames(nodes = node)
-                            if(length(varName) > 1) stop("MCMCconf: conjugate sampler for more than one variable: ", node, ".")
                             addConjugateSampler(conjugacyResult = conjugacyResult,
                                                 dynamicallyIndexed = model$modelDef$varInfo[[varName]]$anyDynamicallyIndexed)
                             next
@@ -304,8 +302,8 @@ Invisibly returns a list of the current sampler configurations, which are sample
                         varName <- model$getVarNames(nodes = target)
                         if(length(varName) > 1) stop("MCMCconf: conjugate sampler for more than one variable: ", target, ".")
                         return(addConjugateSampler(conjugacyResult = conjugacyResult,
-                                                   dynamicallyIndexed = model$modelDef$varInfo[[varName]]$anyDynamicallyIndexed),
-                                                   print = print)
+                                                   dynamicallyIndexed = model$modelDef$varInfo[[varName]]$anyDynamicallyIndexed,
+                                                   print = print))
                     } else stop(paste0('Cannot assign conjugate sampler to non-conjugate node: \'', target, '\''))
                 }
                 thisSamplerName <- if(nameProvided) name else gsub('^sampler_', '', type)   ## removes 'sampler_' from beginning of name, if present

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -203,7 +203,12 @@ print: A logical argument, specifying whether to print the ordered list of defau
                         if(useConjugacy) {
                             conjugacyResult <- conjugacyResultsAll[[node]]
                             if(!is.null(conjugacyResult)) {
-                                addConjugateSampler(conjugacyResult = conjugacyResult);     next }
+                                varName <- model$getVarNames(nodes = node)
+                                if(length(varName) > 1) stop("MCMCconf: conjugate sampler for more than one variable: ", node, ".")
+                                addConjugateSampler(conjugacyResult = conjugacyResult,
+                                                    dynamicallyIndexed = model$modelDef$varInfo[[varName]]$anyDynamicallyIndexed)
+                                next
+                            }
                         }
                         if(nodeDist == 'dmulti')       { addSampler(target = node, type = 'RW_multinomial');     next }
                         if(nodeDist == 'ddirch')       { addSampler(target = node, type = 'RW_dirichlet');       next }
@@ -221,7 +226,12 @@ print: A logical argument, specifying whether to print the ordered list of defau
                     if(useConjugacy) {
                         conjugacyResult <- conjugacyResultsAll[[node]]
                         if(!is.null(conjugacyResult)) {
-                            addConjugateSampler(conjugacyResult = conjugacyResult);     next }
+                            varName <- model$getVarNames(nodes = node)
+                            if(length(varName) > 1) stop("MCMCconf: conjugate sampler for more than one variable: ", node, ".")
+                            addConjugateSampler(conjugacyResult = conjugacyResult,
+                                                dynamicallyIndexed = model$modelDef$varInfo[[varName]]$anyDynamicallyIndexed)
+                            next
+                        }
                     }
                     
                     ## if node is discrete 0/1 (binary), assign 'binary' sampler
@@ -242,7 +252,7 @@ print: A logical argument, specifying whether to print the ordered list of defau
             if(print)   printSamplers()
         },
 
-        addConjugateSampler = function(conjugacyResult, print = FALSE) {
+        addConjugateSampler = function(conjugacyResult, dynamicallyIndexed = FALSE, print = FALSE) {
             ## update May 2016: old (non-dynamic) system is no longer supported -DT
             ##if(!getNimbleOption('useDynamicConjugacy')) {
             ##    addSampler(target = conjugacyResult$target, type = conjugacyResult$type, control = conjugacyResult$control)
@@ -251,12 +261,13 @@ print: A logical argument, specifying whether to print the ordered list of defau
             prior <- conjugacyResult$prior
             dependentCounts <- sapply(conjugacyResult$control, length)
             names(dependentCounts) <- gsub('^dep_', '', names(dependentCounts))
-            ## FIXME: add check here of whether node is dynamically indexed and if so pass doDependentScreen flag to do screening
-            ## add _unknownIndex to samplers where we do the screen
-            ## have generate...Definition take arg about whether to do screen
-            conjSamplerName <- createDynamicConjugateSamplerName(prior = prior, dependentCounts = dependentCounts)
+            ## we now have separate sampler functions for the same conjugacy
+            ## when there are both dynamically and non-dynamically indexed
+            ## nodes with that conjugacy, as the dynamically-indexed
+            ## sampler has a check for zero contributions for each dependent
+            conjSamplerName <- createDynamicConjugateSamplerName(prior = prior, dependentCounts = dependentCounts, dynamicallyIndexed = dynamicallyIndexed)
             if(!dynamicConjugateSamplerExists(conjSamplerName)) {
-                conjSamplerDef <- conjugacyRelationshipsObject$generateDynamicConjugateSamplerDefinition(prior = prior, dependentCounts = dependentCounts, doDependentScreen = nimbleOptions()$allowDynamicIndexing)
+                conjSamplerDef <- conjugacyRelationshipsObject$generateDynamicConjugateSamplerDefinition(prior = prior, dependentCounts = dependentCounts, doDependentScreen = dynamicallyIndexed)
                 dynamicConjugateSamplerAdd(conjSamplerName, conjSamplerDef)
             }
             conjSamplerFunction <- dynamicConjugateSamplerGet(conjSamplerName)
@@ -290,7 +301,11 @@ Invisibly returns a list of the current sampler configurations, which are sample
                 if(type == 'conjugate') {
                     conjugacyResult <- model$checkConjugacy(target)[[target]]
                     if(!is.null(conjugacyResult)) {
-                        return(addConjugateSampler(conjugacyResult = conjugacyResult, print = print))
+                        varName <- model$getVarNames(nodes = target)
+                        if(length(varName) > 1) stop("MCMCconf: conjugate sampler for more than one variable: ", target, ".")
+                        return(addConjugateSampler(conjugacyResult = conjugacyResult,
+                                                   dynamicallyIndexed = model$modelDef$varInfo[[varName]]$anyDynamicallyIndexed),
+                                                   print = print)
                     } else stop(paste0('Cannot assign conjugate sampler to non-conjugate node: \'', target, '\''))
                 }
                 thisSamplerName <- if(nameProvided) name else gsub('^sampler_', '', type)   ## removes 'sampler_' from beginning of name, if present
@@ -790,6 +805,7 @@ print: Logical argument (default = FALSE).  If TRUE, the resulting ordered list 
             addRule(quote(isEndNode), 'posterior_predictive')
             
 	    ## conjugate nodes
+            ## FIXME: CJP not sure how to modify this to include the new 'dynamicallyIndexed' argument here
             addRule(quote(useConjugacy && isConjugate),
                     quote(addConjugateSampler(conjugacyResultsAll[[node]])))
             

--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -778,7 +778,7 @@ conjugacyClass <- setRefClass(
                 for(contributionName in posteriorObject$neededContributionNames) {
                     if(!(contributionName %in% dependents[[distName]]$contributionNames))     next
                     contributionExpr <- eval(substitute(substitute(EXPR, subList), list(EXPR=dependents[[distName]]$contributionExprs[[contributionName]])))
-                    if(nimbleOptions()$allowDynamicIndexing && doDependentScreen) { ## FIXME: do so only have one if() here and only insert the check if the sampler involves a dynamic index
+                    if(nimbleOptions()$allowDynamicIndexing && doDependentScreen) { ## FIXME: would be nice to only have one if() here when we loop through multiple parameters
                         if(targetNdim == 0)
                             forLoopBody$addCode(if(COEFF_EXPR != 0) CONTRIB_NAME <<- CONTRIB_NAME + CONTRIB_EXPR,
                                                 list(COEFF_EXPR = subList$coeff, CONTRIB_NAME = as.name(contributionName), CONTRIB_EXPR = contributionExpr))
@@ -1181,10 +1181,10 @@ compareConjugacyLists <- function(C1, C2) {
     }
 }
 
-createDynamicConjugateSamplerName <- function(prior, dependentCounts, unknownIndex = FALSE) {
+createDynamicConjugateSamplerName <- function(prior, dependentCounts, dynamicallyIndexed = FALSE) {
     ##depString <- paste0(dependentCounts, names(dependentCounts), collapse='_')  ## including the numbers of dependents
     depString <- paste0(names(dependentCounts), collapse='_')                     ## without the numbers of each type of dependent node
-    paste0('sampler_conjugate_', prior, '_', depString, ifelse(unknownIndex, '_unknownIndex', ''))
+    paste0('sampler_conjugate_', prior, '_', depString, ifelse(dynamicallyIndexed, '_dynamicDeps', ''))
 }
 
 makeDeclareSizeField <- function(firstSize, secondSize, thirdSize, nDim) {


### PR DESCRIPTION
We have code like this in conjugate samplers:
```
   for (iDep in 1:N_dep_dnorm) {
        if (dep_dnorm_coeff[iDep] != 0) 
            contribution_mean <<- contribution_mean + dep_dnorm_coeff[iDep] * 
                (dep_dnorm_values[iDep] - dep_dnorm_offset[iDep]) * 
                dep_dnorm_tau[iDep]
        if (dep_dnorm_coeff[iDep] != 0) 
            contribution_tau <<- contribution_tau + dep_dnorm_coeff[iDep]^2 * 
                dep_dnorm_tau[iDep]
    }

```

This PR makes it so the check for != 0 is only added if the node is in a variable that is dynamically indexed.

Two shortcomings:
1) code above has two if() statements as I wasn't sure how to wrap multiple lines in an if in 'addForLoopBody'
2) in MCMC_configuration.R I didn't look deeply enough to see how to update the addConjugateSampler call that is part of the new dynamic conj rules. It still needs the 'dynamicallyIndexed' argument that one can see in the standard conjugacy processing code.