### PR TITLE
Make nimbleRcall work uncompiled by inserting new body after creating RCfunction

### DIFF
--- a/packages/nimble/R/externalCalls.R
+++ b/packages/nimble/R/externalCalls.R
@@ -224,4 +224,13 @@ nimbleRcall <- function(prototype, returnType, Rfun, envir = .GlobalEnv) {
     body(fun) <- as.call(allLines)
     ans <- quote(RCfunction(fun, check = FALSE))
     ans <- eval(ans)
+    ## By calling RCfunction, there is an nfMethodRC with the necessary body
+    ## for subsequent compiler processing.
+    ## Now we can replace the body of the R function with something that
+    ## will actually execute in R.
+    Rcall <- as.call(c(list(as.name(as.character(Rfun))),
+                       lapply(argNames, as.name)))
+    body(ans) <- substitute({ RCALL },
+                            list(RCALL = Rcall))
+    ans
 }

--- a/packages/nimble/inst/tests/test-externalCalls.R
+++ b/packages/nimble/inst/tests/test-externalCalls.R
@@ -81,12 +81,11 @@ void my_internal_function(double *p, double *ans, int n) {
     demoCode <- nimbleCode({
         for(i in 1:4) {x[i] ~ dnorm(0,1)} ## just to get a vector
         y[1:4] <- wrappedRadd1p5(x[1:4])
-        z[1:4] <- Radd2p5(x[1:4])
+        z[1:4] <- Radd2p5(x[1:4]) 
     })
-    
-    demoModel <- nimbleModel(demoCode, inits = list(x = rnorm(4)), check = FALSE, calculate = FALSE)
+    ## building model will test uncompiled execution.
+    demoModel <- nimbleModel(demoCode, inits = list(x = rnorm(4)), check = FALSE)
     ## Again ignore the error during checking.  We'll have to trap and handle that, but right now I'm focused on core functionality.
-    ## The model will not work uncompiled!
     
     CdemoModel <- compileNimble(demoModel, dirName = '.') ## last arg puts the C++ code in your working directory so you can look at it if you like
 


### PR DESCRIPTION
Fixed #658.

Previously a nimbleRcall would not actually execute in R (but it would compile, which was the main goal).  That wasn't good.

I fixed this by a bit of a trick.  The nimbleRcall involves construction of somewhat arcane RCfunction code for the compiler to handle.  That is the code that is not executable in R.  But after the RCfunction is created, including the nfMethodRC in its closure environment, it is ok to modify the body of the R function that was used as input.  So at the end of nimbleRcall, I change the body of the constructed function to a simple call to the desired R call.  Hence it executes in R.  This seems to work fine.  I updated test-externalCalls.R as well.
