### PR TITLE
Add a warning message when a user assigns an `RW_block` sampler 

### DIFF
--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -297,7 +297,7 @@ Invisibly returns a list of the current sampler configurations, which are sample
                 }
                 thisSamplerName <- if(nameProvided) name else gsub('^sampler_', '', type)   ## removes 'sampler_' from beginning of name, if present
                 if(thisSamplerName == 'RW_block' && !silent){
-                  print('Note: Assigning an RW_block sampler to nodes with very different scales can result in low MCMC efficiency.  If all nodes are not on a similar scale, we recommend providing an informed value for the "propCov" control list argument, or using the AFSS sampler instead.')
+                  message('Note: Assigning an RW_block sampler to nodes with very different scales can result in low MCMC efficiency.  If all nodes assigned to RW_block are not on a similar scale, we recommend providing an informed value for the \"propCov\" control list argument, or using the AFSS sampler instead.')
                 }
                 if(exists(type) && is.nfGenerator(eval(as.name(type)))) {   ## try to find sampler function 'type'
                     samplerFunction <- eval(as.name(type))

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -296,8 +296,8 @@ Invisibly returns a list of the current sampler configurations, which are sample
                     } else stop(paste0('Cannot assign conjugate sampler to non-conjugate node: \'', target, '\''))
                 }
                 thisSamplerName <- if(nameProvided) name else gsub('^sampler_', '', type)   ## removes 'sampler_' from beginning of name, if present
-                if(thisSamplerName == 'RW_block' && !silent){
-                  message('Note: Assigning an RW_block sampler to nodes with very different scales can result in low MCMC efficiency.  If all nodes assigned to RW_block are not on a similar scale, we recommend providing an informed value for the \"propCov\" control list argument, or using the AFSS sampler instead.')
+                if(thisSamplerName == 'RW_block' && !silent) {
+                    message('Note: Assigning an RW_block sampler to nodes with very different scales can result in low MCMC efficiency.  If all nodes assigned to RW_block are not on a similar scale, we recommend providing an informed value for the \"propCov\" control list argument, or using the AFSS sampler instead.')
                 }
                 if(exists(type) && is.nfGenerator(eval(as.name(type)))) {   ## try to find sampler function 'type'
                     samplerFunction <- eval(as.name(type))


### PR DESCRIPTION
This PR causes a message to be issued if a user assigns an `RW_block` sampler to nodes in a model.  The message reads as follows:

```
Note: Assigning an RW_block sampler to nodes with very different scales can result in low MCMC efficiency.  If all nodes assigned to RW_block are not on a similar scale, we recommend providing an informed value for the "propCov" control list argument, or using the AFSS sampler instead.
```

The message is controlled by a new argument to the `addSampler()` method of the `MCMCconf` ref class, named `silent`.  `silent` defaults to `FALSE`, but is set to `TRUE` for `RW_block` samplers that are assigned via `addSampler` in the `initialize` method of `MCMCconf`.  