### PR TITLE
New message for uninitialized variables in nimbleModel().

### DIFF
--- a/packages/nimble/NEWS
+++ b/packages/nimble/NEWS
@@ -9,6 +9,8 @@ USER LEVEL CHANGES
 
 -- Addition of dcar_proper distributino, the proper Gaussian conditional autoregressive (CAR) distribution, and MCMC sampling support.
 
+-- nimbleModel no longer outputs the names of all uninitialized variables in a model.  Instead, users are directed to use the new $initializeInfo() method if uninitialized variables are detected. 
+
 BUG FIXES
 
 -- Fixed MCMC autoBlocking procedure, to work with new sampler default values system.

--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -1343,7 +1343,6 @@ whyInvalid <- function(value) {
 #'  Having uninitialized nodes in a nimbleModel can potentially cause some algorithms to fail, and can lead to poor performance in others.  Here are some
 #'  general guidelines on  how non-intitialized variables can affect performance:
 #'  \itemize{
-#'    \item Any dynamic indices need to be initialized in order for the model to perform correctly.
 #'    \item MCMC will atuo-initialize, but will do so from the prior distribution.  This can cause slow convergence, especially in the case of diffuse priors.
 #'    \item Likewise, particle filtering methods will initialize top-level parameters from their prior distributions, which can lead to errors or poor performance in these methods.
 #' }

--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -1,5 +1,5 @@
 #' Class \code{modelBaseClass}
-#' @aliases modelBaseClass getVarNames getNodeNames topologicallySortNodes resetData setData isData isEndNode getDistribution isDiscrete isBinary isStoch isDeterm isTruncated isUnivariate getDimension getDependencies setInits checkConjugacy newModel [[,modelBaseClass-method [[<-,modelBaseClass-method
+#' @aliases modelBaseClass getVarNames getNodeNames topologicallySortNodes resetData setData isData isEndNode getDistribution isDiscrete isBinary isStoch isDeterm isTruncated isUnivariate getDimension getDependencies setInits checkConjugacy newModel [[,modelBaseClass-method [[<-,modelBaseClass-method initializeInfo
 #' @export
 #' @description
 #' This class underlies all NIMBLE model objects: both R model objects created from the return value of nimbleModel(), and compiled model objects.
@@ -1336,9 +1336,6 @@ whyInvalid <- function(value) {
     if(any(abs(value)==Inf)) return('inf')
     stop('should never happen')
 }
-
-
-
 
 #' Information on initial values in a nimbleModel
 #'

--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -19,6 +19,7 @@
 #' Rmodel$resetData()
 #' Rmodel$setData(list(x = c(1.2, NA)))   ## flags only 'x[1]' node as data
 #' Rmodel$isData(c('mu', 'x[1]', 'x[2]'))   ## returns c(FALSE, TRUE, FALSE)
+#' @seealso \code{\link{initializeModel}}
 modelBaseClass <- setRefClass('modelBaseClass',
                               fields = list(
                                   modelDef = 'ANY',
@@ -955,7 +956,7 @@ Checks for size/dimension mismatches and for presence of NAs in model variables 
                                         varsWithNAs <- NULL
                                         for(v in .self$getVarNames()){
                                           if(!nimble:::isValid(.self[[v]])){
-                                            message(' This model is not fully initialized.  To see which variables are not initialized, use model$initializeInfo().  This is not an error.  For more information on model initialization, see help(modelInitialization).', appendLF = FALSE)
+                                            message(' This model is not fully initialized.  This is not an error.  To see which variables are not initialized, use model$initializeInfo().  For more information on model initialization, see help(modelInitialization).', appendLF = FALSE)
                                             break()
                                           }
                                         }
@@ -1340,10 +1341,10 @@ whyInvalid <- function(value) {
 #' Information on initial values in a nimbleModel
 #'
 #'  Having uninitialized nodes in a nimbleModel can potentially cause some algorithms to fail, and can lead to poor performance in others.  Here are some
-#'  general guidelines on  how non-intitialized variables can effect performance:
+#'  general guidelines on  how non-intitialized variables can affect performance:
 #'  \itemize{
 #'    \item Any dynamic indices need to be initialized in order for the model to perform correctly.
-#'    \item MCMC will atuo-initialize, but will do so from the prior distribution.  This can cause convergence issues, especially in the case of diffuse priors.
+#'    \item MCMC will atuo-initialize, but will do so from the prior distribution.  This can cause slow convergence, especially in the case of diffuse priors.
 #'    \item Likewise, particle filtering methods will initialize top-level parameters from their prior distributions, which can lead to errors or poor performance in these methods.
 #' }
 #'

--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -956,7 +956,7 @@ Checks for size/dimension mismatches and for presence of NAs in model variables 
                                         varsWithNAs <- NULL
                                         for(v in .self$getVarNames()){
                                           if(!nimble:::isValid(.self[[v]])){
-                                            message(' This model is not fully initialized.  This is not an error.  To see which variables are not initialized, use model$initializeInfo().  For more information on model initialization, see help(modelInitialization).', appendLF = FALSE)
+                                            message(' This model is not fully initialized. This is not an error. To see which variables are not initialized, use model$initializeInfo(). For more information on model initialization, see help(modelInitialization).', appendLF = FALSE)
                                             break()
                                           }
                                         }


### PR DESCRIPTION
This PR replaces the former warning message output by `nimbleModel()` for non-initialized variables, which looked like:
```
note that missing values (NAs) or non-finite values were found in model variables: x. This is not an error, but some or all variables may need to be initialized for certain algorithms to operate properly.
```
with a new warning message that reads:
```
This model is not fully initialized.  To see which variables are not initialized, use model$initializeInfo().  This is not an error.  For more information on model initialization, see help(modelInitialization).
```

In addition, there is a new `initializeInfo()` method for `nimbleModel` objects that returns the names of all uninitialized  variables, in a message such as:
```
Missing values (NAs) or non-finite values were found in model variables: x. This is not an error, but some or all variables may need to be initialized for certain algorithms to operate properly. For more information on model initialization, see help(modelInitialization).
```

Finally, if a user calls `help(modelInitialization)`, they will get an informative R help entry with some guidelines on the effect that non-initialized variables can have in different circumstances.