### PR TITLE
Fix bug and update help for bootstrap filter.

### DIFF
--- a/packages/nimble/R/filtering_auxiliary.R
+++ b/packages/nimble/R/filtering_auxiliary.R
@@ -222,8 +222,10 @@ return(0)
 #' 
 #' @description Create an auxiliary particle filter algorithm for a given NIMBLE state space model.  
 #'
-#' @param model A NIMBLE model object, typically representing a state space model or a hidden Markov model
-#' @param nodes A character vector specifying the latent model nodes over which the particle filter will stochastically integrate to estimate the log-likelihood function
+#' @param model A NIMBLE model object, typically representing a state space model or a hidden Markov model.
+#' @param nodes A character vector specifying the latent model nodes 
+#'  over which the particle filter will stochastically integrate over to
+#'  estimate the log-likelihood function.  All provided nodes must be stochastic, and must come from the same variable in the model. 
 #' @param control  A list specifying different control options for the particle filter.  Options are described in the details section below.
 #' @author  Nicholas Michaud
 #' @details 

--- a/packages/nimble/R/filtering_bootstrap.R
+++ b/packages/nimble/R/filtering_bootstrap.R
@@ -165,7 +165,7 @@ bootFStep <- nimbleFunction(
 #'
 #' @param model A nimble model object, typically representing a state 
 #'  space model or a hidden Markov model.
-#' @param nodes A string, or vector of strings, specifying the latent model nodes 
+#' @param nodes A character vector specifying the latent model nodes 
 #'  over which the particle filter will stochastically integrate over to
 #'  estimate the log-likelihood function.  All provided nodes must be stochastic, and must come from the same variable in the model. 
 #' @param control  A list specifying different control options for the particle filter.  Options are described in the details section below.

--- a/packages/nimble/R/filtering_enkf.R
+++ b/packages/nimble/R/filtering_enkf.R
@@ -204,7 +204,8 @@ ENKFStep <- nimbleFunction(
 #' @description Create an Ensemble Kalman filter algorithm for a given NIMBLE state space model.  
 #'
 #' @param model A NIMBLE model object, typically representing a state space model or a hidden Markov model
-#' @param nodes A character vector specifying the latent model nodes which the Ensemble Kalman filter will estimate.
+#' @param nodes A character vector specifying the latent model nodes 
+#'  the Ensemble Kalman Filter will estimate.  All provided nodes must be stochastic, and must come from the same variable in the model. 
 #' @param control  A list specifying different control options for the particle filter.  Options are described in the details section below.
 #' @author Nicholas Michaud
 #' @family particle filtering methods

--- a/packages/nimble/R/filtering_liuwest.R
+++ b/packages/nimble/R/filtering_liuwest.R
@@ -321,7 +321,7 @@ LWparFunc <- nimbleFunction(
 #'  space model or a hidden Markov model
 #' @param nodes A character vector specifying the latent model nodes 
 #'  over which the particle filter will stochastically integrate over to
-#'  estimate the log-likelihood function
+#'  estimate the log-likelihood function.  All provided nodes must be stochastic, and must come from the same variable in the model. 
 #' @param params A character vector specifying the top-level parameters to estimate the posterior distribution of. 
 #'   If unspecified, parameter nodes are specified as all stochastic top level nodes which
 #'  are not in the set of latent nodes specified in \code{nodes}.


### PR DESCRIPTION
This PR fixes a bug in the bootstrap filter, where weights were being calculated incorrectly in the case that particles were not resampled at the previous time point.  Additionally, it clarifies in the help text for the `buildBootstrapFilter` function that the particles stored in `mvEWSamples` may not, in fact, be equally weighted if `thresh < 1`.

@paciorek @perrydv @danielturek  I also attempted to fix #761 by updating the text for the `nodes` argument for all particle filters.  Let me know if you are okay with the new text, or if you have any suggestions for further changes.  It occurs to me that we could check that all `node`s provided to PFs are in fact stochastic, which may help to avoid future confusion, but I haven't implemented that here.