### PR TITLE
push parse step of parseEvalNumericManyList to C++

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -2878,12 +2878,15 @@ parseEvalNumericMany <- function(x, env) {
     )
 }
 
+
 parseEvalNumericManyList <- function(x, env) {
     withCallingHandlers(
-        if(length(x) > 1) {
-            eval(parse(text = paste0('list(', paste0("as.numeric(",x,")", collapse=','),')'), keep.source = FALSE)[[1]], envir = env)
-        } else 
-            eval(parse(text = paste0('list(as.numeric(',x,'))'), keep.source = FALSE)[[1]], envir = env)
+        eval(.Call(makeParsedVarList, x), envir = env)
+        ## Above line replaces:
+        ## if(length(x) > 1) {
+        ##     eval(parse(text = paste0('list(', paste0("as.numeric(",x,")", collapse=','),')'), keep.source = FALSE)[[1]], envir = env)
+        ## } else 
+        ##     eval(parse(text = paste0('list(as.numeric(',x,'))'), keep.source = FALSE)[[1]], envir = env)
        ,
         error = function(cond) {
             parseEvalNumericManyHandleError(cond, x, env)

--- a/packages/nimble/inst/include/nimble/RcppUtils.h
+++ b/packages/nimble/inst/include/nimble/RcppUtils.h
@@ -43,6 +43,12 @@ using namespace std;
 #define Inf R_PosInf
 #define NA 0
 
+class varAndIndicesClass {
+public:
+  std::string varName;
+  std::vector< std::vector<int> > indices;
+};
+
 #define SET_NEXT_LANG_ARG(SLANG, ARGNAME) SETCAR(SLANG, ARGNAME); \
   SLANG = CDR(SLANG);
 
@@ -77,6 +83,7 @@ void populate_SEXP_2_double_for_copyFromRobject(void *vPtr, SEXP rScalar);
 void populate_SEXP_2_int_for_copyFromRobject(void *vPtr, SEXP rScalar);
 void populate_SEXP_2_bool_for_copyFromRobject(void *vPtr, SEXP rScalar);
 
+void parseVarAndInds(const std::string &input, varAndIndicesClass &output);
 extern "C" {
   SEXP populate_SEXP_2_double(SEXP rPtr, SEXP refNum, SEXP rScalar);
   SEXP extract_double_2_SEXP(SEXP rPtr, SEXP refNum);
@@ -97,6 +104,7 @@ extern "C" {
   SEXP C_rankSample(SEXP p, SEXP n, SEXP not_used, SEXP s);
 
   SEXP parseVar(SEXP Sinput);
+  SEXP makeParsedVarList(SEXP Sx);
 }
 
 void rawSample(double* p, int c_samps, int N, int* ans, bool unsort, bool silent);

--- a/packages/nimble/src/nimble.cpp
+++ b/packages/nimble/src/nimble.cpp
@@ -57,7 +57,7 @@ R_CallMethodDef CallEntries[] = {
  FUN(matrix2ListInt, 5),
  FUN(C_rankSample, 4),
  FUN(parseVar, 1),
-
+ FUN(makeParsedVarList, 1),
  FUN(C_setGraph, 7),
  FUN(C_anyStochDependencies, 1),
  FUN(C_anyStochParents, 1),


### PR DESCRIPTION
This PR moves a costly step in lots of model processing into C++.  On one example model, configureMCMC with useConjugacy = FALSE saves 40% from this change.