### PR TITLE
If returnType() is provided, check that there is a return.

### DIFF
--- a/packages/nimble/R/RCfunction_core.R
+++ b/packages/nimble/R/RCfunction_core.R
@@ -80,7 +80,7 @@ nfMethodRC <- setRefClass(
                 nf_checkDSLcode(code, methodNames, setupVarNames)
             generateArgs()
             generateTemplate() ## used for argument matching
-            removeAndSetReturnType()
+            removeAndSetReturnType(check = check)
             ## Includes for .h and .cpp files when making external calls:
             ## If needed, these will be populated by nimbleExternalCall
             externalHincludes <<- externalCPPincludes <<- list() 
@@ -99,7 +99,8 @@ nfMethodRC <- setRefClass(
             functionAsList[[3]] <- quote({})
             template <<- eval(as.call(functionAsList))
         },
-        removeAndSetReturnType = function() {
+        removeAndSetReturnType = function(check = TRUE) {
+            ## check will be FALSE in the case of a virtualNimbleFunction method
             returnLineNum <- 0
             for(i in seq_along(code)) {
                 if(length(code[[i]]) > 1) {
@@ -112,7 +113,7 @@ nfMethodRC <- setRefClass(
                 }
             }
             if(sum(all.names(code) == 'returnType') > 1)
-                stop('multiple returnType() declarations in nimbleFunction method; only one allowed')
+                stop('multiple returnType() declarations in nimbleFunction method; only one allowed', call. = FALSE)
             if(returnLineNum == 0) {
                 ## no returnType() declaration was found;
                 ## create default behavior.
@@ -120,6 +121,14 @@ nfMethodRC <- setRefClass(
             } else {
                 ## returnType() declaration was found
                 returnTypeDeclaration <- code[[returnLineNum]][[2]]
+                ## Check that there is at least one return() statement
+                if(check) {
+                    if(!("return" %in% all.names(code))) {
+                        writeLines("Problem in this code:")
+                        writeLines(deparse(code))
+                        stop('returnType() declaration was provided but there is no return() statement.  At least one return() statement must be provided', call. = FALSE)
+                    }
+                }
                 code[returnLineNum] <<- NULL
             }
             ## a very patchy solution: switch nimInteger back to integer

--- a/packages/nimble/inst/tests/test-misc.R
+++ b/packages/nimble/inst/tests/test-misc.R
@@ -221,5 +221,17 @@ test_that("setInits works in complicated case", {
 }
 )
 
+test_that("missing return statement is trapped",
+{
+    ## capture.output here just suppresses the print()ed error
+    ## message to keep it out of Travis log files.
+    expect_error(msg <- capture.output({a <- nimbleFunction(
+                                            run = function() {
+                                                returnType(double(1))
+                                                out <- rnorm(10, 0, 1)
+                                            })}),
+                 info = "error-trapping missing return statement")
+})
+
 options(warn = RwarnLevel)
 nimbleOptions(verbose = nimbleVerboseSetting)


### PR DESCRIPTION
Fixes #669.

It appears that in C++ a missing return statement yields undefined behavior, and this is giving us a crash.

I added a check when the returnType() statement is extracted.  If there is a returnType statement, and if it is not in a virtualNimbleFunction, then I added a simple check for the presence of `return` in the code.  Note that incorrect return types are (or should be) trapped at another stage.  This simply makes sure there is a return statement somewhere in the code.  It would take more work to ensure that every path through the code ends in a return statement.