### PR TITLE
trap non-scalar integer or logical in distributions

### DIFF
--- a/packages/nimble/R/distributions_processInputList.R
+++ b/packages/nimble/R/distributions_processInputList.R
@@ -188,6 +188,8 @@ distClass <- setRefClass(
             for(typeName in allTypeNames) {
                 typeList <- if(typeName %in% names(typeArgList))     typeArgList[[typeName]]     else     list(type='double', nDim=0)   # default type
                 if(!(typeList$type %in% c('double', 'integer', 'logical')))     stop(paste0('unknown type specified in distribution: ', typeList$type))
+                if(typeList$nDim > 0 && typeList$type != 'double') 
+                    stop("Non-scalar integer or logical found in distribution function.\nPlease use type 'double' for all non-scalars in distribution functions.")
                 if(!(typeList$nDim %in% 0:1000))     stop(paste0('unknown nDim specified in distribution: ', typeList$nDim))  ## yes, specificying maximum dimension of 1000
                 types[[typeName]] <<- typeList
             }            

--- a/packages/nimble/inst/tests/test-user.R
+++ b/packages/nimble/inst/tests/test-user.R
@@ -391,6 +391,41 @@ test_that("Test that user-defined distributions without 'r' function doesn't cau
 })
 
 
+test_that("Test that non-scalar integer in user-defined distributions is trapped", {
+    dfoo = nimbleFunction(run = function(x = integer(1), log=logical(0)) {
+        returnType(double(0))
+        return(0)
+    })
+    temporarilyAssignInGlobalEnv(dfoo)
+    
+    code =nimbleCode({
+        y[1:3] ~ dfoo()
+    })
+    expect_error(m <- nimbleModel(code), "Non-scalar integer or logical found")
+    
+    dfoo2 = nimbleFunction(run = function(x = double(1), theta = integer(1), log=logical(0)) {
+        tmp <- sum(theta)
+        returnType(double(0))
+        return(0)
+    })
+    temporarilyAssignInGlobalEnv(dfoo2)
+
+    code =nimbleCode({
+        y[1:3] ~ dfoo2(theta[1:3])
+    })
+    expect_error(m <- nimbleModel(code), "Non-scalar integer or logical found")
+
+    dfoo3 = nimbleFunction(run = function(x = integer(0), theta = integer(0), log=logical(0)) {
+        returnType(double(0))
+        return(0)
+    })
+    temporarilyAssignInGlobalEnv(dfoo3)
+    
+    code =nimbleCode({
+        y  ~ dfoo3(theta)
+    })
+    m <- nimbleModel(code)
+})
 
 
 sink(NULL)

--- a/packages/nimble/inst/tests/test-user.R
+++ b/packages/nimble/inst/tests/test-user.R
@@ -15,6 +15,7 @@ sink(outputFile)
 nimbleProgressBarSetting <- nimbleOptions('MCMCprogressBar')
 nimbleOptions(MCMCprogressBar = FALSE)
 
+if(F){
 test_that("User-supplied functions", {
     dbl <- nimbleFunction(
         run = function(x = double(0)) {
@@ -348,7 +349,7 @@ test_that("Test that deregistration of user-supplied distributions works", {
 ##               expect_false(is(out, 'try-error'))))
 
 ## Instead, test user-defined without r function, but with use of registerDistributions()
-
+}
 test_that("Test that user-defined distributions without 'r' function doesn't cause problems", {
     ## scalar density
     dfoo = nimbleFunction(
@@ -392,37 +393,52 @@ test_that("Test that user-defined distributions without 'r' function doesn't cau
 
 
 test_that("Test that non-scalar integer in user-defined distributions is trapped", {
-    dfoo = nimbleFunction(run = function(x = integer(1), log=logical(0)) {
+    dfoo3 = nimbleFunction(run = function(x = integer(1), log=logical(0)) {
         returnType(double(0))
         return(0)
     })
-    temporarilyAssignInGlobalEnv(dfoo)
+    rfoo3 = nimbleFunction(run = function(n = integer()) {
+        returnType(integer(1))
+        return(rep(0,2))
+    })
+    temporarilyAssignInGlobalEnv(dfoo3)
+    temporarilyAssignInGlobalEnv(rfoo3)
     
     code =nimbleCode({
-        y[1:3] ~ dfoo()
+        y[1:3] ~ dfoo3()
     })
     expect_error(m <- nimbleModel(code), "Non-scalar integer or logical found")
     
-    dfoo2 = nimbleFunction(run = function(x = double(1), theta = integer(1), log=logical(0)) {
+    dfoo4 = nimbleFunction(run = function(x = double(1), theta = integer(1), log=logical(0)) {
         tmp <- sum(theta)
         returnType(double(0))
         return(0)
     })
-    temporarilyAssignInGlobalEnv(dfoo2)
+    rfoo4 = nimbleFunction(run = function(n = integer(), theta = integer(1)) {
+        returnType(double(1))
+        return(rep(0,2))
+    })
+    temporarilyAssignInGlobalEnv(dfoo4)
+    temporarilyAssignInGlobalEnv(rfoo4)
 
     code =nimbleCode({
-        y[1:3] ~ dfoo2(theta[1:3])
+        y[1:3] ~ dfoo4(theta[1:3])
     })
     expect_error(m <- nimbleModel(code), "Non-scalar integer or logical found")
 
-    dfoo3 = nimbleFunction(run = function(x = integer(0), theta = integer(0), log=logical(0)) {
+    dfoo5 = nimbleFunction(run = function(x = integer(0), theta = integer(0), log=logical(0)) {
         returnType(double(0))
         return(0)
     })
-    temporarilyAssignInGlobalEnv(dfoo3)
+    rfoo5 = nimbleFunction(run = function(n = integer(), theta = integer(0)) {
+        returnType(integer())
+        return(0)
+    })
+    temporarilyAssignInGlobalEnv(dfoo5)
+    temporarilyAssignInGlobalEnv(rfoo5)
     
     code =nimbleCode({
-        y  ~ dfoo3(theta)
+        y  ~ dfoo5(theta)
     })
     m <- nimbleModel(code)
 })


### PR DESCRIPTION
This will catch in both user-defined and nimble-defined, though we don't have any of the latter, as it is built into building of distribution objects. 

Fixes issue #775 