### PR TITLE
Add warning message for discrete top-level params in MCEM.

### DIFF
--- a/packages/nimble/NEWS
+++ b/packages/nimble/NEWS
@@ -15,6 +15,8 @@ BUG FIXES
 
 -- Fixed bug in MCEM where bounds for multivariate top-level parameters were not stored correctly.
 
+-- MCEM outputs a warning message if the provided model has discrete top-level parameters.
+
 -- Sped up WAIC calculation for large models.
 
 

--- a/packages/nimble/R/MCEM_build.R
+++ b/packages/nimble/R/MCEM_build.R
@@ -201,7 +201,6 @@ buildMCEM <- function(model, latentNodes, burnIn = 500 , mcmcControl = list(adap
   if(length(setdiff(latentNodes, allStochNonDataNodes) ) != 0 )
     stop('latentNodes provided not found in model')
   maxNodes = model$expandNodeNames(setdiff(allStochNonDataNodes, latentNodes), returnScalarComponents = TRUE)
-
   limits <- getMCEMRanges(model, maxNodes, buffer)
   low_limits = limits[[1]]
   hi_limits  = limits[[2]]
@@ -272,7 +271,8 @@ buildMCEM <- function(model, latentNodes, burnIn = 500 , mcmcControl = list(adap
   cGetCov = compileNimble(RgetCov, project = Rmodel)  
   cvarCalc <- compileNimble(RvarCalc, project = Rmodel)
   cCalc_E_llk = compileNimble(Rcalc_E_llk, project = Rmodel)  
-  
+  if(any(model$isDiscrete(maxNodes))) cat(paste0("Warning: MCEM cannot optimize over discrete top-level parameters. The following top-level parameters in your model are discrete: ",
+                                                 paste0(maxNodes[model$isDiscrete(maxNodes)], collapse = ', ')))
   nParams = length(maxNodes)
   run <- function(initM = 1000){
     if(burnIn >= initM)

--- a/packages/nimble/R/MCEM_build.R
+++ b/packages/nimble/R/MCEM_build.R
@@ -201,6 +201,9 @@ buildMCEM <- function(model, latentNodes, burnIn = 500 , mcmcControl = list(adap
   if(length(setdiff(latentNodes, allStochNonDataNodes) ) != 0 )
     stop('latentNodes provided not found in model')
   maxNodes = model$expandNodeNames(setdiff(allStochNonDataNodes, latentNodes), returnScalarComponents = TRUE)
+  if(any(model$isDiscrete(maxNodes))) stop(paste0("MCEM cannot optimize over discrete top-level parameters. The following top-level parameters in your model are discrete: ",
+                                                  paste0(maxNodes[model$isDiscrete(maxNodes)], collapse = ', ')))
+  
   limits <- getMCEMRanges(model, maxNodes, buffer)
   low_limits = limits[[1]]
   hi_limits  = limits[[2]]
@@ -271,8 +274,6 @@ buildMCEM <- function(model, latentNodes, burnIn = 500 , mcmcControl = list(adap
   cGetCov = compileNimble(RgetCov, project = Rmodel)  
   cvarCalc <- compileNimble(RvarCalc, project = Rmodel)
   cCalc_E_llk = compileNimble(Rcalc_E_llk, project = Rmodel)  
-  if(any(model$isDiscrete(maxNodes))) cat(paste0("Warning: MCEM cannot optimize over discrete top-level parameters. The following top-level parameters in your model are discrete: ",
-                                                 paste0(maxNodes[model$isDiscrete(maxNodes)], collapse = ', ')))
   nParams = length(maxNodes)
   run <- function(initM = 1000){
     if(burnIn >= initM)


### PR DESCRIPTION
This PR adds a warning message if a user sets up an MCEM algorithm on a model that has discrete top-level parameters.  The message reads:

```
Warning: MCEM cannot optimize over discrete top-level parameters. The following top-level parameters in your model are discrete: ... (parameter names here)
```
