### PR TITLE
Get bounds rename

### DIFF
--- a/packages/nimble/R/BUGS_BUGSdecl.R
+++ b/packages/nimble/R/BUGS_BUGSdecl.R
@@ -553,35 +553,35 @@ BUGSdeclClass$methods(
                 if(truncated) {  # check for user-provided constant bounds inconsistent with distribution range
                     distName <- as.character(RHSreplaced[[1]])
                     distRange <- getDistributionInfo(distName)$range
-                    if(is.numeric(boundExprs$lower) &&
+                    if(is.numeric(boundExprs$lower_) &&
                        is.numeric(distRange$lower) &&
-                       is.numeric(boundExprs$upper) &&
+                       is.numeric(boundExprs$upper_) &&
                        is.numeric(distRange$upper) &&
-                       boundExprs$lower <= distRange$lower &&
-                       boundExprs$upper >= distRange$upper)  # user specified bounds irrelevant
+                       boundExprs$lower_ <= distRange$lower &&
+                       boundExprs$upper_ >= distRange$upper)  # user specified bounds irrelevant
                         truncated <<- FALSE
                     
-                    if(is.numeric(boundExprs$lower) &&
-                       is.numeric(boundExprs$upper) &&
-                       boundExprs$lower >= boundExprs$upper)
+                    if(is.numeric(boundExprs$lower_) &&
+                       is.numeric(boundExprs$upper_) &&
+                       boundExprs$lower_ >= boundExprs$upper_)
                         warning(paste0("Lower bound is greater than or equal to upper bound in ",
                                        deparse(codeReplaced),
                                        "; proceeding anyway, but this is likely to cause numerical issues."))
-                    if(is.numeric(boundExprs$lower) &&
+                    if(is.numeric(boundExprs$lower_) &&
                        is.numeric(distRange$lower) &&
-                       boundExprs$lower < distRange$lower) {
+                       boundExprs$lower_ < distRange$lower) {
                         warning(paste0("Lower bound is less than or equal to distribution lower bound in ",
                                        deparse(codeReplaced), "; ignoring user-provided lower bound."))
-                        boundExprs$lower <<- distRange$lower
+                        boundExprs$lower_ <<- distRange$lower
                         codeReplaced[[3]]['lower_'] <<- distRange$lower
                     }
-                    if(is.numeric(boundExprs$upper) &&
+                    if(is.numeric(boundExprs$upper_) &&
                        is.numeric(distRange$upper) &&
-                       boundExprs$upper > distRange$upper) {
+                       boundExprs$upper_ > distRange$upper) {
                         warning(paste0("Upper bound is greater than or equal to distribution upper bound in ",
                                        deparse(codeReplaced),
                                        "; ignoring user-provided upper bound."))
-                        boundExprs$upper <<- distRange$upper
+                        boundExprs$upper_ <<- distRange$upper
                         codeReplaced[[3]]['upper_'] <<- distRange$upper
                     }
                 }

--- a/packages/nimble/R/BUGS_BUGSdecl.R
+++ b/packages/nimble/R/BUGS_BUGSdecl.R
@@ -548,7 +548,7 @@ BUGSdeclClass$methods(
         if(type == 'stoch') {
             RHSreplaced <- codeReplaced[[3]]
             if(length(RHSreplaced) > 1) { ## It actually has argument(s)
-                boundNames <- c('lower', 'upper')
+                boundNames <- c('lower_', 'upper_')
                 boundExprs <<- as.list(RHSreplaced[boundNames])
                 if(truncated) {  # check for user-provided constant bounds inconsistent with distribution range
                     distName <- as.character(RHSreplaced[[1]])
@@ -573,7 +573,7 @@ BUGSdeclClass$methods(
                         warning(paste0("Lower bound is less than or equal to distribution lower bound in ",
                                        deparse(codeReplaced), "; ignoring user-provided lower bound."))
                         boundExprs$lower <<- distRange$lower
-                        codeReplaced[[3]]['lower'] <<- distRange$lower
+                        codeReplaced[[3]]['lower_'] <<- distRange$lower
                     }
                     if(is.numeric(boundExprs$upper) &&
                        is.numeric(distRange$upper) &&
@@ -582,7 +582,7 @@ BUGSdeclClass$methods(
                                        deparse(codeReplaced),
                                        "; ignoring user-provided upper bound."))
                         boundExprs$upper <<- distRange$upper
-                        codeReplaced[[3]]['upper'] <<- distRange$upper
+                        codeReplaced[[3]]['upper_'] <<- distRange$upper
                     }
                 }
                 if(!truncated) {

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -772,6 +772,7 @@ modelDefClass$methods(reparameterizeDists = function() {
           
                                         # insert altParams and bounds into code
         }
+        names(boundExprs)[names(boundExprs) %in% c('lower', 'upper')] <- paste0(names(boundExprs)[names(boundExprs) %in% c('lower', 'upper')], '_')
         newValueExpr <- as.call(c(as.list(newValueExpr), nonReqdArgExprs, boundExprs))
         newCode <- BUGSdecl$code
         newCode[[3]] <- newValueExpr
@@ -939,7 +940,7 @@ modelDefClass$methods(liftExpressionArgs = function() {
             params <- as.list(valueExpr[-1])   ## extract the original distribution parameters
             
             for(iParam in seq_along(params)) {
-                if(grepl('^\\.', names(params)[iParam]) || names(params)[iParam] %in% c('lower', 'upper'))   next        ## skips '.param' names, 'lower', and 'upper'; we do NOT lift these
+                if(grepl('^\\.', names(params)[iParam]) || names(params)[iParam] %in% c('lower_', 'upper_'))   next        ## skips '.param' names, 'lower', and 'upper'; we do NOT lift these
                 paramExpr <- params[[iParam]]
                 if(!isExprLiftable(paramExpr))    next     ## if this param isn't an expression, go ahead to next parameter
                 requireNewAndUniqueDecl <- any(contexts[[BUGSdecl$contextID]]$indexVarNames %in% all.vars(paramExpr))

--- a/packages/nimble/R/distributions_processInputList.R
+++ b/packages/nimble/R/distributions_processInputList.R
@@ -199,7 +199,9 @@ distClass <- setRefClass(
         },
         
         init_types_makeArgList = function(typeArgCharVector) {
-            parsedArgList <- lapply(typeArgCharVector, function(x) parse(text=x)[[1]])
+            parsedArgList <- try(lapply(typeArgCharVector, function(x) parse(text=x)[[1]]))
+            if(is(parsedArgList, 'try-error'))
+                stop("init_types_makeArgList: problem with arguments ", paste(typeArgCharVector, collapse = ","), ". Perhaps you didn't define types for your user-defined distribution nimbleFunctions?")
             allNames <- unlist(lapply(parsedArgList, function(pa) as.character(pa[[2]])))
             declExprs <- lapply(parsedArgList, function(pa) pa[[3]])
             allTypes <- unlist(lapply(parsedArgList, function(pa) as.character(pa[[3]][[1]])))

--- a/packages/nimble/R/nimbleFunction_nodeFunction.R
+++ b/packages/nimble/R/nimbleFunction_nodeFunction.R
@@ -30,7 +30,7 @@ ndf_createStochSimulate <- function(LHS, RHS, dynamicIndexLimitsExpr, RHSnonRepl
     RHS[[1]] <- as.name(getDistributionInfo(BUGSdistName)$simulateName)   # does the appropriate substituion of the distribution name
     if(length(RHS) > 1) {    for(i in (length(RHS)+1):3)   { RHS[i] <- RHS[i-1];     names(RHS)[i] <- names(RHS)[i-1] } }    # scoots all named arguments right 1 position
     RHS[[2]] <- 1;     names(RHS)[2] <- ''    # adds the first (unnamed) argument '1'    
-    if("lower" %in% names(RHS) || "upper" %in% names(RHS)) {
+    if("lower_" %in% names(RHS) || "upper_" %in% names(RHS)) {
         RHS <- ndf_createStochSimulateTrunc(RHS, discrete = getAllDistributionsInfo('discrete')[BUGSdistName])
     } 
     if(nimbleOptions()$allowDynamicIndexing && !is.null(dynamicIndexLimitsExpr)) {
@@ -49,11 +49,11 @@ ndf_createStochSimulate <- function(LHS, RHS, dynamicIndexLimitsExpr, RHSnonRepl
 }
 
 
-## changes 'rnorm(mean=1, sd=2, lower=0, upper=3)' into correct truncated simulation
+## changes 'rnorm(mean=1, sd=2, lower_=0, upper_=3)' into correct truncated simulation
 ##   using inverse CDF
 ndf_createStochSimulateTrunc <- function(RHS, discrete = FALSE) {
-    lowerPosn <- which("lower" == names(RHS))
-    upperPosn <- which("upper" == names(RHS))
+    lowerPosn <- which("lower_" == names(RHS))
+    upperPosn <- which("upper_" == names(RHS))
     lower <- RHS[[lowerPosn]]
     upper <- RHS[[upperPosn]]
     RHS <- RHS[-c(lowerPosn, upperPosn)]
@@ -121,7 +121,7 @@ ndf_createStochCalculate <- function(logProbNodeExpr, LHS, RHS, diff = FALSE, AD
     RHS[[1]] <- as.name(getDistributionInfo(BUGSdistName)$densityName)   # does the appropriate substituion of the distribution name
     if(length(RHS) > 1) {    for(i in (length(RHS)+1):3)   { RHS[i] <- RHS[i-1];     names(RHS)[i] <- names(RHS)[i-1] } }    # scoots all named arguments right 1 position
     RHS[[2]] <- LHS;     names(RHS)[2] <- ''    # adds the first (unnamed) argument LHS
-    if("lower" %in% names(RHS) || "upper" %in% names(RHS)) {
+    if("lower_" %in% names(RHS) || "upper_" %in% names(RHS)) {
         return(ndf_createStochCalculateTrunc(logProbNodeExpr, LHS, RHS, diff = diff, discrete = getAllDistributionsInfo('discrete')[BUGSdistName], dynamicIndexLimitsExpr = dynamicIndexLimitsExpr, RHSnonReplaced = RHSnonReplaced))
     } else {
         userDist <- BUGSdistName %in% getAllDistributionsInfo('namesVector', userOnly = TRUE)
@@ -170,8 +170,8 @@ ndf_createStochCalculate <- function(logProbNodeExpr, LHS, RHS, diff = FALSE, AD
 
 ## changes 'dnorm(mean=1, sd=2, lower=0, upper=3)' into correct truncated calculation
 ndf_createStochCalculateTrunc <- function(logProbNodeExpr, LHS, RHS, diff = FALSE, discrete = FALSE, dynamicIndexLimitsExpr, RHSnonReplaced) {
-    lowerPosn <- which("lower" == names(RHS))
-    upperPosn <- which("upper" == names(RHS))
+    lowerPosn <- which("lower_" == names(RHS))
+    upperPosn <- which("upper_" == names(RHS))
     lower <- RHS[[lowerPosn]]
     upper <- RHS[[upperPosn]]
     RHS <- RHS[-c(lowerPosn, upperPosn)]

--- a/packages/nimble/R/nimbleFunction_nodeFunctionNew.R
+++ b/packages/nimble/R/nimbleFunction_nodeFunctionNew.R
@@ -180,7 +180,7 @@ nndf_createMethodList <- function(LHS, RHS, parentsSizeAndDims, altParams, bound
             methodList[['get_value']] <- ndf_generateGetParamFunction(LHS, type, nDim)
             ## add accessor functions for stochastic node distribution parameters
             for(param in names(RHS[-1])) {
-                if(!param %in% c("lower", "upper")) {
+                if(!param %in% c("lower_", "upper_")) {
                     type = getType(distName, param)
                     nDim <- getDimension(distName, param)
                     methodList[[paste0('get_',param)]] <- ndf_generateGetParamFunction(RHS[[param]], type, nDim)

--- a/packages/nimble/inst/tests/test-user.R
+++ b/packages/nimble/inst/tests/test-user.R
@@ -299,6 +299,13 @@ test_that("Test that user-defined distributions with 'lower' and 'upper' params 
             return(1) else return(0)
         returnType(double())
     })
+    rmyunif <- nimbleFunction(
+        run = function(n = double(0), lower = double(0), upper = double(0)) {
+            return(0)
+            returnType(double(0))
+        })
+    temporarilyAssignInGlobalEnv(dmyunif)
+    temporarilyAssignInGlobalEnv(rmyunif)
 
     code = nimbleCode({
         y ~ dmyunif(lower = 3, upper = 7)

--- a/packages/nimble/inst/tests/test-user.R
+++ b/packages/nimble/inst/tests/test-user.R
@@ -291,6 +291,28 @@ test_that("Test that truncation works with nodeFunctions and MCMC for user-suppl
     expect_lt(max(smp[ , 'lambda']), (upper))
 })
 
+
+test_that("Test that user-defined distributions with 'lower' and 'upper' params don't cause problems", {
+    dmyunif <- nimbleFunction(
+    run = function(x = double(0), lower = double(0), upper = double(0), log = integer(0, default = 0)) {
+        if(x > lower & x < upper)
+            return(1) else return(0)
+        returnType(double())
+    })
+
+    code = nimbleCode({
+        y ~ dmyunif(lower = 3, upper = 7)
+    })
+    m <- nimbleModel(code, inits = list(y=4))
+    cm <- compileNimble(m)
+    expect_equal(m$getParam('y','lower'), 3)
+    expect_equal(cm$getParam('y','lower'), 3)
+    expect_equal(m$getBound('y','lower'), -Inf)
+    expect_equal(cm$getBound('y','lower'), -Inf)
+})
+
+
+
 test_that("Test that deregistration of user-supplied distributions works", {
     deregisterDistributions('ddirchmulti')
     expect_true(is.null(nimble:::nimbleUserNamespace$distributions[['ddirchmulti']]),


### PR DESCRIPTION
For review/travis testing only as devel still frozen. 

This addresses issue #639 by changing to {lower,upper}_ when we add these to the declInfo code.