### PR TITLE
Fix WAIC bug in getting dependencies of logProb variables 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ cache:
 # We parallelize the tests into baches, and run only one batch on OS X.
 matrix:
   include:
+    - os: osx
+      env: NIMBLE_TEST_BATCH=1 NIMBLE_USE_TENSORFLOW=0
     - os: linux
       env: NIMBLE_TEST_BATCH=1
     - os: linux
@@ -21,8 +23,6 @@ matrix:
       env: NIMBLE_TEST_BATCH=4
     - os: linux
       env: NIMBLE_TEST_BATCH=5
-    - os: osx
-      env: NIMBLE_TEST_BATCH=1 NIMBLE_USE_TENSORFLOW=0
 
 warnings_are_errors: true
 
@@ -46,16 +46,16 @@ addons:
       - python-virtualenv  # For tensorflow::install_tensorflow().
 
 install:
-  - pip2.7 install --upgrade --ignore-installed --user travis pip2 setuptools wheel virtualenv
+  - pip2.7 install --upgrade --ignore-installed --user travis pip setuptools wheel virtualenv
   - ./install_requirements.R
-  - pip2 freeze
+  - pip2.7 freeze
   - R CMD build packages/nimble
   - R CMD INSTALL packages/nimble
 
 script:
   - source /home/travis/.virtualenvs/r-tensorflow/bin/activate \
     || echo 'Missing tensorflow'
-  - pip2 freeze
+  - pip2.7 freeze
   - ./run_tests.R
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,14 +49,14 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir $HOME/bin; ln -s $(which pip2) $HOME/bin/pip; fi
   - pip install --upgrade --force-reinstall --user travis pip setuptools wheel virtualenv
   - ./install_requirements.R
-  - pip freeze
+  # - pip freeze
   - R CMD build packages/nimble
   - R CMD INSTALL packages/nimble
 
 script:
   - source /home/travis/.virtualenvs/r-tensorflow/bin/activate \
     || echo 'Missing tensorflow'
-  - pip freeze
+  # - pip freeze
   - ./run_tests.R
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,16 +46,17 @@ addons:
       - python-virtualenv  # For tensorflow::install_tensorflow().
 
 install:
-  - pip2.7 install --upgrade --ignore-installed --user travis pip setuptools wheel virtualenv
++  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir $HOME/bin; ln -s $(which pip2) $HOME/bin/pip; fi
+  - pip install --upgrade --ignore-installed --user travis pip setuptools wheel virtualenv
   - ./install_requirements.R
-  - pip2.7 freeze
+  - pip freeze
   - R CMD build packages/nimble
   - R CMD INSTALL packages/nimble
 
 script:
   - source /home/travis/.virtualenvs/r-tensorflow/bin/activate \
     || echo 'Missing tensorflow'
-  - pip2.7 freeze
+  - pip freeze
   - ./run_tests.R
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ addons:
       - python-virtualenv  # For tensorflow::install_tensorflow().
 
 install:
-+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir $HOME/bin; ln -s $(which pip2) $HOME/bin/pip; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir $HOME/bin; ln -s $(which pip2) $HOME/bin/pip; fi
   - pip install --upgrade --ignore-installed --user travis pip setuptools wheel virtualenv
   - ./install_requirements.R
   - pip freeze

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ addons:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir $HOME/bin; ln -s $(which pip2) $HOME/bin/pip; fi
-  - pip install --upgrade --ignore-installed --user travis pip setuptools wheel virtualenv
+  - pip install --upgrade --force-reinstall --user travis pip setuptools wheel virtualenv
   - ./install_requirements.R
   - pip freeze
   - R CMD build packages/nimble

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,14 +48,14 @@ addons:
 install:
   - pip2.7 install --upgrade --ignore-installed --user travis pip setuptools wheel virtualenv
   - ./install_requirements.R
-  - pip freeze
+  - pip2 freeze
   - R CMD build packages/nimble
   - R CMD INSTALL packages/nimble
 
 script:
   - source /home/travis/.virtualenvs/r-tensorflow/bin/activate \
     || echo 'Missing tensorflow'
-  - pip freeze
+  - pip2 freeze
   - ./run_tests.R
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ addons:
       - python-virtualenv  # For tensorflow::install_tensorflow().
 
 install:
-  - pip2.7 install --upgrade --ignore-installed --user travis pip setuptools wheel virtualenv
+  - pip2.7 install --upgrade --ignore-installed --user travis pip2 setuptools wheel virtualenv
   - ./install_requirements.R
   - pip2 freeze
   - R CMD build packages/nimble

--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -92,7 +92,7 @@ buildMCMC <- nimbleFunction(
         ## WAIC setup below:
         dataNodes <- model$getNodeNames(dataOnly = TRUE)
         dataNodeLength <- length(dataNodes)
-        sampledNodes <- model$getVarNames(FALSE, colnames(as.matrix(mvSamples)))
+        sampledNodes <- model$getVarNames(FALSE, monitors)
         ## Remove any logProb variables from nodes used in WAIC calculation:
         sampledNodes <- sampledNodes[sampledNodes %in% model$getVarNames(FALSE)]
         paramDeps <- model$getDependencies(sampledNodes, self = FALSE)

--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -93,6 +93,8 @@ buildMCMC <- nimbleFunction(
         dataNodes <- model$getNodeNames(dataOnly = TRUE)
         dataNodeLength <- length(dataNodes)
         sampledNodes <- model$getVarNames(FALSE, colnames(as.matrix(mvSamples)))
+        ## Remove any logProb variables from nodes used in WAIC calculation:
+        sampledNodes <- sampledNodes[sampledNodes %in% model$getVarNames(FALSE)]
         paramDeps <- model$getDependencies(sampledNodes, self = FALSE)
     },
 

--- a/packages/nimble/inst/tests/mcmcTestLog_Correct.Rout
+++ b/packages/nimble/inst/tests/mcmcTestLog_Correct.Rout
@@ -2977,4 +2977,5 @@ sd      0.6607385   0.5216073    1.807713
 ===== Finished MCMC test for conjugate Wishart. =====
 ===== Starting MCMC test for conjugate MVN with ragged dependencies. ========== Starting MCMC test for binary sampler. ========== Starting MCMC test for binary sampler handles out of bounds. ========== Starting MCMC test for RW_multinomial sampler. ========== Starting MCMC test RW_multinomial sampler on distribution of size 2. ========== Starting MCMC test if RW_dirichlet sampler consistent with conjugate multinomial sampler. ========== Starting MCMC test RW_dirichlet sampler more complicated. =====thin = 1: alpha, theta, p1, p2
 ===== Starting MCMC test dcar_normal sampling. ========== Starting test dcar_proper density evaluations. ========== Starting MCMC test dcar_proper sampling. =====thin = 1: tau, gamma, x
+===== Starting MCMC test of logProb variable monitoring =====
 

--- a/packages/nimble/inst/tests/test-mcmc.R
+++ b/packages/nimble/inst/tests/test-mcmc.R
@@ -1356,6 +1356,30 @@ test_that('dnorm-dmnorm conjugacies NIMBLE fails to detect', {
          info = "EXPECTED FAILURE NOT FAILING: this known failure should occur because of limitations in conjugacy detection with dnorm dependents of dmnorm target")
 })
 
+
+test_that('MCMC with logProb variable being monitored builds and compiles.', {
+  cat('===== Starting MCMC test of logProb variable monitoring =====')
+  code <- nimbleCode({
+    prob[1] <- p
+    prob[2] <- 1-p
+    x[1:2] ~ dmultinom(size = N, prob = prob[1:2])
+    y      ~ dbinom(   size = N, prob = p)
+  })
+  set.seed(0)
+  N <- 100
+  p <- 0.3
+  x1 <- rbinom(1, size=N, prob=p)
+  x2 <- N - x1
+  inits <- list(N = N, p = p, x = c(x1, x2), y = x1)
+  Rmodel <- nimbleModel(code, constants=list(), data=list(), inits=inits)
+  Cmodel <- compileNimble(Rmodel)
+  conf <- configureMCMC(Rmodel, monitors = 'logProb_y')
+  Rmcmc  <- buildMCMC(conf)
+  Cmcmc <- compileNimble(Rmcmc, project = Rmodel)
+  Cmcmc$run(10)
+})
+
+
 sink(NULL)
 
 if(!generatingGoldFile) {


### PR DESCRIPTION
This PR fixes a bug where logProb variables could no longer be monitored in an MCMC algorithm due to a line of code added to allow WAIC calculations.  It additionally adds a test to test-MCMC that builds, compiles, and runs an MCMC algorithm for which a logProb variable is monitored.  