### PR TITLE
Deprecate identityMatrix in favor of diag

### DIFF
--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -676,7 +676,7 @@ conjugacyClass <- setRefClass(
                                ## I <- model[[target]] * 0
                                ## for(sizeIndex in 1:d)   { I[sizeIndex, sizeIndex] <- 1 }
                                ## model[[target]] <<- I   ## initially, propogate through X = I
-                               I <- identityMatrix(d)
+                               I <- diag(d)
                                model[[target]] <<- I   ## initially, propogate through X = I
                                calculate(model, calcNodesDeterm)
                            })

--- a/packages/nimble/R/NF_utils.R
+++ b/packages/nimble/R/NF_utils.R
@@ -196,11 +196,11 @@ getLogProbNodesMV <- nimbleFunction(
 
 
 
-#' Create an Identity matrix
+#' Create an Identity matrix (Deprecated)
 #'
 #' Returns a d-by-d identity matrix (square matrix of 0's, with 1's on the main diagnol).
 #'
-#' This function can be used in NIMBLE run code.
+#' This function can be used in NIMBLE run code.  It is deprecated because now one can use diag(d) instead.
 #'
 #' @param d The size of the identity matrix to return, will return a d-by-d matrix
 #'

--- a/packages/nimble/R/miscFunctions.R
+++ b/packages/nimble/R/miscFunctions.R
@@ -20,7 +20,7 @@ calc_dmnormAltParams <- nimbleFunction(
         if(prec_param == return_prec) {
             ans <- t(cholesky) %*% cholesky
         } else {
-            I <- identityMatrix(dim(cholesky)[1])
+            I <- diag(dim(cholesky)[1])
             ans <- backsolve(cholesky, forwardsolve(t(cholesky), I))
             ## Chris suggests:
             ## tmp <- forwardsolve(L, I)
@@ -68,7 +68,7 @@ calc_dwishAltParams <- nimbleFunction(
         if(scale_param == return_scale) {
             ans <- t(cholesky) %*% cholesky
         } else {
-            I <- identityMatrix(dim(cholesky)[1])
+            I <- diag(dim(cholesky)[1])
             ans <- backsolve(cholesky, forwardsolve(t(cholesky), I))
             ## Chris suggests:
             ## tmp <- forwardsolve(L, I)


### PR DESCRIPTION
For a long time we have supported R-like use of diag() to create an identity matrix.  I noticed there were three cases of the old identityMatrix still in the code base.  That is more cumbersome because it uses an entirely separate nimbleFunction.  This PR puts identityMatrix in deprecated status by adding a note to its roxygen entry and changing its uses to diag() instead. 