### PR TITLE
Make model[['b']] work when b is a variable, not a node

### DIFF
--- a/UserManual/chapter_WritingNimbleFunctions.Rnw
+++ b/UserManual/chapter_WritingNimbleFunctions.Rnw
@@ -233,12 +233,13 @@ can only be indexed within a call to \cd{calculate}, \cd{calculateDiff},
 \subsubsection{Using indexing with nodes}
   
 
-Here is an example that illustrates getting and setting of nodes and subsets of nodes.  Note the following:
+Here is an example that illustrates getting and setting of nodes,
+subsets of nodes, or variables.  Note the following:
 
 \begin{itemize}
-  \item In \cd{model[[node]]}, \cd{node} can only be a single node name, not a vector of multiple nodes nor an element of such a vector (\cd{model[[ nodes[i] ]]} does not work).  The node itself may be a vector, matrix or array node.
-  \item In fact, \cd{node} can be a node-name-like character string, even if it is not actually a node in the model.  See example 4 in the code below.
-  \item One can also use \cd{model\$nodeName}, with the caveat that \cd{nodeName} can't be a variable (i.e., it needs to be the actual name of a variable or node) and so would only make sense for a nimbleFunction written for models known to have a specific node.
+  \item In \cd{model[[v]]}, \cd{v} can only be a single node or variable name, not a vector of multiple nodes nor an element of such a vector (\cd{model[[ nodes[i] ]]} does not work).  The node itself may be a vector, matrix or array node.
+  \item In fact, \cd{v} can be a node-name-like character string, even if it is not actually a node in the model.  See example 4 in the code below.
+  \item One can also use \cd{model\$varName}, with the caveat that \cd{varName} must be a variable name.  This usage would only make sense for a nimbleFunction written for models known to have a specific variable.  (Note that if \cd{a} is a scalar node in \cd{model}, then \cd{model[['a']]} will be a scalar but \cd{model\$a} will be a vector of length 1.)
  \item one should use the \cd{<<-} global assignment operator to assign into model nodes. 
 \end{itemize}
 

--- a/packages/nimble/inst/tests/test-nimbleFunctionModelAccess.R
+++ b/packages/nimble/inst/tests/test-nimbleFunctionModelAccess.R
@@ -23,12 +23,24 @@ test_that("nimbleFunction use of model variables and nodes works",
             aNode <- 'a'                ## CORRECT
             bNode <- 'b'
             cNode <- 'c'
+            bNode2 <- 'b[2]'
+            cNode34 <- 'c[3, 4]'
         },
         run = function(aCheck = double(),
                        bCheck = double(1),
                        cCheck = double(2)) {
             ok <- TRUE
 
+            bNode2v <- model[[bNode2]]
+            cNode34v <- model[[cNode34]]
+            bNode2v2 <- model[['b[2]']]
+            cNode34v2 <- model[['c[3, 4]']]
+
+            ok <- ok & bNode2v == bCheck[2]
+            ok <- ok & bNode2v == bNode2v2
+            ok <- ok & cNode34v == cCheck[3, 4]
+            ok <- ok & cNode34v2 == cNode34v
+            
             a1 <- model[['a']]
             ok <- ok & a1 == aCheck
             b1 <- model[['b']]

--- a/packages/nimble/inst/tests/test-nimbleFunctionModelAccess.R
+++ b/packages/nimble/inst/tests/test-nimbleFunctionModelAccess.R
@@ -1,0 +1,148 @@
+context("Testing how nimbleFunctions use model variables and nodes")
+
+source(system.file(file.path('tests', 'test_utils.R'), package = 'nimble'))
+
+test_that("nimbleFunction use of model variables and nodes works",
+{
+    code <- nimbleCode({
+        a ~ dnorm(0, 1)
+        for(i in 1:5) {
+            b[i] ~ dnorm(0, 1)
+            for(j in 1:3)
+                c[i,j] ~ dnorm(0, 1)
+        }
+    })
+    constants <- list()
+    data <- list()
+    inits <- list(a = 1, b=1:5, c = array(1:30, c(5,6)))
+
+    Rmodel <- nimbleModel(code, constants, data, inits)
+
+    nfDef <- nimbleFunction(
+        setup = function(model) {
+            aNode <- 'a'                ## CORRECT
+            bNode <- 'b'
+            cNode <- 'c'
+        },
+        run = function(aCheck = double(),
+                       bCheck = double(1),
+                       cCheck = double(2)) {
+            ok <- TRUE
+
+            a1 <- model[['a']]
+            ok <- ok & a1 == aCheck
+            b1 <- model[['b']]
+            ok <- ok & sum(dim(b1) != dim(bCheck)) == 0
+            ok <- ok & sum(b1 != bCheck) == 0
+            c1 <- model[['c']]
+            ok <- ok & sum(dim(c1) != dim(cCheck)) == 0
+            ok <- ok & sum(c1 != cCheck) == 0
+
+            ## This isn't a very creative check of assignment
+            ## but at least it should compile.  If the value
+            ## assignment fails, it should be revealed in the next
+            ## checks.
+            model[['a']] <<- a1 + 1
+            model[['b']] <<- b1 + 1
+            model[['c']] <<- c1 + 1
+            aCheck <- aCheck + 1
+            bCheck <- bCheck + 1
+            cCheck <- cCheck + 1
+            
+            a2 <- model$a
+            ok <- ok & sum(a2 != aCheck) == 0
+            b2 <- model$b
+            ok <- ok & sum(dim(b2) != dim(bCheck)) == 0
+            ok <- ok & sum(b2 != bCheck) == 0
+            c2 <- model$c
+            ok <- ok & sum(dim(c2) != dim(cCheck)) == 0
+            ok <- ok & sum(c2 != cCheck) == 0
+
+            model$a <<- a2 + 1
+            model$b <<- b2 + 1
+            model$c <<- c2 + 1
+            aCheck <- aCheck + 1
+            bCheck <- bCheck + 1
+            cCheck <- cCheck + 1
+            bSubCheck <- bCheck[2:4]
+            cSubCheck <- cCheck[2:4, 3:5]
+
+            ## model$a is a vector, so model$a[1] is allowed
+            a3 <- model$a[1]
+            ok <- ok & a3 == aCheck
+            b3 <- model$b[2:4]
+            ok <- ok & sum(dim(b3) != dim(bSubCheck)) == 0
+            ok <- ok & sum(b3 != bSubCheck) == 0
+            c3 <- model$c[2:4 , 3:5]
+            ok <- ok & sum(dim(c3) != dim(cSubCheck)) == 0
+            ok <- ok & sum(c3 != cSubCheck) == 0
+
+            model$a[1] <<- a3 + 1
+            model$b[2:4] <<- bSubCheck + 1
+            model$c[2:4, 3:5] <<- cSubCheck + 1
+            aCheck <- aCheck + 1
+            bCheck[2:4] <- bSubCheck + 1
+            cCheck[2:4, 3:5] <- cSubCheck + 1
+            bSubCheck <- bCheck[2:4]
+            cSubCheck <- cCheck[2:4, 3:5]
+            
+            ## model[['a']] is a scalar, so model[['a']][1] is not allowed
+            ##            a4 <- model[['a']][1]
+            ##            ok <- ok & a4 == aCheck
+            b4 <- model[['b']][2:4]
+            ok <- ok & sum(dim(b4) != dim(bSubCheck)) == 0
+            ok <- ok & sum(b4 != bSubCheck) == 0
+            c4 <- model[['c']][2:4 , 3:5]
+            ok <- ok & sum(dim(c4) != dim(cSubCheck)) == 0
+            ok <- ok & sum(c4 != cSubCheck) == 0
+
+            model[['b']][2:4] <<- bSubCheck + 1
+            model[['c']][2:4, 3:5] <<- cSubCheck + 1
+            bCheck[2:4] <- bSubCheck + 1
+            cCheck[2:4, 3:5] <- cSubCheck + 1
+            bSubCheck <- bCheck[2:4]
+            cSubCheck <- cCheck[2:4, 3:5]
+            
+            a5 <- model[[aNode]]
+            ok <- ok & a5 == aCheck
+            b5 <- model[[bNode]]
+            ok <- ok & sum(dim(b5) != dim(bCheck)) == 0
+            ok <- ok & sum(b5 != bCheck) == 0
+            c5 <- model[[cNode]]
+            ok <- ok & sum(dim(c5) != dim(cCheck)) == 0
+            ok <- ok & sum(c5 != cCheck) == 0
+
+            model[[aNode]] <<- a5 + 1
+            model[[bNode]] <<- b5 + 1
+            model[[cNode]] <<- c5 + 1
+            aCheck <- aCheck + 1
+            bCheck <- bCheck + 1
+            cCheck <- cCheck + 1
+            bSubCheck <- bCheck[2:4]
+            cSubCheck <- cCheck[2:4, 3:5]
+
+            ## model[[aNode]] is a scalar, so model[[aNode]][1] is not allowed
+            ## a6 <- model[[aNode]][1]
+            ## ok <- ok & a6 == aCheck
+            b6 <- model[[bNode]][2:4]
+            ok <- ok & sum(dim(b6) != dim(bSubCheck)) == 0
+            ok <- ok & sum(b6 != bSubCheck) == 0
+            c6 <- model[[cNode]][2:4 , 3:5]
+            ok <- ok & sum(dim(c6) != dim(cSubCheck)) == 0
+            ok <- ok & sum(c6 != cSubCheck) == 0
+
+            model[[bNode]][2:4] <<- bSubCheck + 1
+            model[[cNode]][2:4, 3:5] <<- cSubCheck + 1
+            
+            return(ok)
+            returnType(logical())
+        }
+    )
+    
+    Rnf <- nfDef(Rmodel)
+    uncompiledAns <- Rnf$run(Rmodel$a, Rmodel$b, Rmodel$c)
+    expect_true(uncompiledAns)
+    compiled <- compileNimble(Rmodel, Rnf)
+    compiledAns <- compiled$Rnf$run(Rmodel$a, Rmodel$b, Rmodel$c)
+    expect_true(compiledAns)    
+})


### PR DESCRIPTION
Fixes #666, whose title has been revised to be more precise.

This issue raised the following case:
`model[["b"]]` in a nimbleFunction.

The features are:

1. "b" is hard-coded
2. The variable `b` in `model` is non-scalar

This silently behaved wrong by returning only the first element of `model$b`.  This was more a bug in error-trapping (silent incorrect behavior), testing (this was not covered in testing), and/or documentation than in functionality of intended usage.  If writing a nimbleFunction that will directly access a fixed (will not vary across instances) node name, the intended way to do so was `model$b`.  In model-generic programming, one typically wants `model[[bNode]]` where `bNode` is a character variable with node or vector name, and that works fine. Section 14.4.2 of the manual covers this, but not extremely clearly.

The case where `model$b` is a scalar was accessed correctly by `model[["b"]]`.

In order to trap the case that `b` in `model` is non-scalar, we must look in `model`.  When possible at this "keyword processing" stage, we try whenever possible to determine what is going on by syntax alone to avoid costly looking around the model.   Until this point, we did not look in model if the index of `[[` for a model was a string. However, given that we are going to need to check in the model, then it becomes as easy to make `model[["b"]]` work as it would be to error-trap what is going on just to tell the user not to do it.  So I made it work.

There is a new test file `test-nimbleFunctionModelAccess.R` that illustrates the different ways to access nodes and variables.  It is not elegant (a failure will take work to pin down) but it covers a lot of cases.

I edited section 14.4.2 ("Getting and setting variable and node values") of the manual.

A subtlety (explained in 14.4.2) is that if `b` in `model` is a scalar, then `model[["b"]]` is a scalar but `model$b` is a length-one vector.  There is a rationale to that, and I'm hoping we can live with it.  It has always been the case for `model[[bNode]]` if `bNode == "b"`.

In summary, `model[["b"]]` works in this PR.

This involves steps of processing used quite a lot, so let's see what testing reveals.