### PR TITLE
Tweaked devel to match RNG calls of calcPriorFirst

### DIFF
--- a/packages/nimble/R/MCMC_utils.R
+++ b/packages/nimble/R/MCMC_utils.R
@@ -10,7 +10,10 @@
 #' @author Daniel Turek
 #' @export
 decide <- function(logMetropolisRatio) {
-  if(is.na(logMetropolisRatio))	return(FALSE)
+    if(is.na(logMetropolisRatio))	{
+        junk <- runif(1, 0, 1) ## purely for debugging of calcPriorFirst. To be removed later.
+        return(FALSE)
+    }
   if(logMetropolisRatio > 0) return(TRUE)
   if(runif(1,0,1) < exp(logMetropolisRatio)) return(TRUE)
   return(FALSE)

--- a/packages/nimble/inst/CppCode/Utils.cpp
+++ b/packages/nimble/inst/CppCode/Utils.cpp
@@ -52,7 +52,11 @@ int rFunLength(bool Arg) {
 }
 
 bool decide(double lMHr) { // simple function accept or reject based on log Metropolis-Hastings ratio
-  if(ISNAN(lMHr)) return(false);
+  if(ISNAN(lMHr)) {
+    double junk = runif(0,1); // purely for debugging to ensure
+    // same sequence of RNG uses for comparison purposes.
+    return(false);
+  }
   if(lMHr > 0) return(true);
   if(runif(0,1) < exp(lMHr)) return(true);
   return(false);


### PR DESCRIPTION
DO NOT MERGE.

The purpose of this PR is to assess whether all test failures in the calcPriorFirst PR are attributable to different sequences of random number generator calls from devel.  Compared to devel, calcPriorFirst leads to different MCMC chains than the reference chains in testing, because the sequence of RNG calls is different from that in devel.  The current branch contains devel with a tweaked version of C++ `decide` to try to emulate the RNG calls of calcPriorFirst.  Therefore if the test failures (and details) of this branch match those of calcPriorFirst, we can conclude that calcPriorFirst matches devel in behavior except for the specific sequence of RNG calls.

