### PR TITLE
remove ^M carriage returns from Windows in 4 .cpp files.

### DIFF
--- a/packages/nimble/inst/CppCode/dists.cpp
+++ b/packages/nimble/inst/CppCode/dists.cpp
@@ -2366,4 +2366,3 @@ void rcar_proper(double* ans, double* mu, double* C, double* adj, double* num, d
   delete [] Qchol;
 }
 
-

--- a/packages/nimble/inst/CppCode/nimbleGraph.cpp
+++ b/packages/nimble/inst/CppCode/nimbleGraph.cpp
@@ -450,7 +450,3 @@ void nimbleGraph::getDependenciesOneNode(vector<int> &deps, int CgraphID, bool d
   PRINTF("      Done iterating through %i children of node %i\n", numChildren, CgraphID);
 #endif
 }
-
-
-
-


### PR DESCRIPTION
This fixes warnings from `R CMD check --as-cran` about CR or CRLF in lines of 4 of the .cpp files.