### PR TITLE
Allow a combined WAIC to be calculated from multiple MCMC chains 

### DIFF
--- a/packages/nimble/R/MCMC_run.R
+++ b/packages/nimble/R/MCMC_run.R
@@ -15,7 +15,7 @@ samplesSummary <- function(samples) {
 #'
 #' Takes as input an MCMC algorithm (ideally a compiled one for speed)
 #' and runs the MCMC with one or more chains, any returns any combination
-#' of posterior samples, posterior summary statistics, and WAIC values.
+#' of posterior samples, posterior summary statistics, and a WAIC value.
 #'
 #' @param mcmc A NIMBLE MCMC algorithm.  See details.
 #'
@@ -37,13 +37,13 @@ samplesSummary <- function(samples) {
 #' 
 #' @param summary Logical argument.  When \code{TRUE}, summary statistics for the posterior samples of each parameter are also returned, for each MCMC chain.  This may be returned in addition to the posterior samples themselves.  Default value is \code{FALSE}.  See details.
 #'
-#' @param WAIC Logical argument.  When \code{TRUE}, the WAIC (Watanabe, 2010) of the model is calculated and returned.  If multiple chains are run, then WAIC is calculated separately for each chain.  Default value is \code{FALSE}.  See details.
+#' @param WAIC Logical argument.  When \code{TRUE}, the WAIC (Watanabe, 2010) of the model is calculated and returned.  If multiple chains are run, then a combined WAIC is calculated using the output from all chains.  Default value is \code{FALSE}.  See details.
 #'
-#' @return A list is returned with named elements depending on the arguments passed to \code{nimbleMCMC}, unless only one among samples, summary, and WAIC are requested, in which case only that element is returned.  These elements may include \code{samples}, \code{summary}, and \code{WAIC}.  When \code{nchains = 1}, posterior samples are returned as a single matrix, and summary statistics as a single matrix.  When \code{nchains > 1}, posterior samples are returned as a list of matrices, one matrix for each chain, and summary statistics are returned as a list containing \code{nchains+1} matrices: one matrix corresponding to each chain, and the final element providing a summary of all chains, combined.  If \code{samplesAsCodaMCMC} is \code{TRUE}, then posterior samples are provided as \code{coda} \code{mcmc} and \code{mcmc.list} objects.  When \code{WAIC} is \code{TRUE}, WAIC values are returned as a numeric vector with one element corresponding to each chain.
+#' @return A list is returned with named elements depending on the arguments passed to \code{nimbleMCMC}, unless only one among samples, summary, and WAIC are requested, in which case only that element is returned.  These elements may include \code{samples}, \code{summary}, and \code{WAIC}.  When \code{nchains = 1}, posterior samples are returned as a single matrix, and summary statistics as a single matrix.  When \code{nchains > 1}, posterior samples are returned as a list of matrices, one matrix for each chain, and summary statistics are returned as a list containing \code{nchains+1} matrices: one matrix corresponding to each chain, and the final element providing a summary of all chains, combined.  If \code{samplesAsCodaMCMC} is \code{TRUE}, then posterior samples are provided as \code{coda} \code{mcmc} and \code{mcmc.list} objects.  When \code{WAIC} is \code{TRUE}, the WAIC value is returned.
 #'
 #' @details
 #'
-#' At least one of \code{samples}, \code{summary} or \code{WAIC} must be \code{TRUE}, since otherwise, nothing will be returned.  Any combination of these may be \code{TRUE}, including possibly all three, in which case posterior samples, summary statistics, and WAIC values are returned for each MCMC chain.
+#' At least one of \code{samples}, \code{summary} or \code{WAIC} must be \code{TRUE}, since otherwise, nothing will be returned.  Any combination of these may be \code{TRUE}, including possibly all three, in which case posterior samples and summary statistics are returned for each MCMC chain, and an overall WAIC value is calculated.
 #'
 #' When \code{samples = TRUE}, the form of the posterior samples is determined by the \code{samplesAsCodaMCMC} argument, as either matrices of posterior samples, or \code{coda} \code{mcmc} and \code{mcmc.list} objects.
 #'
@@ -108,10 +108,10 @@ runMCMC <- function(mcmc,
     if(!is.model(model)) stop('something went wrong')
     samplesList <- vector('list', nchains)
     names(samplesList) <- paste0('chain', 1:nchains)
-    if(WAIC) {
-        WAICvalues <- numeric(nchains)
-        if(nchains > 1) names(WAICvalues) <- paste0('chain', 1:nchains)
-    }
+    # if(WAIC) {
+    #     WAICvalues <- numeric(nchains)
+    #     if(nchains > 1) names(WAICvalues) <- paste0('chain', 1:nchains)
+    # }
     for(i in 1:nchains) {
         if(nimbleOptions('verbose')) message('running chain ', i, '...')
         if(setSeed) set.seed(i)
@@ -128,7 +128,16 @@ runMCMC <- function(mcmc,
         samplesMatrix <- as.matrix(mcmc$mvSamples)
         if(nburnin > 0) samplesMatrix <- samplesMatrix[-(1:nburnin), , drop = FALSE]
         samplesList[[i]] <- samplesMatrix
-        if(WAIC) WAICvalues[i] <- mcmc$calculateWAIC(nburnin = nburnin)
+    }
+    if(WAIC){
+      if(nchains > 1){
+        WAICcalcFunc <- calculateWAICfomSamplesList(mcmc$Robject$model, samplesList)
+        cWAICcalcFunc <- compileNimble(WAICcalcFunc, project = model)
+        WAICvalue <- cWAICcalcFunc$run()
+      }
+      else{
+        WAICvalue <- mcmc$calculateWAIC()
+      }
     }
     if(samplesAsCodaMCMC) samplesList <- coda::as.mcmc.list(lapply(samplesList, as.mcmc))
     if(nchains == 1) samplesList <- samplesList[[1]]  ## returns matrix when nchains = 1
@@ -144,7 +153,7 @@ runMCMC <- function(mcmc,
     retList <- list()
     if(samples) retList$samples <- samplesList
     if(summary) retList$summary <- summaryObject
-    if(WAIC)    retList$WAIC    <- WAICvalues
+    if(WAIC)    retList$WAIC    <- WAICvalue
     if(samples + summary + WAIC == 1) retList <- retList[[1]]
     return(retList)
 }
@@ -152,7 +161,7 @@ runMCMC <- function(mcmc,
 
 #' Executes one or more chains of NIMBLE's default MCMC algorithm, for a model specified using BUGS code
 #'
-#' \code{nimbleMCMC} is designed as the most straight forward entry point to using NIMBLE's default MCMC algorithm.  It provides capability for running multiple MCMC chains, specifying the number of MCMC iterations, thinning, and burn-in, and which model variables should be monitored.  It also provides options to return the posterior samples, to return summary statistics calculated from the posterior samples, and to return the WAIC value calculated from each chain.
+#' \code{nimbleMCMC} is designed as the most straight forward entry point to using NIMBLE's default MCMC algorithm.  It provides capability for running multiple MCMC chains, specifying the number of MCMC iterations, thinning, and burn-in, and which model variables should be monitored.  It also provides options to return the posterior samples, to return summary statistics calculated from the posterior samples, and to return a WAIC value.
 #'
 #' The entry point for this function is providing the \code{code}, \code{constants}, \code{data} and \code{inits} arguments, to create a new NIMBLE model object, or alternatively providing an exisiting NIMBLE model object as the \code{model} argument.
 #'
@@ -188,9 +197,9 @@ runMCMC <- function(mcmc,
 #' 
 #' @param summary Logical argument.  When \code{TRUE}, summary statistics for the posterior samples of each parameter are also returned, for each MCMC chain.  This may be returned in addition to the posterior samples themselves.  Default value is \code{FALSE}.  See details.
 #'
-#' @param WAIC Logical argument.  When \code{TRUE}, the WAIC (Watanabe, 2010) of the model is calculated and returned.  If multiple chains are run, then WAIC is calculated separately for each chain.  Default value is \code{FALSE}.  See details.
+#' @param WAIC Logical argument.  When \code{TRUE}, the WAIC (Watanabe, 2010) of the model is calculated and returned.  If multiple chains are run, then a combined WAIC is calculated using the output from all chains.  Default value is \code{FALSE}.  See details.
 #'
-#' @return A list is returned with named elements depending on the arguments passed to \code{nimbleMCMC}, unless only one among samples, summary, and WAIC are requested, in which case only that element is returned.  These elements may include \code{samples}, \code{summary}, and \code{WAIC}.  When \code{nchains = 1}, posterior samples are returned as a single matrix, and summary statistics as a single matrix.  When \code{nchains > 1}, posterior samples are returned as a list of matrices, one matrix for each chain, and summary statistics are returned as a list containing \code{nchains+1} matrices: one matrix corresponding to each chain, and the final element providing a summary of all chains, combined.  If \code{samplesAsCodaMCMC} is \code{TRUE}, then posterior samples are provided as \code{coda} \code{mcmc} and \code{mcmc.list} objects.  When \code{WAIC} is \code{TRUE}, WAIC values are returned as a numeric vector with one element corresponding to each chain.
+#' @return A list is returned with named elements depending on the arguments passed to \code{nimbleMCMC}, unless only one among samples, summary, and WAIC are requested, in which case only that element is returned.  These elements may include \code{samples}, \code{summary}, and \code{WAIC}.  When \code{nchains = 1}, posterior samples are returned as a single matrix, and summary statistics as a single matrix.  When \code{nchains > 1}, posterior samples are returned as a list of matrices, one matrix for each chain, and summary statistics are returned as a list containing \code{nchains+1} matrices: one matrix corresponding to each chain, and the final element providing a summary of all chains, combined.  If \code{samplesAsCodaMCMC} is \code{TRUE}, then posterior samples are provided as \code{coda} \code{mcmc} and \code{mcmc.list} objects.  When \code{WAIC} is \code{TRUE}, the WAIC value is returned.
 #'
 #' @details
 #'
@@ -275,3 +284,58 @@ nimbleMCMC <- function(code, constants = list(), data = list(), inits, model,
 }
 
 
+
+## Below function calculates WAIC in the case that 
+## runMCMC was called, with WAIC = TRUE, and nchains > 1.
+## Uses a list of matrices of posterior samples to calculate WAIC,
+## as opposed to the modelValues object used in the buildMCMC()
+## version.
+calculateWAICfomSamplesList <- nimbleFunction(
+  setup = function(model, samplesList){
+    samplesPerChain <- dim(samplesList[[1]])[1]
+    posteriorSamplesMatrix <- matrix(0, nrow = samplesPerChain*length(samplesList), ncol = dim(samplesList[[1]])[2])
+    for(i in seq_along(samplesList)){
+      posteriorSamplesMatrix[((i-1)*samplesPerChain + 1):(i*samplesPerChain),] <- samplesList[[i]][,]
+    }
+    dataNodes <- model$getNodeNames(dataOnly = TRUE)
+    dataNodeLength <- length(dataNodes)
+    sampledNodes <- model$getVarNames(FALSE, colnames(samplesList[[1]]))
+    paramDeps <- model$getDependencies(sampledNodes, self = FALSE)
+    totalMCMCSamples <- dim(posteriorSamplesMatrix)[1]
+  },
+  run = function(nburnin = integer(default = 0), burnIn = integer(default = 0)) {
+    if(burnIn != 0) {
+      print("Warning, `burnIn` argument is deprecated and will not be supported in future versions of NIMBLE. Please use the `nburnin` argument instead.")
+      if(nburnin == 0) {  ## if nburnin has not been changed from default, we replace with `burnIn` value here.
+        nburnin <- burnIn
+      }
+    }
+    if((totalMCMCSamples) < 2) {
+      print('Error, need more than one post burn-in MCMC samples')
+      return(-Inf)
+    }
+    logPredProbs <- matrix(nrow = totalMCMCSamples, ncol = dataNodeLength)
+    logAvgProb <- 0
+    pWAIC <- 0
+    currentVals <- values(model, sampledNodes)
+    for(i in 1:totalMCMCSamples) {
+      values(model, sampledNodes) <<- posteriorSamplesMatrix[i,]
+      model$simulate(paramDeps)
+      model$calculate(dataNodes)
+      for(j in 1:dataNodeLength) {
+        logPredProbs[i,j] <- model$getLogProb(dataNodes[j])
+      }
+    }
+    for(j in 1:dataNodeLength) {
+      maxLogPred <- max(logPredProbs[,j])
+      thisDataLogAvgProb <- maxLogPred + log(mean(exp(logPredProbs[,j] - maxLogPred)))
+      logAvgProb <- logAvgProb + thisDataLogAvgProb
+      pointLogPredVar <- var(logPredProbs[,j])
+      pWAIC <- pWAIC + pointLogPredVar
+    }
+    WAIC <- -2*(logAvgProb - pWAIC)
+    values(model, sampledNodes) <<- currentVals
+    model$calculate(paramDeps)
+    returnType(double())
+    return(WAIC)
+  })

--- a/packages/nimble/R/MCMC_run.R
+++ b/packages/nimble/R/MCMC_run.R
@@ -125,17 +125,17 @@ runMCMC <- function(mcmc,
         if(nburnin > 0) samplesMatrix <- samplesMatrix[-(1:nburnin), , drop = FALSE]
         samplesList[[i]] <- samplesMatrix
     }
-    if(WAIC){
-      if(nchains > 1){
-        samplesPerChain <- dim(samplesList[[1]])[1]
-        posteriorSamplesMatrix <- matrix(0, nrow = samplesPerChain*nchains, ncol = dim(samplesList[[1]])[2])
-        for(i in seq_along(samplesList)){
-          posteriorSamplesMatrix[((i-1)*samplesPerChain + 1):(i*samplesPerChain),] <- samplesList[[i]][,]
+    if(WAIC) {
+        if(nchains > 1) {
+            samplesPerChain <- dim(samplesList[[1]])[1]
+            posteriorSamplesMatrix <- matrix(0, nrow = samplesPerChain*nchains, ncol = dim(samplesList[[1]])[2])
+            for(i in seq_along(samplesList)) {
+                posteriorSamplesMatrix[((i-1)*samplesPerChain + 1):(i*samplesPerChain),] <- samplesList[[i]][,]
+            }
+            colnames(posteriorSamplesMatrix) <- colnames(samplesList[[1]])
+            matrix2mv(posteriorSamplesMatrix, mcmc$mvSamples)  ## transfer all posterior samples into mcmc$mvSamples
         }
-        colnames(posteriorSamplesMatrix) <- colnames(samplesList[[1]])
-        matrix2mv(posteriorSamplesMatrix, mcmc$mvSamples)  ## transfer all posterior samples into mcmc$mvSamples
-      }
-      WAICvalue <- mcmc$calculateWAIC()
+        WAICvalue <- mcmc$calculateWAIC()
     }
     if(samplesAsCodaMCMC) samplesList <- coda::as.mcmc.list(lapply(samplesList, as.mcmc))
     if(nchains == 1) samplesList <- samplesList[[1]]  ## returns matrix when nchains = 1
@@ -280,3 +280,5 @@ nimbleMCMC <- function(code, constants = list(), data = list(), inits, model,
             setSeed = setSeed, progressBar = progressBar, samples = samples,
             samplesAsCodaMCMC = samplesAsCodaMCMC, summary = summary, WAIC = WAIC)
 }
+
+

--- a/packages/nimble/R/MCMC_run.R
+++ b/packages/nimble/R/MCMC_run.R
@@ -134,7 +134,6 @@ runMCMC <- function(mcmc,
         }
         colnames(posteriorSamplesMatrix) <- colnames(samplesList[[1]])
         matrix2mv(posteriorSamplesMatrix, mcmc$mvSamples)  ## transfer all posterior samples into mcmc$mvSamples
-        mcmc$calculateWAIC()
       }
       WAICvalue <- mcmc$calculateWAIC()
     }

--- a/packages/nimble/R/types_util.R
+++ b/packages/nimble/R/types_util.R
@@ -219,7 +219,7 @@ modelValuesElement2Matrix <- function(mv, varName){
 Cmatrix2mvOneVar <- function(mat, mv, varName, k){
 	ptr <- mv$componentExtptrs[[varName]]
 	if(inherits(ptr, 'externalptr')) {
-            eval(call('.Call', mv$dll$matrix2VecNimArr, ptr, mat, rowStart = as.integer(1), rowEnd = k ))
+            eval(call('.Call', nimbleUserNamespace$sessionSpecificDll$matrix2VecNimArr, ptr, mat, rowStart = as.integer(1), rowEnd = k ))
         } else
             stop('varName not found in modelValues')
 }

--- a/packages/nimble/inst/tests/test-crossVal.R
+++ b/packages/nimble/inst/tests/test-crossVal.R
@@ -12,7 +12,7 @@ nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
 nimbleProgressBarSetting <- nimbleOptions('MCMCprogressBar')
-nimbleOptions(MCMCprogressBar = FALSE)
+nimbleOptions(MCMCprogressBar = TRUE) ## try to prevent timeout on Travis due to lack of output
 
 test_that("voter model cross-validation is accurate: ", {
   y <- c(44.6, 57.76, 49.91, 61.34, 49.60, 61.79, 48.95, 44.70, 59.17, 53.94,


### PR DESCRIPTION
This PR changes runMCMC() to return a single WAIC value, even if multiple chains have been run.  This is accomplished by a new, non-user facing function named `calculateWAICfomSamplesList`, which calculates the WAIC given a list of posterior samples, where each list element is a matrix of posterior samples from a single MCMC chain.