### PR TITLE
added ability to save MCMC history

### DIFF
--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -142,7 +142,11 @@ sampler_RW <- nimbleFunction(
         timesRan      <- 0
         timesAccepted <- 0
         timesAdapted  <- 0
-        ##scaleHistory  <- c(0, 0)   ## scaleHistory
+        scaleHistory  <- c(0, 0)   ## scaleHistory
+        acceptanceHistory  <- c(0, 0)   ## scaleHistory
+        if(nimbleOptions('saveMCMChistory')) {
+            saveMCMChistory <- TRUE
+        } else saveMCMChistory <- FALSE
         optimalAR     <- 0.44
         gamma1        <- 0
         ## checks
@@ -178,8 +182,12 @@ sampler_RW <- nimbleFunction(
             if(timesRan %% adaptInterval == 0) {
                 acceptanceRate <- timesAccepted / timesRan
                 timesAdapted <<- timesAdapted + 1
-                ##setSize(scaleHistory, timesAdapted)         ## scaleHistory
-                ##scaleHistory[timesAdapted] <<- scale        ## scaleHistory
+                if(saveMCMChistory) {
+                    setSize(scaleHistory, timesAdapted)         ## scaleHistory
+                    scaleHistory[timesAdapted] <<- scale        ## scaleHistory
+                    setSize(acceptanceHistory, timesAdapted)         ## scaleHistory
+                    acceptanceHistory[timesAdapted] <<- acceptanceRate  ## scaleHistory
+                }   
                 gamma1 <<- 1/((timesAdapted + 3)^0.8)
                 gamma2 <- 10 * gamma1
                 adaptFactor <- exp(gamma2 * (acceptanceRate - optimalAR))
@@ -188,7 +196,24 @@ sampler_RW <- nimbleFunction(
                 timesAccepted <<- 0
             }
         },
-        ##getScaleHistory = function() { returnType(double(1)); return(scaleHistory) },          ## scaleHistory
+        getScaleHistory = function() {  ## scaleHistory
+            returnType(double(1))
+            if(saveMCMChistory) {
+                return(scaleHistory)
+            } else {
+                print("Please set 'nimbleOptions(saveMCMChistory = TRUE)' before building the MCMC")
+                return(numeric(1, 0))
+            }
+        },          
+        getAcceptanceHistory = function() {  ## scaleHistory
+            returnType(double(1))
+            if(saveMCMChistory) {
+                return(acceptanceHistory)
+            } else {
+                print("Please set 'nimbleOptions(saveMCMChistory = TRUE)' before building the MCMC")
+                return(numeric(1, 0))
+            }
+        },          
         ##getScaleHistoryExpanded = function() {                                                 ## scaleHistory
         ##    scaleHistoryExpanded <- numeric(timesAdapted*adaptInterval, init=FALSE)            ## scaleHistory
         ##    for(iTA in 1:timesAdapted)                                                         ## scaleHistory
@@ -200,7 +225,10 @@ sampler_RW <- nimbleFunction(
             timesRan      <<- 0
             timesAccepted <<- 0
             timesAdapted  <<- 0
-            ##scaleHistory  <<- scaleHistory * 0    ## scaleHistory
+            if(saveMCMChistory) {
+                scaleHistory  <<- c(0, 0)    ## scaleHistory
+                acceptanceHistory  <<- c(0, 0)
+            }
             gamma1 <<- 0
         }
     ), where = getLoadingNamespace()
@@ -233,7 +261,11 @@ sampler_RW_block <- nimbleFunction(
         timesAccepted <- 0
         timesAdapted  <- 0
         d <- length(targetAsScalar)
-        ##scaleHistory   <- c(0, 0)                       ## scaleHistory
+        scaleHistory  <- c(0, 0)   ## scaleHistory
+        acceptanceHistory  <- c(0, 0)   ## scaleHistory
+        if(nimbleOptions('saveMCMChistory')) {
+            saveMCMChistory <- TRUE
+        } else saveMCMChistory <- FALSE
         ##propCovHistory <- array(0, dim = c(2, d, d))    ## scaleHistory
         if(is.character(propCov) && propCov == 'identity')     propCov <- diag(d)
         propCovOriginal <- propCov
@@ -269,8 +301,12 @@ sampler_RW_block <- nimbleFunction(
             if(timesRan %% adaptInterval == 0) {
                 acceptanceRate <- timesAccepted / timesRan
                 timesAdapted <<- timesAdapted + 1
-                ##setSize(scaleHistory, timesAdapted)                                     ## scaleHistory
-                ##scaleHistory[timesAdapted] <<- scale                                    ## scaleHistory
+                if(saveMCMChistory) {
+                    setSize(scaleHistory, timesAdapted)         ## scaleHistory
+                    scaleHistory[timesAdapted] <<- scale        ## scaleHistory
+                    setSize(acceptanceHistory, timesAdapted)         ## scaleHistory
+                    acceptanceHistory[timesAdapted] <<- acceptanceRate  ## scaleHistory
+                }   
                 ##propCovTemp <- propCovHistory                                           ## scaleHistory
                 ##setSize(propCovHistory, timesAdapted, d, d)                             ## scaleHistory
                 ##if(timesAdapted > 1)                                                    ## scaleHistory
@@ -292,6 +328,24 @@ sampler_RW_block <- nimbleFunction(
                 timesAccepted <<- 0
             }
         },
+        getScaleHistory = function() {  ## scaleHistory
+            returnType(double(1))
+            if(saveMCMChistory) {
+                return(scaleHistory)
+            } else {
+                print("Please set 'nimbleOptions(saveMCMChistory = TRUE)' before building the MCMC")
+                return(numeric(1, 0))
+            }
+        },          
+        getAcceptanceHistory = function() {  ## scaleHistory
+            returnType(double(1))
+            if(saveMCMChistory) {
+                return(acceptanceHistory)
+            } else {
+                print("Please set 'nimbleOptions(saveMCMChistory = TRUE)' before building the MCMC")
+                return(numeric(1, 0))
+            }
+        },                  
         ##getScaleHistory   = function() { returnType(double(1)); return(scaleHistory)   },                   ## scaleHistory
         ##getPropCovHistory = function() { returnType(double(3)); return(propCovHistory) },                   ## scaleHistory
         ##getScaleHistoryExpanded = function() {                                                              ## scaleHistory
@@ -314,7 +368,10 @@ sampler_RW_block <- nimbleFunction(
             timesRan      <<- 0
             timesAccepted <<- 0
             timesAdapted  <<- 0
-            ##scaleHistory  <<- scaleHistory * 0                                       ## scaleHistory
+            if(saveMCMChistory) {
+                scaleHistory  <<- c(0, 0)    ## scaleHistory
+                acceptanceHistory  <<- c(0, 0)
+            }
             ##for(iTA in 1:dim(scaleHistory)[1])                                       ## scaleHistory
             ##    propCovHistory[iTA, 1:d, 1:d] <<- propCovHistory[1, 1:d, 1:d] * 0    ## scaleHistory
             my_calcAdaptationFactor$reset()

--- a/packages/nimble/R/options.R
+++ b/packages/nimble/R/options.R
@@ -56,6 +56,7 @@ nimbleUserNamespace <- as.environment(list(sessionSpecificDll = NULL))
         ## samplerAssignmentRules object that controls the default sampler assignments by configureMCMC.
         ## value is set to samplerAssignmentRules() (the defaults) in MCMC_configuration.R
         MCMCuseSamplerAssignmentRules = FALSE,
+        saveMCMChistory = FALSE,
         MCMCdefaultSamplerAssignmentRules = NULL
         
         ## default settings for MCMC samplers


### PR DESCRIPTION
This is hidden behind nimbleOptions(saveMCMChistory). When enabled (and with `nimbleOptions(buildInterfacesForCompiledNestedNimbleFunctions = TRUE)`), users can use 
code like `cmcmc$samplerFunctions[[3]]$getScaleHistory()` to get the vector of scales, and similarly for vector of acceptance rates.

Will merge when passes testing.

This fixes #436 .