### PR TITLE
use symbolicParentNodesReplaced in findDynamicIndexParticipants

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -1833,8 +1833,8 @@ modelDefClass$methods(findDynamicIndexParticipants = function() {
         for(iDI in seq_along(declInfo)) {
             if(declInfo[[iDI]]$type == "unknownIndex") next
             declInfo[[iDI]]$dynamicIndexInfo <<- list()
-            for(iSPN in seq_along(declInfo[[iDI]]$symbolicParentNodes)) {
-                symbolicParent <- declInfo[[iDI]]$symbolicParentNodes[[iSPN]]
+            for(iSPN in seq_along(declInfo[[iDI]]$symbolicParentNodesReplaced)) {
+                symbolicParent <- declInfo[[iDI]]$symbolicParentNodesReplaced[[iSPN]]
                 dynamicIndexes <- detectDynamicIndexes(symbolicParent)
                 ## We do not yet check bounds of inner indexes in nested indexing. To do so we need to
                 ## find dynamic indexing within a USED_IN_INDEX() and add to dynamicIndexInfo;

--- a/packages/nimble/inst/tests/test-dynamicIndexing.R
+++ b/packages/nimble/inst/tests/test-dynamicIndexing.R
@@ -442,6 +442,46 @@ test_that('basic mixture model without conjugacy', {
               avoidNestedTest=TRUE)
 })
 
+
+test_that('range checking with dynamic indexing', {
+    code <- nimbleCode({
+        for(i in 3:4) {
+            z[i-1] ~ dcat(alpha[z[i-2], 1:2])
+        }
+    }
+    )
+    
+    m <- nimbleModel(code, inits = list(alpha = matrix(c(0.9,.1,0.1,.9), 2),
+                                        z = c(1,2,1)), calculate = FALSE)
+    ## will give error if issue #790 is not fixed:
+    expect_silent(output <- m$calculate())
+
+    code <- nimbleCode({
+        for(i in 1:2) {
+            z[i+1] ~ dcat(alpha[z[i], 1:2])
+        }
+    }
+    )
+    
+    m <- nimbleModel(code, inits = list(alpha = matrix(c(0.9,.1,0.1,.9), 2),
+                                        z = c(1,2,1)), calculate = FALSE)
+    expect_silent(output <- m$calculate())
+    
+    code <- nimbleCode({
+        for(i in 2:3) {
+            z[i] ~ dcat(alpha[z[i-1], 1:2])
+        }
+    }
+    )
+    
+    
+    m <- nimbleModel(code, inits = list(alpha = matrix(c(0.9,.1,0.1,.9), 2),
+                                        z = c(1,2,1)), calculate = FALSE)
+    expect_silent(output <- m$calculate())
+    
+})
+
+
 if(FALSE) {
     ## Heisenbug here - running manually vs. via testthat causes different ordering of mixture components even though we are setting seed before each use of RNG; this test _does_ pass when run manually.
 test_that('basic multivariate mixture model with conjugacy', {


### PR DESCRIPTION
This should fix issue #790.

Still need to think through whether there are any cases in which we would want to use `symbolicParentNodes` rather than `symbolicParentNodesReplaced` or whether this was just an oversight originally. I believe the only use of the `dynamicIndexInfo` created in `findDynamicIndexParticipants` is for range checking in dynamic index expressions, so should be ok.