### PR TITLE
speed up makeParamInfo and related functions/methods

### DIFF
--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -93,7 +93,10 @@ Details: The return value is logical vector with an element for each node indica
 
                                   ## returns the declaration ID corresponding to nodes
                                   getDeclID = function(nodes) {
-                                      graphIDs <- modelDef$nodeName2GraphIDs(nodes, unique = FALSE)
+                                      graphIDs <- if(is.character(nodes))
+                                                      modelDef$nodeName2GraphIDs(nodes, unique = FALSE)
+                                                  else
+                                                      nodes
                                       declIDs <- getMaps('graphID_2_declID')[graphIDs]
                                       return(declIDs)
                                   },
@@ -130,10 +133,10 @@ nodes: A character vector specifying one or more node or variable names.
 
 Details: The return value is a character vector with an element for each node indicated in the input. Note that variable names are expanded to their constituent node names, so the length of the output may be longer than that of the input.
 '
-                                      nodeNames <- expandNodeNames(nodes, unique = FALSE)
+                                      nodeNames <- expandNodeNames(nodes, unique = FALSE, returnType = "ids")
                                       out <- sapply(nodeNames, function(x)
 				      	getDeclInfo(x)[[1]]$getDistributionName())
-                                      names(out) <- nodeNames
+                                      names(out) <- modelDef$maps$graphID_2_nodeName[nodeNames]
                                       return(out)
                                   },
 

--- a/packages/nimble/R/distributions_processInputList.R
+++ b/packages/nimble/R/distributions_processInputList.R
@@ -655,9 +655,13 @@ NULL
 #' @export
 getDistributionInfo <- function(dist) {
     if(is.na(dist)) return(NA)
-    if(dist %in% distributions$namesVector) return(distributions[[dist]])
-    if(exists('distributions', nimbleUserNamespace) && dist %in% nimbleUserNamespace$distributions$namesVector)
-        return(nimbleUserNamespace$distributions[[dist]])
+    ans <- distributions[[dist]]
+    if(!is.null(ans)) return(ans)
+    ##    if(dist %in% distributions$namesVector) return(distributions[[dist]])
+    ans <- nimbleUserNamespace$distributions[[dist]]
+    if(!is.null(ans)) return(ans)
+    ##if(exists('distributions', nimbleUserNamespace) && dist %in% nimbleUserNamespace$distributions$namesVector)
+    ##    return(nimbleUserNamespace$distributions[[dist]])
     stop(paste0("getDistributionInfo: ", dist, " is not a distribution provided by NIMBLE or supplied by the user."))
 }
 

--- a/packages/nimble/R/nimbleFunction_Rexecution.R
+++ b/packages/nimble/R/nimbleFunction_Rexecution.R
@@ -158,17 +158,17 @@ makeParamInfo <- function(model, nodes, param) {
 
     distNames <- model$getDistribution(nodes)
 
-    ## if(length(nodes) != 1) stop(paste0("Problem with nodes argument while setting up getParam.  Should be length 1 but was: ", paste0(nodes, collapse = ",")))
-    ## distInfo <- getDistributionList(model$getDistribution(nodes))[[1]]
-    ## ## If nodes is invalid, an error from the above line will be trapped in parseEvalNumericMany
     if(length(param) != 1) stop(paste0(paste0('Problem with param(s) ', paste0(param, collapse = ','), ' while setting up getParam for node ', nodes,
-                 '\nOnly one parameter is allowed.')))
-    ## paramID <- distInfo$paramIDs[param]
-    ## if(length(paramID)!=1 | any(is.na(paramID))) stop(paste0('Problem with param ', paste0(param, collapse = ','), ' while setting up getParam for node ', nodes,
-    ##                                    '\nThe parameter name is not valid.'))
-    paramIDvec <- sapply(distNames, getParamID, param)
-    typeVec <- sapply(distNames, getType, param)
-    nDimVec <- sapply(distNames, getDimension, param)
+                                              '\nOnly one parameter is allowed.')))
+
+    distInfos <- lapply(distNames, getDistributionInfo)
+    paramIDvec <- unlist(lapply(distInfos, function(x) x$paramIDs[param]))
+    typeVec <- unlist(lapply(distInfos, function(x) x$types[[param]]$type))
+    nDimVec <- unlist(lapply(distInfos, function(x) x$types[[param]]$nDim))
+    
+   ## paramIDvec <- sapply(distNames, getParamID, param)
+   ## typeVec <- sapply(distNames, getType, param)
+   ## nDimVec <- sapply(distNames, getDimension, param)
     if(length(unique(typeVec)) != 1 || length(unique(nDimVec)) != 1) stop('cannot have an indexed vector of nodes used in getParam if they have different types or dimensions for the same parameter.') 
     ans <- c(list(paramID = paramIDvec), type = typeVec[1], nDim = nDimVec[1])
     class(ans) <- 'getParam_info'


### PR DESCRIPTION
With some stochastic indexing examples we see cases where `makeParamInfo` takes a huge amount of time while compiling an MCMC.  This PR contains some hasty fixes that reduce the time by perhaps  around 75% in the motivating example (careful before/after timing was not done because it is clearly must faster, and case-specific).  This could be made faster still, but this PR is limited to the quick fixes that were feasible in a short time.