### PR TITLE
make AF_slice enforce correct topological order in calculate()

### DIFF
--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -658,9 +658,12 @@ sampler_AF_slice <- nimbleFunction(
                 for(i in 1:d)
                     if(discrete[i] == 1)   targetValues[i] <- floor(targetValues[i])            
             values(model, target) <<- targetValues
-            lp <- calculate(model, target)
-            if(lp == -Inf) return(-Inf) # deals with dynamic index out of bounds
-            lp <- lp + calculate(model, calcNodesNoSelf)
+            lp <- model$calculate(calcNodes)
+            ## Following lines were intended to prevent bugs in dynamic index cases,
+            ## but in other cases they violate topological ordering.
+            ##            lp <- calculate(model, target)
+            ##            if(lp == -Inf) return(-Inf) # deals with dynamic index out of bounds
+            ##            lp <- lp + calculate(model, calcNodesNoSelf)
             returnType(double())
             return(lp)
         },


### PR DESCRIPTION
A previous attempt to avoid problems with dynamic indices led to an error in respecting topological ordering of nodes.  This is a short-term fix for devel while we discuss a more permanent fix.