### PR TITLE
change a min() to max() in test-trunc

### DIFF
--- a/packages/nimble/inst/tests/test-trunc.R
+++ b/packages/nimble/inst/tests/test-trunc.R
@@ -131,7 +131,7 @@ test_that("Test that MCMC respects truncation bounds", {
     Cmcmc$run(5000)
     smp <- as.matrix(Cmcmc$mvSamples)
     expect_gt(min(smp), 0.2, label = "minimum in MCMC", expected.label = "lower bound")
-    expect_lt(min(smp), 2, label = "maximum in MCMC", expected.label = "upper bound")
+    expect_lt(max(smp), 2, label = "maximum in MCMC", expected.label = "upper bound")
 
     test_mcmc(model = code, data = c(data, constants), inits = inits,
               results = list(mean = list(mu = 1.5), sd = list(mu = .27 )),


### PR DESCRIPTION
@paciorek I think this two-character change in test-trunc fixes a typo.  First there is a check that the min of an MCMC sample is greater than the truncation lower bound.  Then there is what looks like it should check that the max of the sample is less than the truncation upper bound.  But it was using min instead of max.  Please confirm.