### PR TITLE
add { -> _oC and } -> _cC to Rname2CppName

### DIFF
--- a/packages/nimble/R/BUGS_utils.R
+++ b/packages/nimble/R/BUGS_utils.R
@@ -233,6 +233,8 @@ Rname2CppName <- function(rName, colonsOK = TRUE) {
     rName <- gsub('\\]', '_cB', rName)
     rName <- gsub('\\(', '_oP', rName)
     rName <- gsub('\\)', '_cP', rName)
+    rName <- gsub('\\{', '_oC', rName)
+    rName <- gsub('\\}', '_cC', rName)
     rName <- gsub("\\$", "_" , rName)
     rName <- gsub(">=", "_gte_", rName)
     rName <- gsub("<=", "_lte_", rName)


### PR DESCRIPTION
I encountered a use case where a file name in C++ contained a '{', so I added '{' and '}' to Rname2CppName.  This is the function that name mangles character strings or R names to valid C++ names.