### PR TITLE
Fix setInits in complicated cases

### DIFF
--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -818,7 +818,7 @@ inits: A named list.  The names of list elements must correspond to model variab
                                           if(any(dataVals)) {
                                               .self[[names(inits)[i]]][!dataVals] <- inits[[i]][!dataVals]
                                               if(any(!is.na(inits[[i]][dataVals])))
-                                                  warning("Ignoring elements in inits for data nodes: ", names(inits)[[i]], ".", call. = FALSE)
+                                                  warning("Ignoring some or all values in inits for data nodes: ", names(inits)[[i]], ".", call. = FALSE)
                                           } else  .self[[names(inits)[i]]] <- inits[[i]]
                                       }
                                   },

--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -813,11 +813,12 @@ inits: A named list.  The names of list elements must correspond to model variab
                                       origInits <<- inits
 
                                       for(i in seq_along(inits)) {
-                                          dataVals <- .self$isData(names(inits)[[i]])
+                                          ##dataVals <- .self$isData(names(inits)[[i]])
+                                          dataVals <- .self$isDataEnv[[names(inits)[[i]] ]]
                                           if(any(dataVals)) {
                                               .self[[names(inits)[i]]][!dataVals] <- inits[[i]][!dataVals]
                                               if(any(!is.na(inits[[i]][dataVals])))
-                                                  warning("Ignoring values in inits for data nodes: ", names(inits)[[i]], ".")
+                                                  warning("Ignoring elements in inits for data nodes: ", names(inits)[[i]], ".", call. = FALSE)
                                           } else  .self[[names(inits)[i]]] <- inits[[i]]
                                       }
                                   },

--- a/packages/nimble/inst/tests/test-misc.R
+++ b/packages/nimble/inst/tests/test-misc.R
@@ -189,5 +189,37 @@ test_that("pi case 3", {
     }
 )
 
+## From GitHub Issue #695
+test_that("setInits works in complicated case", {
+    mc1 <- nimbleCode({
+        for(i in 1:2) {
+            for(j in f[i]:n) {
+                x[i, j] ~ dnorm(0,1)
+            }
+        }
+    })
+    inits = list(x = matrix(1:6, nrow = 2))
+    data = list(x = matrix(c(100, NA, 100, NA, NA, NA), nrow = 2))
+    m <- nimbleModel(mc1,
+                     constants = list(f = c(1, 2),
+                                      n = 3),
+                     data = data,
+                     inits = inits)
+    ## This model defines x[1, 1], x[1, 2], x[1, 3], x[2, 2], and x[2, 3]. 
+    ## x[2,1] is not a node in the model.
+    ## data are provided for x[1, 1] and x[1, 2]
+
+    ##m$x ## This is wrong
+    ##       [,1] [,2] [,3]
+    ##[1,]   100   3    5
+    ##[2,]   NA    4    NA
+    ##matrix(c(100, 2, 100, 4, 5, 6), nrow = 2) ## It should be this
+    ##       [,1] [,2] [,3]
+    ##[1,]  100  100    5
+    ##[2,]    2    4    6
+    expect_equal(m$x, matrix(c(100, 2, 100, 4, 5, 6), nrow = 2))
+}
+)
+
 options(warn = RwarnLevel)
 nimbleOptions(verbose = nimbleVerboseSetting)

--- a/packages/nimble/inst/tests/test-models.R
+++ b/packages/nimble/inst/tests/test-models.R
@@ -367,7 +367,7 @@ test_that("test of preventing overwriting of data values by inits:", {
     })
     xVal <- c(3, NA)
     xInit <- c(4, 4)
-    expect_warning(m <- nimbleModel(code, constants = list(x = xVal), inits = list(x = xInit)), "Ignoring values in inits for data nodes")
+    expect_warning(m <- nimbleModel(code, constants = list(x = xVal), inits = list(x = xInit)), "Ignoring some or all values in inits for data nodes")
     expect_equal(m$isData('x'), c(TRUE, FALSE), info = "'x' data flag is not set correctly in fourth test")
     expect_equal(m$x, c(xVal[1], xInit[2]), info = "value of 'x' not correctly set in fourth test")
     expect_equal(c('x[1]','x[2]') %in% m$getNodeNames(), c(TRUE, TRUE), info = "'x' nodes note correctly set in fourth test")

--- a/packages/nimble/inst/tests/test-models.R
+++ b/packages/nimble/inst/tests/test-models.R
@@ -377,7 +377,7 @@ test_that("test of preventing overwriting of data values by inits:", {
         x[2] ~ dnorm(mu,1)
         mu ~ dnorm(0, 1)
     })
-    expect_warning(m <- nimbleModel(code, data = list(x = xVal), inits = list(x = xInit)), "Ignoring values in inits for data nodes")
+    expect_warning(m <- nimbleModel(code, data = list(x = xVal), inits = list(x = xInit)), "Ignoring some or all values in inits for data nodes")
     expect_equal(m$isData('x'), c(TRUE, FALSE), info = "'x' data flag is not set correctly in fifth test")
     expect_equal(m$x, c(xVal[1], xInit[2]), info = "value of 'x' not correctly set in fifth test")
     expect_equal(c('x[1]','x[2]') %in% m$getNodeNames(), c(TRUE, TRUE), info = "'x' nodes note correctly set in fifth test")


### PR DESCRIPTION
Fixes #695 

`model$setInits` uses `model$isData()` to look up what nodes in a variable are data.  This goes wrong if not all elements in a variable were defined as nodes.  The problem is that `model$isData` returns a logical vector of the wrong length, which is then used according to the recycling rule to index elements of the inits variable.

The proposed solution uses logical variables in `model$isDataEnv` directly.  This should work because setInits always operates for whole variables (skipping any `NA` elements).
