### PR TITLE
make checkMultiVarExpr optional

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -152,7 +152,8 @@ modelDefClass$methods(setupModel = function(code, constants, dimensions, inits, 
     addMissingIndexing()              ## overwrites declInfo, using dimensionsList, fills in any missing indexing
     processBoundsAndTruncation()      ## puts bound expressions into declInfo, including transforming T(ddist(),lower,upper); need to do this before expandDistributions(), which is not set up to handle T() wrapping; need to save bound info for later use in reparameterizeDists() -- hence temporarily stored in boundExprs (can't put in code because it would be stripped out in expandDistributions, though alternative is to modify expandDistributions to add lower,upper back into code)
     expandDistributions()             ## overwrites declInfo for stochastic nodes: calls match.call() on RHS      (uses distributions$matchCallEnv)
-    checkMultivarExpr()               ## checks that multivariate params are not expressions
+    if(getNimbleOption('disallow_multivariate_argument_expressions'))
+       checkMultivarExpr()               ## checks that multivariate params are not expressions
     processLinks()                    ## overwrites declInfo (*and adds*) for nodes with link functions           (uses linkInverses)
     reparameterizeDists()             ## overwrites declInfo when distribution reparameterization is needed       (uses distributions), keeps track of orig parameter in .paramName; also processes bound info to evaluate in context of model
     replaceAllConstants()

--- a/packages/nimble/R/options.R
+++ b/packages/nimble/R/options.R
@@ -7,6 +7,7 @@ nimbleUserNamespace <- as.environment(list(sessionSpecificDll = NULL))
 # These options are for development use at this point.
 .nimbleOptions <- as.environment(
     list(
+        disallow_multivariate_argument_expressions = TRUE,
         stop_after_processing_model_code = FALSE,
         enableModelMacros = FALSE,
         allowDynamicIndexing = TRUE,


### PR DESCRIPTION
This PR provides a short-term work-around for issue #684.  It simply provides a new nimbleOption, `disallow_multivariate_argument_expressions`.  If this option is set to `FALSE` (it's default is `TRUE`, yielding current behavior), then the step of checking for expressions in multivariate arguments is simply skipped. This will allow users a path to build a model such as the example given in the Issue.

This seems sufficiently minor and does not change regular behavior that it could be squeezed in 0.6-10, but it is also fine if not.

