### PR TITLE
edited warning and error messages

### DIFF
--- a/packages/nimble/R/BUGS_BUGSdecl.R
+++ b/packages/nimble/R/BUGS_BUGSdecl.R
@@ -740,7 +740,7 @@ getSymbolicParentNodesRecurse <- function(code, constNames = list(), indexNames 
                 ## block[i], so block is replaceable
                 if(!all(contentsReplaceable)) 
                     ## dynamic index on a constant
-                    stop('getSymbolicParentNodesRecurse: dynamic indexing of constants is not allowed in ', deparse(code))
+                    stop('getSymbolicParentNodesRecurse: dynamic indexing of constants is not allowed in ', deparse(code), '. Try adding the dynamically-indexed constant as data instead (using the data argument of nimbleModel).')
                 boolIndexingBlock <-
                     unlist(
                         lapply(code[-c(1,2)],

--- a/packages/nimble/R/distributions_processInputList.R
+++ b/packages/nimble/R/distributions_processInputList.R
@@ -256,10 +256,10 @@ checkDistributionFunctions <- function(distributionInput, userEnv) {
     if(!exists(densityName, where = userEnv) ||
         !is.rcf(get(densityName, pos = userEnv)))
         stop(paste0("checkDistributionFunctions: density function for ", densityName,
-                    " is not available as a nimbleFunction without setup code."))
+                    " is not available.  It must be a nimbleFunction (with no setup code)."))
     if(!exists(simulateName, where = userEnv) || !is.rcf(get(simulateName, pos = userEnv))) {
         cat(paste0("Warning: random generation function for ", densityName,
-                    " is not available as a nimbleFunction without setup code. NIMBLE is generating a placeholder function that will invoke an error if an algorithm needs to simulate from this distribution. Some algorithms (such as random-walk Metropolis MCMC sampling) will work without the ability to simulate from the distribution.\n"))
+                    " is not available. NIMBLE is generating a placeholder function that will invoke an error if an algorithm needs to simulate from this distribution. Some algorithms (such as random-walk Metropolis MCMC sampling) will work without the ability to simulate from the distribution.  If simulation is needed, provide a nimbleFunction (with no setup code) to do it.\n"))
         rargInfo <- environment(get(densityName, pos = userEnv))$nfMethodRCobject$argInfo
         returnType <- deparse(unlist(rargInfo[[1]]))
         rargInfo <- rargInfo[-length(rargInfo)]  # remove 'log' argument
@@ -291,7 +291,7 @@ checkDistributionFunctions <- function(distributionInput, userEnv) {
         quantileName <- sub('^d', 'q', densityName)
         if(!is.rcf(get(cdfName, pos = userEnv)) || !is.rcf(get(quantileName, pos = userEnv)))
             stop(paste0("checkDistributionFunctions: Either distribution (CDF) or quantile (inverse CDF) functions for ", densityName,
-                        " are not available as nimbleFunctions without setup code."))
+                        " are not available.  If needed, they must be nimbleFunction (with no setup code)."))
 
         pargs <- args <- formals(get(cdfName, pos = userEnv))
         nArgs <- length(args)
@@ -396,7 +396,7 @@ prepareDistributionInput <- function(dist) {
 #' a character string in the form of the density name (starting with 'd') followed by the names of the parameters in parentheses. When alternative parameterizations are given in \code{Rdist}, this should be an exhaustive list of the unique parameter names from all possible parameterizations, with the default parameters specified first.
 #' }
 #' \item{\code{Rdist}} {
-#' an optional character vector with one or more alternative specifications of the density; each alternative specification can be an alternative name for the density, a different ordering of the parameters, different parameter name(s), or an alternative parameterization. In the latter case, the character string in parentheses should provide a given reparameterization as comma-separated name = value pairs, one for each default parameter, where name is the name of the default parameter and value is a mathematical expression relating the default parameter to the alternative parameters or other default parameters. The default parameters should correspond to the input arguments of the nimbleFunctions provided as the density and random generation functions. The mathematical expression can use any of the math functions allowed in NIMBLE (see the User Manual) as well as user-supplied nimbleFunctions without setup code. The names of your nimbleFunctions for the distribution functions must match the function name in the \code{Rdist} entry (or if missing, the function name in the \code{BUGSdist} entry
+#' an optional character vector with one or more alternative specifications of the density; each alternative specification can be an alternative name for the density, a different ordering of the parameters, different parameter name(s), or an alternative parameterization. In the latter case, the character string in parentheses should provide a given reparameterization as comma-separated name = value pairs, one for each default parameter, where name is the name of the default parameter and value is a mathematical expression relating the default parameter to the alternative parameters or other default parameters. The default parameters should correspond to the input arguments of the nimbleFunctions provided as the density and random generation functions. The mathematical expression can use any of the math functions allowed in NIMBLE (see the User Manual) as well as user-supplied nimbleFunctions (which must have no setup code). The names of your nimbleFunctions for the distribution functions must match the function name in the \code{Rdist} entry (or if missing, the function name in the \code{BUGSdist} entry
 #' }
 #' \item{\code{discrete}} {
 #' a optional logical indicating if the distribution is that of a discrete random variable. If not supplied, distribution is assumed to be for a continuous random variable.


### PR DESCRIPTION
This PR contains some minor edits to a handful of warning and error messages.

* When the object being dynamically indexed was provided as a constant, I added a sentence suggesting to the user to try adding it as data instead.  

* I felt the warnings and errors when some component of a user-defined distribution is missing could be slightly clarified.  Specifically, the phrase “nimbleFunction without setup code” could be confusing and was re-written in a few cases.