### PR TITLE
Add error message for recursively defined BUGS node and prevent R crash.

### DIFF
--- a/packages/nimble/NEWS
+++ b/packages/nimble/NEWS
@@ -1,4 +1,11 @@
-                           CHANGES IN VERSION 0.6-8 and 0.6-7 (November 2017)
+                           CHANGES IN VERSION 0.6-9 (January 2018)
+						   
+BUG FIXES
+
+-- Fixed a bug where calling nimbleModel() on a BUGS model with a node that was it's own parent caused R to crash.
+
+						   
+						   CHANGES IN VERSION 0.6-8 and 0.6-7 (November 2017)
 
 Note: versions 0.6-8 and 0.6-7 are the same except for a non-user-facing change to the withNimbleOptions function example to pass CRAN checks.
 

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -174,6 +174,7 @@ modelDefClass$methods(setupModel = function(code, constants, dimensions, userEnv
     addFullDimExtentToUnknownIndexDeclarations() ## update unknownIndex declarations with full extent of relevant parent variable; this splits parent variable and does edge determination (from parent variable to unknownIndex variable) but without splitting based on unknown indices
     genExpandedNodeAndParentNames3(debug = debug) ## heavy processing: all graphIDs, maps, graph, nodeNames etc. built here
     stripUnknownIndexInfo()               ## removes unknownIndex declarations and vars
+    checkForSelfParents()                 ## Checks to see if any nodes are their own parents, and errors out if so
     maps$setPositions3()                  ## Determine top, latent and end nodes
     buildSymbolTable()                    ## 
     genIsDataVarInfo()                    ## only the maxs is ever used, in newModel
@@ -2898,4 +2899,12 @@ detectDynamicIndexes <- function(expr) {
     if(length(expr) == 1 || expr[[1]] != "[") return(FALSE) # stop("whichDynamicIndices: 'expr' should be a bracket expression")
     return(sapply(expr[3:length(expr)], isDynamicIndex)) 
 }
+
+modelDefClass$methods(checkForSelfParents = function(){
+  for(i in seq_along(maps$edgesFrom)){
+    if(maps$edgesFrom[i] == maps$edgesTo[i]){
+      stop(paste("In building model, node", maps$graphID_2_nodeName[maps$edgesFrom[i]], "is recursively defined."), call. = FALSE)
+    }
+  }
+})
 

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -2903,7 +2903,7 @@ detectDynamicIndexes <- function(expr) {
 modelDefClass$methods(checkForSelfParents = function(){
   for(i in seq_along(maps$edgesFrom)){
     if(maps$edgesFrom[i] == maps$edgesTo[i]){
-      stop(paste("In building model, node", maps$graphID_2_nodeName[maps$edgesFrom[i]], "is recursively defined."), call. = FALSE)
+      stop(paste("In building model, node", maps$graphID_2_nodeName[maps$edgesFrom[i]], "is its own parent node."), call. = FALSE)
     }
   }
 })

--- a/packages/nimble/inst/CppCode/nimbleGraph.cpp
+++ b/packages/nimble/inst/CppCode/nimbleGraph.cpp
@@ -181,10 +181,6 @@ void nimbleGraph::setNodes(const vector<int> &edgesFrom, const vector<int> &edge
     graphNodeVec[iNode] = new graphNode(iNode, types[iNode], names[iNode]);
   }
   for(unsigned int iEdge = 0; iEdge < numEdges; iEdge++) {
-    if(edgesFrom[iEdge] == edgesTo[iEdge]){
-      PRINTF("Error in setNodes: node %i is recursively defined in model\n", edgesFrom[iEdge]+1);
-      return;
-    }
     graphNodeVec[ edgesFrom[iEdge]]->addChild( graphNodeVec[edgesTo[iEdge]], edgesFrom2ParentExprIDs[iEdge] );
   }
   for(unsigned int iNode = 0; iNode < numNodes; iNode++) {

--- a/packages/nimble/inst/CppCode/nimbleGraph.cpp
+++ b/packages/nimble/inst/CppCode/nimbleGraph.cpp
@@ -181,6 +181,10 @@ void nimbleGraph::setNodes(const vector<int> &edgesFrom, const vector<int> &edge
     graphNodeVec[iNode] = new graphNode(iNode, types[iNode], names[iNode]);
   }
   for(unsigned int iEdge = 0; iEdge < numEdges; iEdge++) {
+    if(edgesFrom[iEdge] == edgesTo[iEdge]){
+      PRINTF("Error in setNodes: node %i is recursively defined in model\n", edgesFrom[iEdge]+1);
+      return;
+    }
     graphNodeVec[ edgesFrom[iEdge]]->addChild( graphNodeVec[edgesTo[iEdge]], edgesFrom2ParentExprIDs[iEdge] );
   }
   for(unsigned int iNode = 0; iNode < numNodes; iNode++) {


### PR DESCRIPTION
This PR, which fixes #654,  adds an error message for BUGS models that have nodes which are their own parents, i.e., models for which there is a node with an edge that leads back to itself.  Previously, such nodes would cause a user's R session to crash after a call to `nimbleModel` due to an infinite recursion in the `nimbleGraph::anyStochDependenciesOneNode` C++ method.  

With this PR, such self-parented nodes will now be detected during the `modelDefClass$setupModel` method,  and model building will error out with a message of the form ` "Error: In building model, node aMatrix[1:4, 1] is its own parent node." ` will be printed.  