### PR TITLE
trap error where user tries to compile mcmc without a project and without compiling model

### DIFF
--- a/packages/nimble/R/nimbleProject.R
+++ b/packages/nimble/R/nimbleProject.R
@@ -1106,12 +1106,13 @@ compileNimble <- function(..., project, dirName = NULL, projectName = '',
         else project <- nimbleProjectClass(dirName, name = projectName)
 
         ## Check for uncompiled models.
-        mcmcUnits <- which(sapply(units, class) == "MCMC")
-        if(any(sapply(mcmcUnits, function(idx) {
-            class(units[[idx]]$model$CobjectInterface) == "uninitializedField"
-        })))
-            stop("compileNimble: The model associated with an MCMC is not compiled. Please compile the model first.")
-        
+        if(!any(sapply(units, is, 'RmodelBaseClass'))) {
+            mcmcUnits <- which(sapply(units, class) == "MCMC")
+            if(any(sapply(mcmcUnits, function(idx) {
+                class(units[[idx]]$model$CobjectInterface) == "uninitializedField"
+            })))
+                stop("compileNimble: The model associated with an MCMC is not compiled. Please compile the model first.")
+        }
     } else {
         project <- getNimbleProject(project, TRUE)
         if(!inherits(project, 'nimbleProjectClass'))

--- a/packages/nimble/R/nimbleProject.R
+++ b/packages/nimble/R/nimbleProject.R
@@ -1098,12 +1098,20 @@ compileNimble <- function(..., project, dirName = NULL, projectName = '',
     if(length(grep('unknown', unitTypes)) > 0) stop(paste0('Some items provided for compilation do not have types that can be compiled: ', paste0(names(units), collapse = ' '), '.  The types provided were: ', paste0(unitTypes, collapse = ' '), '. Be sure only specialized nimbleFunctions are provided, not nimbleFunction generators.'), call. = FALSE)
     if(is.null(names(units))) names(units) <- rep('', length(units))
     if(length(units) == 0) stop('No objects for compilation provided')
-    
+
     ## 2. Get project or make new project
     if(missing(project)) {
         if(reset) warning("reset = TRUE but no project was provided.  If you are trying to re-compiled something into the same project, give it as the project argument as well as a compilation item. For example, 'compileNimble(myFunction, project = myFunction, reset = TRUE)'")
         if(!is.null(nimbleOptions()$nimbleProject)) project <- nimbleOptions()$nimbleProject
         else project <- nimbleProjectClass(dirName, name = projectName)
+
+        ## Check for uncompiled models.
+        mcmcUnits <- which(sapply(units, class) == "MCMC")
+        if(any(sapply(mcmcUnits, function(idx) {
+            class(units[[idx]]$model$CobjectInterface) == "uninitializedField"
+        })))
+            stop("compileNimble: The model associated with an MCMC is not compiled. Please compile the model first.")
+        
     } else {
         project <- getNimbleProject(project, TRUE)
         if(!inherits(project, 'nimbleProjectClass'))


### PR DESCRIPTION
This injects a `stop()` into `compileNimble` in the case that the project is missing.