### PR TITLE
addition of error trap when an index value is 0 or less

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -2556,6 +2556,15 @@ modelDefClass$methods(genVarInfo3 = function() {
         if(any(dimensionsList[[dimVarName]] < varInfo[[dimVarName]]$maxs))  stop(paste0('dimensions specified are smaller than model specification for variable \'', dimVarName, '\''))
         varInfo[[dimVarName]]$maxs <<- dimensionsList[[dimVarName]]
     }
+
+    ## check for mins or maxs zero or less (these trigger various errors including R crashes)
+    if(any(sapply(varInfo, function(x) min(x$mins)) < 1) ||
+       any(sapply(varInfo, function(x) min(x$maxs)) < 1)) {
+           problemVars <- c(which(sapply(varInfo, function(x) min(x$mins)) < 1),
+                         which(sapply(varInfo, function(x) min(x$maxs)) < 1))
+           stop("genVarInfo3: index value of zero or less found for model variable(s): ",
+                paste(names(varInfo)[problemVars], collapse = ' '))
+    }
 })
 
 modelDefClass$methods(addUnknownIndexVars = function(debug = FALSE) {

--- a/packages/nimble/inst/tests/test-models.R
+++ b/packages/nimble/inst/tests/test-models.R
@@ -399,6 +399,12 @@ test_that("test of the handling of missing covariates:", {
 
 })
 
+test_that("test of error trapping for indexes that are zero or less:", {
+    code <- nimbleCode( {
+        for(i in 1:n)
+            y[i] ~ dnorm(mu[n-i], 1)})
+    expect_error(m <- nimbleModel(code, constants = list(n=3)), 'index value of zero or less')
+})
 
 ## test of use of alias names for distributions
 


### PR DESCRIPTION
This is done by checking for values of 0 or less in varInfo$mins and varInfo$maxs at end of genVarInfo3.

Will merge once testing completes. 

This fixes issue #601 