### PR TITLE
Make NimArrBase::setLength obey fillZeroes even on first allocation.

### DIFF
--- a/packages/nimble/R/cppDefs_modelValues.R
+++ b/packages/nimble/R/cppDefs_modelValues.R
@@ -67,7 +67,9 @@ cppModelValuesClass <- setRefClass('cppModelValuesClass',
                                            codeLines2 <- list()
                                            if(is.list(vars)) {
                                                for(v in names(Rnames2CppNames)) {
-                                                   ssc <- as.call(c(list(as.name('setSize')), as.list(vars[[v]])))
+                                                   ssc <- as.call(c(list(as.name('initialize')),
+                                                                    c(list(quote(NA_REAL), 1)),
+                                                                    as.list(vars[[v]])))
                                                    codeLines2[[v]] <- codeSubstitute(template2, list(SETSIZECALL = ssc, VAR = as.name(Rnames2CppNames[[v]])))
                                                    
                                                }
@@ -76,7 +78,9 @@ cppModelValuesClass <- setRefClass('cppModelValuesClass',
                                                for(v in names(Rnames2CppNames)) {
                                                    thisSize <- vars$getSymbolObject(v)$size
                                                    if(length(thisSize)==0) thisSize <- 1
-                                                   ssc <- as.call(c(list(as.name('setSize')), as.list(thisSize)))
+                                                   ssc <- as.call(c(list(as.name('initialize')),
+                                                                    c(list(quote(NA_REAL), 1)),
+                                                                    as.list(thisSize)))
                                                    codeLines2[[v]] <- codeSubstitute(template2, list(SETSIZECALL = ssc, VAR = as.name(Rnames2CppNames[[v]])))
                                                }
                                            }

--- a/packages/nimble/R/cppDefs_modelValues.R
+++ b/packages/nimble/R/cppDefs_modelValues.R
@@ -67,9 +67,7 @@ cppModelValuesClass <- setRefClass('cppModelValuesClass',
                                            codeLines2 <- list()
                                            if(is.list(vars)) {
                                                for(v in names(Rnames2CppNames)) {
-                                                   ssc <- as.call(c(list(as.name('initialize')),
-                                                                    c(list(quote(NA_REAL), 1)),
-                                                                    as.list(vars[[v]])))
+                                                   ssc <- as.call(c(list(as.name('setSize')), as.list(vars[[v]])))
                                                    codeLines2[[v]] <- codeSubstitute(template2, list(SETSIZECALL = ssc, VAR = as.name(Rnames2CppNames[[v]])))
                                                    
                                                }
@@ -78,9 +76,7 @@ cppModelValuesClass <- setRefClass('cppModelValuesClass',
                                                for(v in names(Rnames2CppNames)) {
                                                    thisSize <- vars$getSymbolObject(v)$size
                                                    if(length(thisSize)==0) thisSize <- 1
-                                                   ssc <- as.call(c(list(as.name('initialize')),
-                                                                    c(list(quote(NA_REAL), 1)),
-                                                                    as.list(thisSize)))
+                                                   ssc <- as.call(c(list(as.name('setSize')), as.list(thisSize)))
                                                    codeLines2[[v]] <- codeSubstitute(template2, list(SETSIZECALL = ssc, VAR = as.name(Rnames2CppNames[[v]])))
                                                }
                                            }

--- a/packages/nimble/inst/include/nimble/NimArr.h
+++ b/packages/nimble/inst/include/nimble/NimArr.h
@@ -163,7 +163,7 @@ class NimArr<1, T> : public NimArrBase<T> {
   }
 
   NimArr<1, T>(const NimArr<1, T> &other) : NimArrBase<T>(other) {
-    NimArrBase<T>::NAdims[0] = other.dim()[0];
+    NimArrBase<T>::NAdims[0] = other.dim()[0]; // redundant with base class copy constructor?
     size1 = NimArrBase<T>::NAdims[0];
 
     NimArrBase<T>::NAstrides[0] = NimArrBase<T>::stride1 = 1;

--- a/packages/nimble/inst/include/nimble/NimArrBase.h
+++ b/packages/nimble/inst/include/nimble/NimArrBase.h
@@ -151,6 +151,8 @@ class NimArrBase : public NimArrType {
         if (fillZeros) std::fill(new_v, new_v + l, static_cast<T>(0));
       }
       nimble_free(v);
+    } else {
+      if (fillZeros) std::fill(new_v, new_v + l, static_cast<T>(0));
     }
     NAlength = l;
     v = new_v;

--- a/packages/nimble/inst/include/nimble/NimArrBase.h
+++ b/packages/nimble/inst/include/nimble/NimArrBase.h
@@ -181,13 +181,14 @@ class NimArrBase : public NimArrType {
   virtual ~NimArrBase() {
     if (own_v) nimble_free(v);
   }
-  // Do we ever use this case?
+  // Base class copy constructor:
+  // This will be used by derived class copy constructors,
+  // which will be called when a VecNimArr resizes its vector of NimArr<>s.
   NimArrBase(const NimArrBase<T> &other)
-      :  // own_v isn't a map but we'll only set to true when giving it values.
-        own_v(false),
-        offset(0),
-        boolMap(false),
-        NAlength(other.size()) {
+    :   own_v(false), // this may get set to true in a derived copy constructor
+    offset(0),
+    boolMap(false),
+    NAlength(other.size()) {
     std::memcpy(NAdims, other.dim(), other.numDims() * sizeof(int));
     myType = other.getNimType();
   }


### PR DESCRIPTION
This PR fixes the issue noted in Pull Request #616, that samples returned for an *unused* node seemed to change behavior across nimble versions.  I could not reproduce that behavior exactly, but I could see that the `NimArr`s used to store the MCMC samples (in a `VecNimArr`) were never being initialized upon memory allocation.  That is ok in normal usage because they will be populated by the MCMC.  And in the past we determined that unnecessary initialization can be a large computational cost in other places (repeatedly called `nimbleFunction`s).  But in this particular step the cost shouldn't be much, and initialization to 0 will create reasonable behavior for the samples of a node that is never used and therefore never even saved as part of the MCMC.

Should it initialize to NA instead?  I'm not sure how to do that but could probably figure out.