### PR TITLE
enhanced error message for disallowed indexing in model code

### DIFF
--- a/packages/nimble/R/BUGS_BUGSdecl.R
+++ b/packages/nimble/R/BUGS_BUGSdecl.R
@@ -366,7 +366,7 @@ makeIndexNamePieces <- function(indexCode) {
     if(as.character(indexCode[[1]] != ':'))
         stop(paste0("Error processing model: something is wrong with the index ",
                     deparse(indexCode),
-                    "."),
+                    ".\nIndexing in model code requires this syntax: '(start expression):(end expression)'."),
              call. = FALSE)
     p1 <- indexCode[[2]]
     p2 <- indexCode[[3]]


### PR DESCRIPTION
This addresses #754 by telling users:
```
Indexing in model code requires this syntax: '(start expression):(end expression)'.
```

Only a change to the message, but running through tests via PR anyway.