### PR TITLE
allow "to" to be a CmodelValues in R version of nimCopy

### DIFF
--- a/packages/nimble/R/nimbleFunction_Rexecution.R
+++ b/packages/nimble/R/nimbleFunction_Rexecution.R
@@ -711,7 +711,7 @@ nimCopy <- function(from, to, nodes = NULL, nodesTo = NULL, row = NA, rowTo = NA
         else
             accessTo = modelVariableAccessorVector(to, nodesTo, logProb = logProb)
     } else
-        if(inherits(to, "modelValuesBaseClass")) {
+        if(inherits(to, "modelValuesBaseClass") || inherits(to, "CmodelValues")) {
             if(is.null(nodesTo) ) 
                 accessTo = modelValuesAccessorVector(to, nodes, logProb = logProb)
             else


### PR DESCRIPTION
Fixes #659 

This turned out to be an easy fix.  Error-trapping in uncompiled `nimCopy` accidentally did not allow `to` to be a `CmodelValues`, but simply allowing this makes it work.