### PR TITLE
Faster checkForSelfParents

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -2957,10 +2957,5 @@ modelDefClass$methods(checkForSelfParents = function(){
                    paste(maps$graphID_2_nodeName[problemNodes], collapse = ", ")),
              call. = FALSE)
     }
-  ##   for(i in seq_along(maps$edgesFrom)){
-  ##   if(maps$edgesFrom[i] == maps$edgesTo[i]){
-  ##     stop(paste("In building model, node", maps$graphID_2_nodeName[maps$edgesFrom[i]], "is its own parent node."), call. = FALSE)
-  ##   }
-  ## }
 })
 

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -2950,10 +2950,17 @@ detectDynamicIndexes <- function(expr) {
 }
 
 modelDefClass$methods(checkForSelfParents = function(){
-  for(i in seq_along(maps$edgesFrom)){
-    if(maps$edgesFrom[i] == maps$edgesTo[i]){
-      stop(paste("In building model, node", maps$graphID_2_nodeName[maps$edgesFrom[i]], "is its own parent node."), call. = FALSE)
+    if(any(maps$edgesFrom == maps$edgesTo)) {
+        problemNodes <- maps$edgesFrom[maps$edgesFrom == maps$edgesTo]
+        stop(paste("In building model, each of the following nodes",
+                   "has itself as a parent node:",
+                   paste(maps$graphID_2_nodeName[problemNodes], collapse = ", ")),
+             call. = FALSE)
     }
-  }
+  ##   for(i in seq_along(maps$edgesFrom)){
+  ##   if(maps$edgesFrom[i] == maps$edgesTo[i]){
+  ##     stop(paste("In building model, node", maps$graphID_2_nodeName[maps$edgesFrom[i]], "is its own parent node."), call. = FALSE)
+  ##   }
+  ## }
 })
 


### PR DESCRIPTION
A step if building the `modelDef` is `checkForSelfParents`, which traps cases where a deterministic node depends on itself.  (Cases where a stochastic node depends on itself seem to trigger an error at an earlier step.)  This worked by iterating through each edge in the graph and checking if it points in a circle.  A user case of slow build times for a large model revealed that about 1/3 of `nimbleModel` time was spent on this inefficient iteration.  In this PR, that iteration is replaced with a vectorized check of whether any edges point in a circle (same “from” and “to” nodes).  This is much faster.