### PR TITLE
Enforce uniqueness of modelDef names, and hence model interface class names

### DIFF
--- a/packages/nimble/R/BUGS_utils.R
+++ b/packages/nimble/R/BUGS_utils.R
@@ -318,7 +318,7 @@ is.Rmodel <- function(obj, inputIsName = FALSE) {
 #' @export
 is.Cmodel <- function(obj, inputIsName = FALSE) {
     if(inputIsName) obj <- get(obj)
-    return(inherits(obj, 'modelBaseClass') && !inherits(obj, 'RmodelBaseClass'))
+    return(inherits(obj, 'CmodelBaseClass'))
 }
 
 # extracts dimension from character vec of form such as c("double(0)", "integer(1)")

--- a/packages/nimble/R/all_utils.R
+++ b/packages/nimble/R/all_utils.R
@@ -47,6 +47,7 @@ resetLabelFunctionCreators <- function() {
 }
 
 nimbleUniqueID <- labelFunctionCreator("UID")
+nimbleModelID  <- labelFunctionCreator("MID")
 
 dimOrLength <- function(obj, scalarize = FALSE) {
     if(scalarize) if(length(obj) == 1) return(numeric(0))

--- a/packages/nimble/inst/tests/test_utils.R
+++ b/packages/nimble/inst/tests/test_utils.R
@@ -1103,7 +1103,7 @@ test_dynamic_indexing_model_internal <- function(param) {
                 expect_identical(m$getDependencies(param$expectedDeps[[i]]$parent, stochOnly = TRUE),
                     param$expectedDeps[[i]]$result, info = paste0("dependencies don't match expected in dependency of ", param$expectedDeps[[i]]$parent))
             cm <- compileNimble(m)
-            expect_true(class(cm) == "Ccode", info = "compiled model object improperly formed")
+            expect_true(is.Cmodel(cm), info = "compiled model object improperly formed")
             expect_identical(calculate(m), calculate(cm), info = "problem with R vs. C calculate with initial indexes")
             for(i in seq_along(param$validIndexes)) {
                 for(j in seq_along(param$invalidIndexes[[i]]$var)) {


### PR DESCRIPTION
Fixes #604 

You should get a prize for this.  The problem occurs in what will be the 2nd or even 1st line of code executed.  We were not enforcing uniqueness of `modelDef` names.  Those names become part of the names of the generated reference classes to interface to compiled models.  The second reference class over-wrote the definition of the first because it had the same name.

One source of non-uniqueness was that if a `name` argument is not provided, we attempt to get it by the expression provided for the `code` argument, by `deparse (substitute(code))`.  But for historical reasons, `nimbleModel` simply calls `BUGSmodel`, which determines the name.  That means that the call to `BUGSmodel` *always* had simply `code` as the expression of its `code` argument, so deparsing that always yielded the name "code".

I remedied this in two ways:

- I flipped the roles of `nimbleModel` and `BUGSmodel`.  Now `nimbleModel` does the real action, and that means the determination of a name really sees the expression passed for `code`.  I also did some processing like using only the first 10 characters (because there could be `nimbleModel(code = nimbleCode({<LOTS>}))` and replacing spaces with underscores.

- I append a unique label "\_MID\_\<number\>" , created from one of our label generators.  MID stands for "model ID".
