### PR TITLE
WAIC fixes

### DIFF
--- a/UserManual/chapter_MCMC.Rnw
+++ b/UserManual/chapter_MCMC.Rnw
@@ -581,7 +581,7 @@ Obtaining samples as matrices is most common, but see Section \ref{sec:modelValu
 \section{Calculating WAIC}
 \label{sec:WAIC}
 
-Once an MCMC algorithm has been run, as dscribed in \ref{sec:executing-the-mcmc-algorithm}, the WAIC \citep{Watanabe_2010} can be calculated from the posterior samples produced by the MCMC algorithm.  Note that in order to calculate the WAIC value after running an MCMC algorithm, the argument \cd{enableWAIC = TRUE} must have been supplied to the call to \cd{buildMCMC}, or the \cd{enableWAIC} nimble option must have been set to \cd{TRUE}.
+Once an MCMC algorithm has been run, as described in \ref{sec:executing-the-mcmc-algorithm}, the WAIC \citep{Watanabe_2010} can be calculated from the posterior samples produced by the MCMC algorithm.  Note that in order to calculate the WAIC value after running an MCMC algorithm, the argument \cd{enableWAIC = TRUE} must have been supplied to the call to \cd{buildMCMC}, or the \cd{enableWAIC} NIMBLE option must have been set to \cd{TRUE}.
 
 The WAIC is calculated by calling the member method \cd{mcmc\$calculateWAIC} (see \cd{help(buildMCMC)} in R for more details).  The \cd{calculateWAIC} method has one required argument, \cd{nburnin}, the number of initial samples to discard prior to WAIC calculation.  \cd{nburnin} defaults to 0.
 

--- a/UserManual/chapter_MCMC.Rnw
+++ b/UserManual/chapter_MCMC.Rnw
@@ -18,7 +18,7 @@ require(igraph, warn.conflicts = FALSE, quietly = TRUE)  # same question
 
 NIMBLE provides a variety of paths to creating and executing an MCMC algorithm, which differ greatly in their simplicity of use, and also in the options available and customizability.
 
-The most direct approach to invoking the MCMC engine is using the \cd{nimbleMCMC} function (Section \ref{sec:nimbleMCMC}).  This one-line call creates and executes an MCMC, and provides a wide range of options for controlling the MCMC: specifying monitors, burn-in, and thinning, running multiple MCMC chains with different initial values, and returning posterior samples, summary statistics, and/or WAIC values.  However, this approach is restricted to using NIMBLE's default MCMC algorithm; further customization of, for example, the specific samplers employed, is not possible.
+The most direct approach to invoking the MCMC engine is using the \cd{nimbleMCMC} function (Section \ref{sec:nimbleMCMC}).  This one-line call creates and executes an MCMC, and provides a wide range of options for controlling the MCMC: specifying monitors, burn-in, and thinning, running multiple MCMC chains with different initial values, and returning posterior samples, summary statistics, and/or a WAIC value.  However, this approach is restricted to using NIMBLE's default MCMC algorithm; further customization of, for example, the specific samplers employed, is not possible.
 
 The lengthier and more customizable approach to invoking the MCMC engine on a particular NIMBLE model object involves the following steps:
 
@@ -84,7 +84,7 @@ End-to-end examples of MCMC in NIMBLE can be found in Sections \ref{sec:creating
 \section{One-line invocation of MCMC: \cd{nimbleMCMC}}
 \label{sec:nimbleMCMC}
 
-The most direct approach to executing an MCMC algorithm in NIMBLE is using \cd{nimbleMCMC}.  This single function can be used to create an underlying model and associated MCMC algorithm, compile both of these, execute the MCMC, and return samples, summary statistics, and WAIC values.  This approach circumvents the longer (and more flexible) approach using \cd{nimbleModel}, \cd{configureMCMC}, \cd{buildMCMC}, \cd{compileNimble}, and \cd{runMCMC}, which is described subsequently.
+The most direct approach to executing an MCMC algorithm in NIMBLE is using \cd{nimbleMCMC}.  This single function can be used to create an underlying model and associated MCMC algorithm, compile both of these, execute the MCMC, and return samples, summary statistics, and a WAIC value.  This approach circumvents the longer (and more flexible) approach using \cd{nimbleModel}, \cd{configureMCMC}, \cd{buildMCMC}, \cd{compileNimble}, and \cd{runMCMC}, which is described subsequently.
 
 The \cd{nimbleMCMC} function provides control over the:
 
@@ -98,7 +98,7 @@ The \cd{nimbleMCMC} function provides control over the:
 \item setting the random number seed;
 \item returning posterior samples as a matrix or a \cd{coda} \cd{mcmc} object;
 \item returning posterior summary statistics; and
-\item returning WAIC values calculated from each chain.
+\item returning a WAIC value calculated using samples from all chains.
 \end{itemize}
 
 This entry point for using \cd{nimbleMCMC} is the \cd{code}, \cd{constants}, \cd{data}, and \cd{inits} arguments that are used for building a NIMBLE model (see Chapters \ref{cha:writing-models} and \ref{cha:building-models}).  However, when using \cd{nimbleMCMC}, the \cd{inits} argument can also specify a list of lists of initial values that will be used for each MCMC chain, or a function that generates a list of initial values, which will be generated at the onset of each chain.  As an alternative entry point, a NIMBLE \cd{model} object can also be supplied to \cd{nimbleMCMC}, in which case this model will be used to build the MCMC algorithm.
@@ -108,7 +108,7 @@ Based on its arguments, \cd{nimbleMCMC} optionally returns any combination of
 \begin{itemize}
 \item posterior samples,
 \item Posterior summary statistics, and
-\item WAIC values.
+\item WAIC value.
 \end{itemize}
 
 The above are calculated and returned for each MCMC chain.  Additionally, posterior summary statistics are calculated for all chains combined when multiple chains are run.
@@ -429,10 +429,12 @@ The \cd{samples} matrix will contain both MCMC samples and model log-probabiliti
 Once the MCMC configuration object has been created, and customized to one's liking, it may be used to build an MCMC function:
 
 <<buildMCMC, eval=FALSE>>=
-Rmcmc <- buildMCMC(mcmcConf)
+Rmcmc <- buildMCMC(mcmcConf, enableWAIC = TRUE)
 @
 
-\cd{buildMCMC} is a nimbleFunction.  The returned object \cd{Rmcmc} is an instance  of the nimbleFunction specific to configuration \cd{mcmcConf} (and of course its associated model).
+\cd{buildMCMC} is a nimbleFunction.  The returned object \cd{Rmcmc} is an instance  of the nimbleFunction specific to configuration \cd{mcmcConf} (and of course its associated model).  
+
+Note that if you would like to be able to calculate the WAIC of the model after the MCMC function has been run, you must set \cd{enableWAIC = TRUE} as an argument to \cd{buildMCMC}, or set \cd{nimbleOptions(enableWAIC = TRUE)}, which will enable WAIC calculations for all subsequently built MCMC functions.  For more information on WAIC calculations, see Section \ref{sec:WAIC} or \cd{help(buildMCMC)} in R.
 
 When no customization is needed, one can skip \cd{configureMCMC} and simply provide a model object to \cd{buildMCMC}. The following two MCMC functions will be identical:
 
@@ -466,7 +468,7 @@ Cmcmc$Rmcmc$run(niter = 1000)
 \section{User-friendly execution of MCMC algorithms: \cd{runMCMC}}
 \label{sec:runMCMC}
 
-Once an MCMC algorithm has been created using \cd{buildMCMC}, the function \cd{runMCMC} can be used to run multiple chains and extract posterior samples, summary statistics and/or WAIC values.  This is a simpler approach to executing an MCMC algorithm, than the process of executing and extracting samples as described in Sections \ref{executing-the-mcmc-algorithm} and \ref{sec:extracting-samples}.
+Once an MCMC algorithm has been created using \cd{buildMCMC}, the function \cd{runMCMC} can be used to run multiple chains and extract posterior samples, summary statistics and/or a WAIC value.  This is a simpler approach to executing an MCMC algorithm, than the process of executing and extracting samples as described in Sections \ref{executing-the-mcmc-algorithm} and \ref{sec:extracting-samples}.
 
 \cd{runMCMC} also provides several user-friendly options such as burn-in, running multiple chains, and different initial values for each chain.  However, using \cd{runMCMC} does not support several lower-level options, such as timing the individual samplers internal to the MCMC, or continuing an exisiting MCMC run (picking up where it left off).
 
@@ -482,7 +484,7 @@ Once an MCMC algorithm has been created using \cd{buildMCMC}, the function \cd{r
 \item Setting the random number seed;
 \item Returning the posterior samples as a \cd{coda} \cd{mcmc} object;
 \item Returning summary statistics calculated from each chains; and
-\item Returning WAIC values calculated from each chain.
+\item Returning a WAIC value calculated using samples from all chains.
 \end{itemize}
 
 % See \cd{help(runMCMC)} for details of these arguments.
@@ -579,7 +581,9 @@ Obtaining samples as matrices is most common, but see Section \ref{sec:modelValu
 \section{Calculating WAIC}
 \label{sec:WAIC}
 
-Once an MCMC algorithm has been run, as dscribed in \ref{sec:executing-the-mcmc-algorithm}, the WAIC \citep{Watanabe_2010} can be calculated from the posterior samples produced by the MCMC algorithm.  The WAIC is calculated by calling the member method \cd{mcmc\$calculateWAIC} (see \cd{help(buildMCMC)} in R).  The \cd{calculateWAIC} method has one required argument, \cd{nburnin}, the number of initial samples to discard prior to WAIC calculation.  \cd{nburnin} defaults to 0.
+Once an MCMC algorithm has been run, as dscribed in \ref{sec:executing-the-mcmc-algorithm}, the WAIC \citep{Watanabe_2010} can be calculated from the posterior samples produced by the MCMC algorithm.  Note that in order to calculate the WAIC value after running an MCMC algorithm, the argument \cd{enableWAIC = TRUE} must have been supplied to the call to \cd{buildMCMC}, or the \cd{enableWAIC} nimble option must have been set to \cd{TRUE}.
+
+The WAIC is calculated by calling the member method \cd{mcmc\$calculateWAIC} (see \cd{help(buildMCMC)} in R for more details).  The \cd{calculateWAIC} method has one required argument, \cd{nburnin}, the number of initial samples to discard prior to WAIC calculation.  \cd{nburnin} defaults to 0.
 
 <<eval=FALSE>>=
 Cmcmc$calculateWAIC(nburnin = 100)

--- a/packages/nimble/NEWS
+++ b/packages/nimble/NEWS
@@ -1,3 +1,16 @@
+                           CHANGES IN VERSION 0.6-10 (March 2018)
+
+USER LEVEL CHANGES
+
+-- To run WAIC, a user now must set 'enableWAIC' to 'TRUE', either in nimble's options or as an argument to buildMCMC().
+
+-- If 'enableWAIC' is 'TRUE', buildMCMC() will now check to make sure that the nodes monitored by the MCMC algorithm will lead to a valid WAIC calculation.	
+
+BUG FIXES
+
+--	Fixed a WAIC bug where downstream nodes were not being re-simulated for certain combinations of models and monitored variables.
+
+
                            CHANGES IN VERSION 0.6-9 (January 2018)
 
 USER LEVEL CHANGES

--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -67,9 +67,10 @@
 #' stochastic node that a data node depends on must be either monitored, or be
 #' downstream from monitored nodes.  An easy way to ensure this is satisfied
 #' is to monitor all top-level parameters in a model (NIMBLE's default).  
-#' However, other combinations of monitored nodes are also valid.  
-#' If \code{enableWAIC = TRUE}, NIMBLE checks to see if the set of monitored 
-#' nodes is valid, and returns an error if not.
+#' Another way to guarantee correctness is to monitor all stochastic nodes
+#' directly upstream from a data node. However, other combinations of monitored
+#' nodes are also valid.  If \code{enableWAIC = TRUE}, NIMBLE checks to see if
+#' the set of monitored nodes is valid, and returns an error if not.
 #' 
 #' 
 #' @examples
@@ -136,7 +137,6 @@ buildMCMC <- nimbleFunction(
           paramDeps <- model$getDependencies(sampledNodes, self = FALSE,
                                              downstream = TRUE)
           checkWAICmonitors(model, sampledNodes, dataNodes)
-          browser()
         }
         else{
           dataNodes <- c('')
@@ -279,8 +279,8 @@ checkWAICmonitors <- function(model, monitors, dataNodes){
                   " See help(buildMCMC) for more information on valid sets of",
                   " monitored nodes for WAIC calculations.", "\n",
                   " Currently, the following data nodes have un-monitored",
-                  " upstream parameters:", "\n ", badDataNodes,
-                  collapse = ', '))
+                  " upstream parameters:", "\n ", paste0(badDataNodes,
+                                                         collapse = ", ")))
     }
     thisVars <- model$getVarNames(nodes = nextNodes)
     thisVars <- thisVars[!(thisVars %in% monitors)]
@@ -289,10 +289,8 @@ checkWAICmonitors <- function(model, monitors, dataNodes){
   simNodes <- model$getDependencies(monitors, self = FALSE,
                                     downstream = TRUE, includeData = FALSE)
   if(length(simNodes) > 0){
-    message(paste0('The following non-data stochastic nodes will be simulated",
-                   " for WAIC: ', '\n',
-                   if(length(simNodes) > 1){paste0(simNodes[-length(simNodes)],
-                                                   sep = ", ")},
-                   simNodes[length(simNodes)]))
+    message(paste0('The following non-data stochastic nodes will be simulated',
+                   ' for WAIC: ', '\n',
+                   paste0(simNodes, collapse = ", ")))
   }
 }

--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -32,13 +32,27 @@
 #' The compiled function will function identically to the uncompiled object, except acting on the compiled model object.
 #'
 #' @section Calculating WAIC:
-#' After the MCMC has been run, calling the \code{calculateWAIC()} method of the MCMC object will return the WAIC for the model, calculated using the posterior samples from the MCMC run.
+#' After the MCMC has been run, calling the \code{calculateWAIC()} method of the
+#' MCMC object will return the WAIC for the model, calculated using the 
+#' posterior samples from the MCMC run.
 #' 
 #' \code{calculateWAIC()} has a single arugment:
 #'
-#' \code{nburnin}: The number of iterations to subtract from the beginning of the posterior samples of the MCMC object for WAIC calculation.  Defaults to 0.
+#' \code{nburnin}: The number of iterations to subtract from the beginning of
+#' the posterior samples of the MCMC object for WAIC calculation.
+#' Defaults to 0.
 #' 
-#' The \code{calculateWAIC} method calculates the WAIC of the model that the MCMC was performed on. The WAIC (Watanabe, 2010) is calculated from Equations 5, 12, and 13 in Gelman (2014).  Note that the set of all parameters monitored by the mcmc object will be treated as \eqn{theta} for the purposes of e.g. Equation 5 from Gelman (2014).  All parameters downstream of the monitored parameters that are necessary to calculate \eqn{p(y|theta)} will be simulated from the posterior samples of \eqn{theta}.
+#' The \code{calculateWAIC} method calculates the WAIC of the model that the
+#' MCMC was performed on. The WAIC (Watanabe, 2010) is calculated from
+#' Equations 5, 12, and 13 in Gelman (2014).  Note that the set of all
+#' stochastic nodes monitored by the mcmc object will be treated as \eqn{theta} for
+#' the purposes of e.g. Equation 5 from Gelman (2014).  \eqn{y} from  Equation 5 
+#' will be set to all data nodes downstream of the monitored nodes \eqn{theta}.
+#' All non-data nodes downstream of the monitored nodes that are necessary to calculate
+#' \eqn{p(y|theta)} will be simulated from the posterior samples of \eqn{theta}.  Any 
+#' stochastic nodes that are not included in or downstream from the monitored nodes will have their values
+#' fixed during the WAIC calculation - this means that if only a subset of the top-level parameters in a model
+#' are monitored, the unmonitored parameters will have their values fixed while the WAIC is calculated.
 #'
 #' @examples
 #' \dontrun{

--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -58,14 +58,14 @@
 #' All non-monitored nodes downstream of the monitored nodes that are necessary
 #' to calculate \eqn{p(y|theta)} will be simulated from the posterior samples of 
 #' \eqn{theta}.  This allows customization of exactly what predictive 
-#' distrtibution \eqn{p(y|theta)} to use for calculations.  For more detail
+#' distribution \eqn{p(y|theta)} to use for calculations.  For more detail
 #' on the use of different predictive distributions, see Section 2.5 from Gelman
 #' (2014).  
 #' 
 #' Note that there exist sets of monitored parameters that do not lead to valid
 #' WAIC calculations.  Specifically, for a valid WAIC calculation, every 
 #' stochastic node that a data node depends on must be either monitored, or be
-#' downstream from monitored nodes.  An easy way to ensure this is satsified
+#' downstream from monitored nodes.  An easy way to ensure this is satisfied
 #' is to monitor all top-level parameters in a model (NIMBLE's default).  
 #' However, other combinations of monitored nodes are also valid.  
 #' If \code{enableWAIC = TRUE}, NIMBLE checks to see if the set of monitored 
@@ -77,8 +77,9 @@
 #' code <- nimbleCode({
 #'     mu ~ dnorm(0, 1)
 #'     x ~ dnorm(mu, 1)
+#'     y ~ dnorm(x, 1)
 #' })
-#' Rmodel <- nimbleModel(code)
+#' Rmodel <- nimbleModel(code, data = list(y = 0))
 #' conf <- configureMCMC(Rmodel)
 #' Rmcmc <- buildMCMC(conf, enableWAIC = TRUE)
 #' Cmodel <- compileNimble(Rmodel)

--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -52,9 +52,9 @@
 #' 
 #' The \code{calculateWAIC} method calculates the WAIC of the model that the
 #' MCMC was performed on. The WAIC (Watanabe, 2010) is calculated from
-#' Equations 5, 12, and 13 in Gelman (2014).  The set of all
-#' stochastic nodes monitored by the MCMC object will be treated as \eqn{theta} 
-#' for the purposes of e.g. Equation 5 from Gelman (2014). 
+#' Equations 5, 12, and 13 in Gelman (2014) (i.e. using \emph{p}WAIC2).  The set
+#' of all stochastic nodes monitored by the MCMC object will be treated as
+#' \eqn{theta} for the purposes of e.g. Equation 5 from Gelman (2014). 
 #' All non-monitored nodes downstream of the monitored nodes that are necessary
 #' to calculate \eqn{p(y|theta)} will be simulated from the posterior samples of 
 #' \eqn{theta}.  This allows customization of exactly what predictive 

--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -281,11 +281,4 @@ checkWAICmonitors <- function(model, monitors, dataNodes){
     thisVars <- thisVars[!(thisVars %in% monitors)]
   }
   message(paste0('Monitored nodes are valid for WAIC.'))
-  # simNodes <- model$getDependencies(monitors, self = FALSE,
-  #                                   downstream = TRUE, includeData = FALSE)
-  # if(length(simNodes) > 0){
-  #   message(paste0('The following non-data stochastic nodes will be simulated',
-  #                  ' for WAIC calculation: ', '\n',
-  #                  paste0(simNodes, collapse = ", ")))
-  # }
 }

--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -98,8 +98,7 @@
 #' @export
 buildMCMC <- nimbleFunction(
     name = 'MCMC',
-    setup = function(conf, ..., enableWAIC = FALSE) {
-      if(identical(nimbleOptions('enableWAIC'), TRUE)) enableWAIC <- TRUE
+    setup = function(conf, enableWAIC = nimbleOptions('enableWAIC'), ...) {
     	if(inherits(conf, 'modelBaseClass'))
             conf <- configureMCMC(conf, ...)
 

--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -4,8 +4,8 @@
 #' Accepts a single required argument, which may be of class MCMCconf, or inherit from class modelBaseClass (a NIMBLE model object).  Returns an MCMC function; see details section.
 #'
 #' @param conf An object of class MCMCconf that specifies the model, samplers, monitors, and thinning intervals for the resulting MCMC function.  See \code{configureMCMC} for details of creating MCMCconf objects.  Alternatively, \code{MCMCconf} may a NIMBLE model object, in which case an MCMC function corresponding to the default MCMC configuration for this model is returned.
+#' @param enableWAIC Boolean specifying whether to enable WAIC calculations for this model and set of monitored nodes.  Defaults to the value of \code{nimbleOptions('enableWAIC')}, which in turn defaults to FALSE.  Setting \code{nimbleOptions('enableWAIC' = TRUE)} will ensure that WAIC is enabled for all calls to \code{buildMCMC()}.
 #' @param ... Additional arguments to be passed to \code{configureMCMC} if \code{conf} is a NIMBLE model object
-#' @param enableWAIC Boolean specifying whether to enable WAIC calculations for this model and set of monitored nodes (default = FALSE).
 #'
 #' @details
 #' Calling buildMCMC(conf) will produce an uncompiled (R) R mcmc function object, say 'Rmcmc'.
@@ -95,7 +95,11 @@
 #' 
 #' @author Daniel Turek
 #' 
-#' @export
+#' @references 
+#' Watanabe, S. (2010). Asymptotic equivalence of Bayes cross validation and widely applicable information criterion in singular learning theory. \emph{Journal of Machine Learning Research} 11: 3571-3594.
+#' 
+#' Gelman, A., Hwang, J. and Vehtari, A. (2014). Understanding predictive information criteria for Bayesian models. \emph{Statistics and Computing} 24(6): 997-1016.
+#'   @export
 buildMCMC <- nimbleFunction(
     name = 'MCMC',
     setup = function(conf, enableWAIC = nimbleOptions('enableWAIC'), ...) {

--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -274,7 +274,7 @@ checkWAICmonitors <- function(model, monitors, dataNodes){
     if(any(nextNodes %in% dataNodes)){
       badDataNodes <- dataNodes[dataNodes %in% nextNodes]
       stop(paste0("In order for a valid WAIC calculation, all parameters of",
-                  " data nodes in the model must be montiored, or be", 
+                  " data nodes in the model must be monitored, or be", 
                   " downstream from monitored nodes.", 
                   " See help(buildMCMC) for more information on valid sets of",
                   " monitored nodes for WAIC calculations.", "\n",
@@ -290,7 +290,7 @@ checkWAICmonitors <- function(model, monitors, dataNodes){
                                     downstream = TRUE, includeData = FALSE)
   if(length(simNodes) > 0){
     message(paste0('The following non-data stochastic nodes will be simulated',
-                   ' for WAIC: ', '\n',
+                   ' for WAIC calculation: ', '\n',
                    paste0(simNodes, collapse = ", ")))
   }
 }

--- a/packages/nimble/R/MCMC_run.R
+++ b/packages/nimble/R/MCMC_run.R
@@ -27,7 +27,7 @@
 #' 
 #' @param summary Logical argument.  When \code{TRUE}, summary statistics for the posterior samples of each parameter are also returned, for each MCMC chain.  This may be returned in addition to the posterior samples themselves.  Default value is \code{FALSE}.  See details.
 #'
-#' @param WAIC Logical argument.  When \code{TRUE}, the WAIC (Watanabe, 2010) of the model is calculated and returned.  If multiple chains are run, then a single WAIC value is calculated using the posterior samples from all chains.  Default value is \code{FALSE}.  See details.
+#' @param WAIC Logical argument.  When \code{TRUE}, the WAIC (Watanabe, 2010) of the model is calculated and returned.  Note that in order for the WAIC to be calculated, the \code{mcmc} object must have also been created with the argument `enableWAIC = TRUE`.  If multiple chains are run, then a single WAIC value is calculated using the posterior samples from all chains.  Default value is \code{FALSE}.  See details.
 #'
 #' @return A list is returned with named elements depending on the arguments passed to \code{nimbleMCMC}, unless only one among samples, summary, and WAIC are requested, in which case only that element is returned.  These elements may include \code{samples}, \code{summary}, and \code{WAIC}.  When \code{nchains = 1}, posterior samples are returned as a single matrix, and summary statistics as a single matrix.  When \code{nchains > 1}, posterior samples are returned as a list of matrices, one matrix for each chain, and summary statistics are returned as a list containing \code{nchains+1} matrices: one matrix corresponding to each chain, and the final element providing a summary of all chains, combined.  If \code{samplesAsCodaMCMC} is \code{TRUE}, then posterior samples are provided as \code{coda} \code{mcmc} and \code{mcmc.list} objects.  When \code{WAIC} is \code{TRUE}, a single WAIC value is returned.
 #'
@@ -94,6 +94,7 @@ runMCMC <- function(mcmc,
         if(!is.function(inits) && !is.list(inits)) stop('inits must be a function, a list of initial values, or a list (of length nchains) of lists of inital values')
         if(is.list(inits) && (length(inits) > 0) && is.list(inits[[1]]) && (length(inits) != nchains)) stop('inits must be a function, a list of initial values, or a list (of length nchains) of lists of inital values')
     }
+    if(WAIC == TRUE && mcmc$enableWAIC == FALSE) stop('mcmc argument must have been created with "enableWAIC = TRUE" in order to calculate WAIC.')
     model <- if(is.Cnf(mcmc)) mcmc$Robject$model$CobjectInterface else mcmc$model
     if(!is.model(model)) stop('something went wrong')
     samplesList <- vector('list', nchains)
@@ -262,7 +263,7 @@ nimbleMCMC <- function(code, constants = list(), data = list(), inits, model,
         if(!is.Rmodel(Rmodel)) stop('something went wrong')
     }
     conf <- configureMCMC(Rmodel, monitors = monitors, thin = thin)
-    Rmcmc <- buildMCMC(conf)
+    Rmcmc <- buildMCMC(conf, enableWAIC = WAIC)
     compiledList <- compileNimble(Rmodel, Rmcmc)    ## only one compileNimble() call
     Cmcmc <- compiledList$Rmcmc
     nburnin <- ceiling(nburnin/thin)    ## accounts for thinning *first*, then dropping burnin

--- a/packages/nimble/R/options.R
+++ b/packages/nimble/R/options.R
@@ -57,8 +57,9 @@ nimbleUserNamespace <- as.environment(list(sessionSpecificDll = NULL))
         ## value is set to samplerAssignmentRules() (the defaults) in MCMC_configuration.R
         MCMCuseSamplerAssignmentRules = FALSE,
         saveMCMChistory = FALSE,
-        MCMCdefaultSamplerAssignmentRules = NULL
+        MCMCdefaultSamplerAssignmentRules = NULL,
         
+        enableWAIC = FALSE
         ## default settings for MCMC samplers
         ## control list defaults for MCMC samplers are
         ## now part of the sampler functions (setup code).

--- a/packages/nimble/inst/tests/test-waic.R
+++ b/packages/nimble/inst/tests/test-waic.R
@@ -40,7 +40,7 @@ test_that("school model WAIC is accurate", {
   expect_equal(CschoolSATmcmc$calculateWAIC(), 61.8, tolerance = 2.0)
   schoolSATmcmcConf <- configureMCMC(schoolSATmodel, monitors = c('mu', 'itau'))
   expect_message(buildMCMC(schoolSATmcmcConf, enableWAIC = TRUE), 
-  "The following non-data stochastic nodes will be simulated for WAIC: \nlifted_d1_over_sqrt_oPitau_cP, schoolmean[1], schoolmean[2], schoolmean[3], schoolmean[4], schoolmean[5], schoolmean[6], schoolmean[7], schoolmean[8]\n",
+  "Monitored nodes are valid for WAIC.",
   all = FALSE, fixed = TRUE)
   schoolSATmcmcConf <- configureMCMC(schoolSATmodel, monitors = c('mu'))
   expect_error(buildMCMC(schoolSATmcmcConf, enableWAIC = TRUE))

--- a/packages/nimble/inst/tests/test-waic.R
+++ b/packages/nimble/inst/tests/test-waic.R
@@ -44,6 +44,17 @@ test_that("school model WAIC is accurate", {
   all = FALSE, fixed = TRUE)
   schoolSATmcmcConf <- configureMCMC(schoolSATmodel, monitors = c('mu'))
   expect_error(buildMCMC(schoolSATmcmcConf, enableWAIC = TRUE))
+  ## different set of monitors than above, so different waic value expected
+  expect_equal(nimbleMCMC(model = schoolSATmodel, WAIC = TRUE)$WAIC, 67, 
+               tolerance = 8) 
+  schoolSATmcmcConf <- configureMCMC(schoolSATmodel, monitors = c('schoolmean'))
+  schoolSATmcmc <- buildMCMC(schoolSATmcmcConf, enableWAIC = TRUE)
+  CschoolSATmcmc <- compileNimble(schoolSATmcmc, project = schoolSATmodel, 
+                                  resetFunctions = TRUE)
+  expect_equal(runMCMC(CschoolSATmcmc, WAIC = TRUE)$WAIC, 61.8, 
+               tolerance = 2) 
+  schoolSATmcmc <- buildMCMC(schoolSATmcmcConf, enableWAIC = FALSE)
+  expect_error(runMCMC(schoolSATmcmc, WAIC = TRUE))
 })
 
 test_that("voter model WAIC is accurate", {

--- a/packages/nimble/inst/tests/test-waic.R
+++ b/packages/nimble/inst/tests/test-waic.R
@@ -70,7 +70,7 @@ test_that("voter model WAIC is accurate", {
   CvoterModel <- compileNimble(voterModel)
   votermcmcConf <- configureMCMC(voterModel, monitors = c('beta_1', 'beta_2',
                                                           'sigma'))
-  votermcmc <- buildMCMC(votermcmcConf)
+  votermcmc <- buildMCMC(votermcmcConf, enableWAIC = TRUE)
   temporarilyAssignInGlobalEnv(votermcmc)
   Cvotermcmc <- compileNimble(votermcmc, project = voterModel)
   Cvotermcmc$run(50000)
@@ -102,7 +102,7 @@ test_that("Radon model WAIC is accurate", {
   temporarilyAssignInGlobalEnv(radonModel)
   CradonModel <- compileNimble(radonModel)
   radonmcmcConf <- configureMCMC(radonModel, monitors = c('beta'))
-  radonmcmc <- buildMCMC(radonmcmcConf)
+  radonmcmc <- buildMCMC(radonmcmcConf, enableWAIC = TRUE)
   temporarilyAssignInGlobalEnv(radonmcmc)
   Cradonmcmc <- compileNimble(radonmcmc, project = radonModel)
   Cradonmcmc$run(10000)

--- a/packages/nimble/inst/tests/test-waic.R
+++ b/packages/nimble/inst/tests/test-waic.R
@@ -33,11 +33,17 @@ test_that("school model WAIC is accurate", {
   temporarilyAssignInGlobalEnv(schoolSATmodel)
   compileNimble(schoolSATmodel)
   schoolSATmcmcConf <- configureMCMC(schoolSATmodel, monitors = c('schoolmean'))
-  schoolSATmcmc <- buildMCMC(schoolSATmcmcConf)
+  schoolSATmcmc <- buildMCMC(schoolSATmcmcConf, enableWAIC = TRUE)
   temporarilyAssignInGlobalEnv(schoolSATmcmc)
   CschoolSATmcmc <- compileNimble(schoolSATmcmc, project = schoolSATmodel)
   CschoolSATmcmc$run(50000)
   expect_equal(CschoolSATmcmc$calculateWAIC(), 61.8, tolerance = 2.0)
+  schoolSATmcmcConf <- configureMCMC(schoolSATmodel, monitors = c('mu', 'itau'))
+  expect_message(buildMCMC(schoolSATmcmcConf, enableWAIC = TRUE), 
+  "The following non-data stochastic nodes will be simulated for WAIC: \nlifted_d1_over_sqrt_oPitau_cP, schoolmean[1], schoolmean[2], schoolmean[3], schoolmean[4], schoolmean[5], schoolmean[6], schoolmean[7], schoolmean[8]\n",
+  all = FALSE, fixed = TRUE)
+  schoolSATmcmcConf <- configureMCMC(schoolSATmodel, monitors = c('mu'))
+  expect_error(buildMCMC(schoolSATmcmcConf, enableWAIC = TRUE))
 })
 
 test_that("voter model WAIC is accurate", {


### PR DESCRIPTION
This PR adds a check to ensure that, if a user would like to calculate a WAIC value, this value will be valid.  It also fixes a bug where downstream nodes were not simulated during WAIC calculation for certain combinations of models and monitors.  The following features are added:

1. A new argument to `buildMCMC()` named `enableWAIC`, which defaults to `FALSE`.  If a user sets `enableWAIC = TRUE`, pre-processing is executed to calculate the necessary sets of nodes for WAIC calculation, and a check is run to ensure that the set of nodes monitored by the MCMC will lead to a valid WAIC calculation.  If a user sets `enableWAIC = FALSE`, no pre-processing or checking will occur.  

2. There is also a nimble option, likewise named `enableWAIC`, that defaults to `FALSE`.  If `nimbleOptions(enableWAIC)` is set to `TRUE`, then WAIC calculations will be enabled for all calls to `buildMCMC`. 

3. A bug where downstream dependencies were not being simulated for certain combinations of models and monitored nodes has been fixed.

4. The function `checkWAICmonitors` now checks to ensure that the set of nodes monitored by the mcmc algorithm lead to a valid WAIC calculation.  If the calculation is not valid, the following error message is printed:
```
"In order for a valid WAIC calculation, all parameters of data nodes in the model must be monitored, or be downstream from monitored nodes.   See help(buildMCMC) for more information on valid sets of monitored nodes for WAIC calculations.
Currently, the following data nodes have un-monitored upstream parameters: ...
```
The first 10 such data nodes will be printed in the above message to keep the error relatively short.

If the calculation is valid, the following informational message is printed:
```
"Monitored nodes are valid for WAIC.  
```

A few questions for @danielturek, although @perrydv and @paciorek please let me know if you have any thoughts too :

1. I've added the `enableWAIC` argument to `buildMCMC`'s setup function after the current two arguments (`conf` and `...`).  This seemed much preferable to adding the `enableWAIC` argument before `...` (which would break existing code), but since `enableWAIC` comes after `...`, I believe that means that a user must set the argument by name instead of using positional argument matching (since the `...` can take an arbitrary number of arguments).  I think an alternative would be to package `enableWAIC` into `...` if you feel that's preferable.  

2. I changed the example model in the MCMC help documentation slightly (added an additional data node).  The original model had no data nodes, so in fact, the WAIC could not be calculated for it.  Let me know if you'd like me to undo this change or use a different example model. 

Thanks!


