### PR TITLE
allows user to request error messages after compileNimble fails

### DIFF
--- a/packages/nimble/R/all_utils.R
+++ b/packages/nimble/R/all_utils.R
@@ -181,3 +181,20 @@ createNamedObjectsFromList <- function(lst, writeToFile = NULL, envir = parent.f
     }
 }
 
+#' Print error messages after failed compilation
+#' 
+#' Retrieves the error file from R's tempdir and prints to the screen.
+#'
+#' @param printErrors logical indicating whether compiler warnings should be printed; generally such warnings can be ignored.
+#'
+#' @author Christopher Paciorek
+#' 
+#' @export
+printErrors <- function(excludeWarnings = TRUE) {
+    if(exists('errorFile', nimbleUserNamespace)) {
+        errors <- readLines(nimbleUserNamespace$errorFile)
+        if(excludeWarnings)
+            errors <- grep("^[Ww]arning", errors, value = TRUE, invert = TRUE)
+        cat(errors, sep = "\n")
+    } else cat("No error file found.")
+}

--- a/packages/nimble/R/cppDefs_cppProject.R
+++ b/packages/nimble/R/cppDefs_cppProject.R
@@ -307,12 +307,10 @@ cppProjectClass <- setRefClass('cppProjectClass',
                                            SHLIBcmd <- paste0(SHLIBcmd, "; ", origSHLIBcmd)
                                        }
                                        
-                                       ## if(!showCompilerOutput) { 
-                                           logFile <- paste0(names[1], "_", format(Sys.time(), "%m_%d_%H_%M_%S"), ".log")
-                                           errorFile <- paste0(names[1], "_", format(Sys.time(), "%m_%d_%H_%M_%S"), ".err")
-                                           SHLIBcmd <- paste(SHLIBcmd, ">", logFile, "2>", errorFile)
-                                           ## See Rstudio comment above
-                                       ## }
+                                       logFile <- paste0(names[1], "_", format(Sys.time(), "%m_%d_%H_%M_%S"), ".log")
+                                       errorFile <- paste0(names[1], "_", format(Sys.time(), "%m_%d_%H_%M_%S"), ".err")
+                                       SHLIBcmd <- paste(SHLIBcmd, ">", logFile, "2>", errorFile)
+                                       ## See Rstudio comment above
 
                                        if(nimbleOptions('pauseAfterWritingFiles')) browser()
                                        ## We formerly used ignore.stdout = !showCompilerOutput, ignore.stderr = !showCompilerOutput
@@ -327,9 +325,16 @@ cppProjectClass <- setRefClass('cppProjectClass',
                                            cat(output, sep = '\n')
                                        }
                                        if(status != 0) {
-                                           errors <- readLines(errorFile)
-                                           stop(structure(simpleError(paste0("Failed to create the shared library:\n\n", paste0(errors, collapse = '\n'))),
-                                                          class = c("SHLIBCreationError", "ShellError", "simpleError", "error", "condition")))
+                                           if(showCompilerOutput) {
+                                               output <- c(readLines(logFile), readLines(errorFile))
+                                               stop(structure(simpleError(paste0("Failed to create the shared library.\n", paste0(output, collapse = "\n"))),
+                                                              class = c("SHLIBCreationError", "ShellError", "simpleError", "error", "condition")))
+
+                                           } else {
+                                               nimbleUserNamespace$errorFile <- file.path(dirName, errorFile)
+                                               stop(structure(simpleError(paste0("Failed to create the shared library. Run 'printErrors()' to see the compilation errors.\n")),
+                                                              class = c("SHLIBCreationError", "ShellError", "simpleError", "error", "condition")))
+                                           }
                                        }
                                        if(isTRUE(nimbleOptions()$stopCompilationBeforeLinking)) stop("safely stopping before linking", call.=FALSE)
                                    },

--- a/packages/nimble/R/cppDefs_cppProject.R
+++ b/packages/nimble/R/cppDefs_cppProject.R
@@ -211,9 +211,9 @@ cppProjectClass <- setRefClass('cppProjectClass',
                                        }
                                        isWindows = (.Platform$OS.type == "windows")
                                        if(isWindows)
-                                           status = system(ssdSHLIBcmd, ignore.stdout = !showCompilerOutput, ignore.stderr = !showCompilerOutput, show.output.on.console = showCompilerOutput)
+                                           status = system(ssdSHLIBcmd, ignore.stdout = !showCompilerOutput, ignore.stderr = FALSE, show.output.on.console = showCompilerOutput)
                                        else
-                                           status = system(ssdSHLIBcmd, ignore.stdout = !showCompilerOutput, ignore.stderr = !showCompilerOutput)
+                                           status = system(ssdSHLIBcmd, ignore.stdout = !showCompilerOutput, ignore.stderr = FALSE)
                                        if(status != 0) 
                                            stop(structure(simpleError("Failed to create the shared library"),
                                                           class = c("SHLIBCreationError", "ShellError", "simpleError", "error", "condition")))
@@ -316,9 +316,9 @@ cppProjectClass <- setRefClass('cppProjectClass',
                                        if(nimbleOptions('pauseAfterWritingFiles')) browser()
 
                                        if(isWindows)
-                                           status = system(SHLIBcmd, ignore.stdout = !showCompilerOutput, ignore.stderr = !showCompilerOutput, show.output.on.console = showCompilerOutput)
+                                           status = system(SHLIBcmd, ignore.stdout = !showCompilerOutput, show.output.on.console = showCompilerOutput, ignore.stderr = FALSE)
                                        else
-                                           status = system(SHLIBcmd, ignore.stdout = !showCompilerOutput, ignore.stderr = !showCompilerOutput)
+                                           status = system(SHLIBcmd, ignore.stdout = !showCompilerOutput, ignore.stderr = FALSE)
 				       if(status != 0)
                                            stop(structure(simpleError("Failed to create the shared library"),
                                                           class = c("SHLIBCreationError", "ShellError", "simpleError", "error", "condition")))

--- a/packages/nimble/R/cppDefs_cppProject.R
+++ b/packages/nimble/R/cppDefs_cppProject.R
@@ -211,11 +211,11 @@ cppProjectClass <- setRefClass('cppProjectClass',
                                        }
                                        isWindows = (.Platform$OS.type == "windows")
                                        if(isWindows)
-                                           status = system(ssdSHLIBcmd, ignore.stdout = !showCompilerOutput, ignore.stderr = FALSE, show.output.on.console = showCompilerOutput)
+                                           status = system(ssdSHLIBcmd, ignore.stdout = !showCompilerOutput, ignore.stderr = !showCompilerOutput, show.output.on.console = showCompilerOutput)
                                        else
-                                           status = system(ssdSHLIBcmd, ignore.stdout = !showCompilerOutput, ignore.stderr = FALSE)
+                                           status = system(ssdSHLIBcmd, ignore.stdout = !showCompilerOutput, ignore.stderr = !showCompilerOutput)
                                        if(status != 0) 
-                                           stop(structure(simpleError("Failed to create the shared library"),
+                                           stop(structure(simpleError("Failed to create the shared library. Please rerun 'compileNimble' with 'showCompilerOutput = TRUE' for more details."),
                                                           class = c("SHLIBCreationError", "ShellError", "simpleError", "error", "condition")))
                                        return(dyn.load(ssDllName, local = TRUE))
                                    },
@@ -316,11 +316,11 @@ cppProjectClass <- setRefClass('cppProjectClass',
                                        if(nimbleOptions('pauseAfterWritingFiles')) browser()
 
                                        if(isWindows)
-                                           status = system(SHLIBcmd, ignore.stdout = !showCompilerOutput, show.output.on.console = showCompilerOutput, ignore.stderr = FALSE)
+                                           status = system(SHLIBcmd, ignore.stdout = !showCompilerOutput, ignore.stderr = !showCompilerOutput, show.output.on.console = showCompilerOutput)
                                        else
-                                           status = system(SHLIBcmd, ignore.stdout = !showCompilerOutput, ignore.stderr = FALSE)
+                                           status = system(SHLIBcmd, ignore.stdout = !showCompilerOutput, ignore.stderr = !showCompilerOutput)
 				       if(status != 0)
-                                           stop(structure(simpleError("Failed to create the shared library"),
+                                           stop(structure(simpleError("Failed to create the shared library. Please rerun 'compileNimble' with 'showCompilerOutput = TRUE' for more details."),
                                                           class = c("SHLIBCreationError", "ShellError", "simpleError", "error", "condition")))
                                        if(isTRUE(nimbleOptions()$stopCompilationBeforeLinking)) stop("safely stopping before linking", call.=FALSE)
 

--- a/packages/nimble/R/nimbleProject.R
+++ b/packages/nimble/R/nimbleProject.R
@@ -1117,7 +1117,7 @@ compileNimble <- function(..., project, dirName = NULL, projectName = '',
     
 
     ## Units should be either Rmodel, nimbleFunction, or RCfunction (now coming from nimbleFunction with no setup)
-    if(nimbleOptions('verbose') && !showCompilerOutput) message("compiling... this may take a minute. Use 'showCompilerOutput = TRUE' to see C++ compiler details.")
+    if(nimbleOptions('verbose') && !showCompilerOutput) message("compiling... this may take a minute. Use 'showCompilerOutput = TRUE' to see C++ compilation details.")
     if(nimbleOptions('verbose') && showCompilerOutput) message("compiling... this may take a minute. On some systems there may be some compiler warnings that can be safely ignored.")
 
     ## Compile models first


### PR DESCRIPTION
This addresses NCT issue 100. 

@danielturek @perrydv if one of you has a chance, please run the following on a Windows machine and report the results: 
```
a = nimbleFunction(
    run = function(x=double(1)) {
        for(i in 1:3)
                x[i-1] = x[i]*'a'
        returnType(double(1))
        return(x)
    })
ca = compileNimble(a, showCompilerOutput=TRUE)
ca = compileNimble(a, showCompilerOutput=FALSE)
printErrors()
printErrors(excludeWarnings = FALSE)
```