### PR TITLE
added warning about multiply-defined nodes in genExpandedNode...

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -1942,6 +1942,13 @@ modelDefClass$methods(genExpandedNodeAndParentNames3 = function(debug = FALSE) {
         if(BUGSdecl$numUnrolledNodes == 0) next
         lhsVar <- BUGSdecl$targetVarName
         nDim <- varInfo[[lhsVar]]$nDim
+        ## Check that LHS has all expected indexes based on context.
+        usedIndexes <- contexts[[BUGSdecl$contextID]]$indexVarNames %in%
+            unlist(all.vars(BUGSdecl$targetExpr))
+        if(!all(usedIndexes)) 
+            warning(paste0("Multiple definitions for the same node. Did you forget indexing with '",
+                          paste(contexts[[BUGSdecl$contextID]]$indexVarNames[!usedIndexes], collapse = ','),  
+                           "' on the left-hand side of '", deparse(BUGSdecl$code), "'?"))
         if(nDim > 0) {  ## pieces is a list of index text to construct node names, e.g. list("1", c("1:2", "1:3", "1:4"), c("3", "4", "5"))
             pieces <- vector('list', nDim)
             for(i in 1:nDim) {

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -1945,7 +1945,7 @@ modelDefClass$methods(genExpandedNodeAndParentNames3 = function(debug = FALSE) {
         ## Check that LHS has all expected indexes based on context.
         usedIndexes <- contexts[[BUGSdecl$contextID]]$indexVarNames %in%
             unlist(all.vars(BUGSdecl$targetExpr))
-        if(!all(usedIndexes)) 
+        if(BUGSdecl$type != "unknownIndex" && !all(usedIndexes))
             warning(paste0("Multiple definitions for the same node. Did you forget indexing with '",
                           paste(contexts[[BUGSdecl$contextID]]$indexVarNames[!usedIndexes], collapse = ','),  
                            "' on the left-hand side of '", deparse(BUGSdecl$code), "'?"))

--- a/packages/nimble/inst/tests/test-models.R
+++ b/packages/nimble/inst/tests/test-models.R
@@ -540,6 +540,43 @@ test_that("test of using ragged arrays in a model:", {
     m <- nimbleModel(mc, constants = constants)
 })
 
+test_that("warnings for multiply-defined model nodes:", {
+    code <- nimbleCode({
+        tmp ~ dnorm(0,1)
+        for(i in 1:3) {
+            y[i] ~ dnorm(0,1)
+            mu ~ dnorm(mu0[i],1)
+        }
+    })
+    expect_warning(m <- nimbleModel(code), "'i' on the left-hand side of 'mu ~ ", fixed = TRUE)
+    code <- nimbleCode({
+        tmp ~ dnorm(0,1)
+        for(i in 1:3) {
+            y[i] ~ dnorm(0,1)
+            mu ~ dnorm(0,1)
+        }
+    })
+    expect_warning(m <- nimbleModel(code), "'i' on the left-hand side of 'mu ~ ", fixed = TRUE)
+    code <- nimbleCode({
+        tmp ~ dnorm(0,1)
+        for(i in 1:3) {
+            for(j in 1:3)
+                mu[i+2,1] ~ dnorm(0,1)
+        }
+    })
+    expect_warning(m <- nimbleModel(code), "'j' on the left-hand side of 'mu[i + 2, 1] ~ ", fixed = TRUE)
+    code <- nimbleCode({
+        tmp ~ dnorm(0,1)
+        for(i in 1:3) {
+            for(j in 1:3)
+                for(k in 1:3)
+                mu[i+2,1,1] ~ dnorm(0,1)
+        }
+    })
+    expect_warning(m <- nimbleModel(code), "'j,k' on the left-hand side of 'mu[i + 2, 1, 1] ~ ", fixed = TRUE)
+})
+
+
 
 sink(NULL)
 


### PR DESCRIPTION
This addresses issue #795, namely a user not having complete indexing for a LHS expression within a loop, e.g.,
```
for(i in 1:3) {
   mu ~ dnorm(0,1)
   for(j in 1:3)
     mu0[i,1] ~ dnorm(0,1)
}
```

@perrydv and @danielturek please take a quick look as this check will be done on all models. I think it's basically what we want as I don't think any cases of redefining a LHS are standard use of NIMBLE, but open to thoughts.