### PR TITLE
fixed break/next statements flagged by cran

### DIFF
--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -961,7 +961,7 @@ Checks for size/dimension mismatches and for presence of NAs in model variables 
                                         for(v in .self$getVarNames()){
                                           if(!nimble:::isValid(.self[[v]])){
                                             message(' This model is not fully initialized. This is not an error. To see which variables are not initialized, use model$initializeInfo(). For more information on model initialization, see help(modelInitialization).', appendLF = FALSE)
-                                            break()
+                                            break
                                           }
                                         }
                                       }

--- a/packages/nimble/R/cppInterfaces_modelValues.R
+++ b/packages/nimble/R/cppInterfaces_modelValues.R
@@ -89,7 +89,7 @@ CmodelValues <- setRefClass(
             dll <<- dll
             initialized <<- initialized
             if(missing(buildCall) ) 
-                break("Cannot build object without buildCall!")
+                stop("Cannot build object without buildCall!")
             extptrCall <<- buildCall
             varNames <<- eval(call('.Call', nimbleUserNamespace$sessionSpecificDll$getAvailableNames, extptr))      
             componentExtptrs <<- vector(mode = 'list', length = length(varNames))

--- a/packages/nimble/R/types_symbolTable.R
+++ b/packages/nimble/R/types_symbolTable.R
@@ -147,7 +147,6 @@ resolveOneUnknownType <- function(unknownSym, neededTypes = NULL, nimbleProject)
         listST$name <- name
         return(list(listST, newNeededType))
         ##symTab$addSymbol(listST, allowReplace = TRUE)
-        next
     } else { ## either create the type, or in the case of 'return', search recursively into neededTypes
         possibleTypeName <- type
         ## look for a valid nlGenerator in the global environment
@@ -162,7 +161,6 @@ resolveOneUnknownType <- function(unknownSym, neededTypes = NULL, nimbleProject)
                     listST$name <- name
                     return(list(listST, newNeededType))
                     ##   symTab$addSymbol(listST, allowReplace = TRUE)
-                   ## next
                 }
                 ## for the case of 'return' only, see if it matches a type nested within a neededType
                 if(name == 'return') {
@@ -171,7 +169,6 @@ resolveOneUnknownType <- function(unknownSym, neededTypes = NULL, nimbleProject)
                         listST$name <- name
                         return(list(listST, newNeededType))
 ##                        symTab$addSymbol(listST, allowReplace = TRUE)
-##                        next
                     }
                 }
                 ## can't find it anywhere, so create it and add to newNeededTypes
@@ -186,7 +183,6 @@ resolveOneUnknownType <- function(unknownSym, neededTypes = NULL, nimbleProject)
                 returnSym <- symbolNimbleList(name = name, nlProc = nlp)
 ##                symTab$addSymbol(lireturnSymstST, allowReplace = TRUE)
                 return(list(returnSym, newNeededType))
-                ##next
             }
         } else {
             stop(paste0("Can't figure out what ", possibleTypeName, " is."))


### PR DESCRIPTION
This fixes incorrect use of break (as break()) and next (outside of loop) flagged by CRAN checks on R-devel.