### PR TITLE
change nimArray to rep in ndf_createDetermSimulate

### DIFF
--- a/packages/nimble/R/nimbleFunction_nodeFunction.R
+++ b/packages/nimble/R/nimbleFunction_nodeFunction.R
@@ -14,7 +14,7 @@ ndf_createDetermSimulate <- function(LHS, RHS, dynamicIndexLimitsExpr, RHSnonRep
         ## error gracefully if dynamic index too small or large; we don't catch non-integers within the bounds though
         if(is.null(nodeDim)) {
             nanExpr <- NaN
-        } else nanExpr <- substitute(nimArray(NaN, LENGTH),
+        } else nanExpr <- substitute(rep(NaN, LENGTH),
                                      list(LENGTH = prod(nodeDim)))
         code <- substitute(if(CONDITION) LHS <<- RHS
                            else {


### PR DESCRIPTION
Fixes a bug noticed by Claudia in this model below.  I was using nimArray and that was resulting in mismatch in number of arguments in initialize() for nimArray.

```
 code <- nimbleCode({
    xi[1:n] ~ dCRP(alpha, n)
    for(i in 1:n){
      mu[i, 1:2] ~ dmnorm(mu0[1:2], cov = S0[1:2, 1:2])
      Sigma[1:2, 1:2, i] ~ dinvwish(S = R0[1:2, 1:2], df = 4)
      SigmaAux[1:2, 1:2, i] <- Sigma[1:2, 1:2, xi[i]] / lambda  
      y[i, 1:2] ~ dmnorm(mu[xi[i], 1:2],  cov = SigmaAux[1:2, 1:2, i] )
    }
    alpha ~ dgamma(1, 1)
    lambda ~ dgamma(1, 1)
  })
  n <- 10
  Consts <- list(n = n, S0 = diag(1, 2), mu0=c(0,0), R0 = diag(1, 2))
  Sigma <- array(0, c(2,2,n))
  for(i in 1:n)
    Sigma[, , i] <- matrix(c(1, 0, 0, 1), 2, 2)
  Inits <- list(xi = sample(1:n, size=n, replace = TRUE), 
                mu = matrix(-10, ncol=2, nrow=n),
                Sigma=Sigma,
                alpha = 1,
                lambda = 1)
  Data <- list(y = rmvnorm(n, c(10, 20), diag(1, 2)))
  
  m <- nimbleModel(code, data=Data, inits=Inits, constants = Consts)
cm <- compileNimble(m, showCompilerOutput = TRUE)
```