### PR TITLE
Allow negative numbers as default arguments to work correctly

### DIFF
--- a/packages/nimble/R/cppDefs_RCfunction.R
+++ b/packages/nimble/R/cppDefs_RCfunction.R
@@ -128,7 +128,9 @@ RCfunctionDef <- setRefClass('RCfunctionDef',
                                    argNamesCall = argNames
                                    for(i in seq_along(argNamesCall) ){
                                      if(argsCode[i] != '')
-                                       argNamesCall[i] = paste(argNames[i], " = ", as.character(argsCode[[i]]) )
+                                         argNamesCall[i] = paste(argNames[i], " = ", deparse(argsCode[[i]]) )
+                                     ## deparse instead of as.character is needed in the above line if there is a negative default
+                                     ## because it will be parsed as a unary - operator with the number as an argument
                                    }
                                    if(includeDotSelfAsArg) argNamesCall <- c(argNamesCall, includeDotSelf)
                                    if(inherits(RCfunProc$compileInfo$returnSymbol, 'symbolNimbleList')){


### PR DESCRIPTION
Fixes #562 

The problem was that when constructing the R wrapper to the compiled function, the insertion of default values failed for negative values.  This occurred because of use of `as.character` where `deparse` is always safer.  `as.character( quote(-1))` return a vector of "-" and "1" because "-" is handled as a unary negative operator, so the "-1" is parsed as a function call instead of a number.  This meant the code constructed was of the form `function(x = -) {...}`.   `deparse(quote(-1))` returns "-1" as desired and allows construction of `function(x = -1) {...}`.