### PR TITLE
CV updates

### DIFF
--- a/packages/nimble/R/crossValidation.R
+++ b/packages/nimble/R/crossValidation.R
@@ -24,7 +24,7 @@ calcCrossVal <- function(i,
                          foldFunction,
                          lossFunction,
                          MCMCiter,
-                         burnInProp,
+                         nburnin,
                          returnSamples,
                          nBootReps){
   model <- conf$model
@@ -58,7 +58,7 @@ calcCrossVal <- function(i,
   C.modelMCMC$run(MCMCiter)
   MCMCout <- as.matrix(C.modelMCMC$mvSamples)[,leaveOutNames]
   sampNum <- dim(MCMCout)[1]
-  startIndex <- max(c(ceiling(burnInProp*MCMCiter), 1))
+  startIndex <- nburnin+1
   message(paste("dropping data fold", i))
   if(predLoss){
     values(model, missingDataNames) <- saveData
@@ -173,12 +173,12 @@ generateRandomFoldFunction <- function(model, k){
 #' @section The \code{MCMCcontrol} Argument:
 #' The \code{MCMCcontrol} argument is a list with the following elements:
 #'	\itemize{
-#'	  \item{\code{nMCMCiters}}{
-#'      an integer argument determining how many MCMC iterations should be run for each posterior predictive p-value calculation.  Defaults to 10000, but should probably be manually set.
+#'	  \item{\code{niter}}{
+#'      an integer argument determining how many MCMC iterations should be run for each loss value calculation.  Defaults to 10000, but should probably be manually set.
 #'	  }
-#'	\item{\code{burnInProp}}{
-#'	   the proportion of the MCMC chain to discard as burn-in for each posterior predictive p-value calculation.  Must be between 0 and 1.  Defaults to 0.
-#'	}
+#'	\item{\code{nburnin}}{
+#'	   the number of samples from the start of the MCMC chain to discard as burn-in for each loss value calculation.  Must be between 0 and \code{niter}.  Defaults to 10% of \code{niter}.
+#'	  }
 #'  }
 #' 
 #' @return
@@ -256,8 +256,8 @@ generateRandomFoldFunction <- function(model, k){
 #'                                    k = 6,
 #'                                    foldFunction = dyesFoldFunction,
 #'                                    lossFunction = RMSElossFunction,
-#'                                    MCMCcontrol = list(nMCMCiters = 5000,
-#'                                                       burnInProp = .1))
+#'                                    MCMCcontrol = list(niter = 5000,
+#'                                                       nburnin = 500))
 #' }  
 #' 
 runCrossValidate <- function(MCMCconfiguration,
@@ -270,20 +270,20 @@ runCrossValidate <- function(MCMCconfiguration,
                              nBootReps = 200){
   
   model <- MCMCconfiguration$model
-  nMCMCiters <- MCMCcontrol[['nMCMCiters']] 
+  niter <- MCMCcontrol[['niter']] 
   if(k < 2){
     stop("k must be at least 2.")
   }
-  if(is.null(nMCMCiters)){
-    nMCMCiters <- 10000
+  if(is.null(niter)){
+    niter <- 10000
     warning("Defaulting to 10,000 MCMC iterations for each MCMC run.")
   }
-  burnInProp <-  MCMCcontrol[['burnInProp']]  
-  if(is.null(burnInProp)){
-    burnInProp <- 0
+  nburnin <-  MCMCcontrol[['nburnin']]  
+  if(is.null(nburnin)){
+    nburnin <- floor(0.1*niter)
   }
-  else if(burnInProp >= 1 | burnInProp < 0){
-    stop("burnInProp needs to be between 0 and 1")
+  else if(nburnin >= niter | nburnin < 0){
+    stop("nburnin needs to be between 0 and niter.")
   }
   if(is.character(foldFunction) && foldFunction == 'random'){
     foldFunction <- generateRandomFoldFunction(model, k)
@@ -312,8 +312,8 @@ runCrossValidate <- function(MCMCconfiguration,
                             MCMCconfiguration,
                             foldFunction,
                             lossFunction,
-                            nMCMCiters,
-                            burnInProp,
+                            niter,
+                            nburnin,
                             returnSamples,
                             nBootReps,
                             mc.cores = nCores)
@@ -322,8 +322,8 @@ runCrossValidate <- function(MCMCconfiguration,
                             MCMCconfiguration,
                             foldFunction,
                             lossFunction,
-                            nMCMCiters,
-                            burnInProp,
+                            niter,
+                            nburnin,
                             returnSamples,
                             nBootReps)
   }

--- a/packages/nimble/R/crossValidation.R
+++ b/packages/nimble/R/crossValidation.R
@@ -308,18 +308,6 @@ runCrossValidate <- function(MCMCconfiguration,
     nCores <- 1
   }
   
-  ## Below we run an initial MCMC chain to get good initial values for model params.  This way the fold-specific chains will hopefully 
-  ## converge quickly.
-  compileNimble(model)
-  initMCMC <- MCMCconfiguration
-  initMCMC <- buildMCMC(MCMCconfiguration)
-  C.initMCMC <- compileNimble(initMCMC,
-                               project = model)
-  C.initMCMC$run(niter)
-  mvSamples <- as.matrix(C.initMCMC$mvSamples)
-  values(MCMCconfiguration$model, colnames(mvSamples)) <- mvSamples[dim(mvSamples)[1],]
-  MCMCconfiguration$model$calculate(MCMCconfiguration$model$getDependencies(colnames(mvSamples)))
-  
   if(nCores > 1){
     crossValOut <- parallel::mclapply(1:k, calcCrossVal,
                             MCMCconfiguration,

--- a/packages/nimble/inst/tests/test-crossVal.R
+++ b/packages/nimble/inst/tests/test-crossVal.R
@@ -39,7 +39,7 @@ test_that("voter model cross-validation is accurate: ", {
                               k = 15, ## do loo-cv so that we can compare against a known value
                               foldFunction = 'random',
                               lossFunction = 'predictive',
-                              MCMCcontrol = list(nMCMCiters = 500),
+                              MCMCcontrol = list(niter = 500),
                               nBootReps = 2)
   expect_equal(testOut$CVvalue, -43.8, tolerance = 2)
 })
@@ -72,11 +72,11 @@ test_that("voter model cross-validation runs using MSE loss: ", {
                               k = 2, 
                               foldFunction = 'random',
                               lossFunction = 'MSE',
-                              MCMCcontrol = list(nMCMCiters = 100),
+                              MCMCcontrol = list(niter = 100),
                               nBootReps = 2)
 })
 
-test_that("Radon model WAIC is accurate: ", {
+test_that("Radon model cross-validation runs using MSE loss: ", {
   url <- "http://stat.columbia.edu/~gelman/arm/examples/arsenic/wells.dat"
   wells <- try(read.table(url), silent = TRUE)
   if (inherits(wells, 'try-error')) skip("No internet connection")
@@ -103,7 +103,7 @@ test_that("Radon model WAIC is accurate: ", {
                               k = 2, 
                               foldFunction = 'random',
                               lossFunction = 'MSE',
-                              MCMCcontrol = list(nMCMCiters = 100),
+                              MCMCcontrol = list(niter = 100),
                               nBootReps = 2)
 })
 


### PR DESCRIPTION
This PR has a few updates to the CV algo:

- the names of the elements of the `MCMCcontrol` list argument have been changed to match the arguments to `runMCMC` (specifically, they are now `niter` and `nburnin`).  

- The `nburnin` argument will default to 10% of the value of `niter`.

- The fold-specific MCMCs will now start at parameter values obtained from a posterior sample from an initial, whole-model MCMC run.

- A bug where a matrix would sometimes be turned into a vector if a scalar data element was held out was fixed.