### PR TITLE
address rchk warnings about PROTECT patterns

### DIFF
--- a/packages/nimble/R/cppDefs_core.R
+++ b/packages/nimble/R/cppDefs_core.R
@@ -172,14 +172,14 @@ cppClassDef <- setRefClass('cppClassDef',
                                                         Sderived = cppSEXP(name = 'Sderived_EXTPTR'))
                                    CBobjectDefs <- c(CBobjectDefs, baseClassPtrObjectDefs)
                                    newCodeLine <- cppLiteral(c(paste0('newObj = new ', name,';'),
-                                                               'PROTECT(Sderived_EXTPTR = R_MakeExternalPtr(newObj, R_NilValue, R_NilValue));'))
+                                                               'Sderived_EXTPTR = PROTECT(R_MakeExternalPtr(newObj, R_NilValue, R_NilValue));'))
                                    baseClassCastLines <- mapply(
                                        function(baseClassName, Sname)
                                            paste0('PROTECT(',Sname,'= R_MakeExternalPtr(dynamic_cast<',baseClassName,'*>(newObj), R_NilValue, R_NilValue));'),
                                        baseClassName = allinheritance,
                                        Sname = SallinheritanceNames)
                                    baseClassCastLines <- cppLiteral(baseClassCastLines)
-                                   allocVectorLine <- cppLiteral(paste0('PROTECT(Sans = Rf_allocVector(VECSXP,',numBaseClasses + 1, '));'))
+                                   allocVectorLine <- cppLiteral(paste0('Sans = PROTECT(Rf_allocVector(VECSXP,',numBaseClasses + 1, '));'))
 
                                    packListLines <- mapply(function(Sname, i) paste0('SET_VECTOR_ELT(Sans,',i,',',Sname,');'),
                                                            Sname = c('Sderived_EXTPTR', SallinheritanceNames),

--- a/packages/nimble/R/cppDefs_nimbleList.R
+++ b/packages/nimble/R/cppDefs_nimbleList.R
@@ -80,9 +80,9 @@ cppNimbleListClass <- setRefClass('cppNimbleListClass',
                                           newCodeLine <- cppLiteral(c(paste0('ptrToSmartPtr = static_cast<nimSmartPtr<',name,'>* >(R_ExternalPtrAddr(input));'),
                                                                       'ptrToSmartPtrBase = dynamic_cast<nimSmartPtrBase*>(ptrToSmartPtr);',
                                                                       'ptrToPtr = ptrToSmartPtr->getVoidPtrToRealPtr();',
-                                                                      'PROTECT(SptrToSmartPtrBase = R_MakeExternalPtr(ptrToSmartPtrBase, R_NilValue, R_NilValue));',
-                                                                      'PROTECT(SptrToPtr = R_MakeExternalPtr(ptrToPtr, R_NilValue, R_NilValue));'))
-                                          allocVectorLine <- cppLiteral(paste0('PROTECT(Sans = Rf_allocVector(VECSXP,', 2, '));'))
+                                                                      'SptrToSmartPtrBase = PROTECT(R_MakeExternalPtr(ptrToSmartPtrBase, R_NilValue, R_NilValue));',
+                                                                      'SptrToPtr = PROTECT(R_MakeExternalPtr(ptrToPtr, R_NilValue, R_NilValue));'))
+                                          allocVectorLine <- cppLiteral(paste0('Sans = PROTECT(Rf_allocVector(VECSXP,', 2, '));'))
                                           
                                           packListLines <- cppLiteral(c('SET_VECTOR_ELT(Sans,0,SptrToSmartPtrBase);',
                                                                         'SET_VECTOR_ELT(Sans,1,SptrToPtr);'
@@ -136,7 +136,7 @@ cppNimbleListClass <- setRefClass('cppNimbleListClass',
                                           newCodeLine <- cppLiteral(c(paste('newObj = new ',name,';'),
                                                                       paste0('ptrToSmartPtr = new nimSmartPtr<',name,'>;'),
                                                                       'ptrToSmartPtr->setPtrFromT(newObj);',
-                                                                      'PROTECT(SptrToSmartPtr = R_MakeExternalPtr(ptrToSmartPtr, R_NilValue, R_NilValue));'))
+                                                                      'SptrToSmartPtr = PROTECT(R_MakeExternalPtr(ptrToSmartPtr, R_NilValue, R_NilValue));'))
                                                                       
                                           codeLines <- substitute({
                                               ## Finalizer registration now happens through nimble's finalizer mapping system.
@@ -192,10 +192,10 @@ cppNimbleListClass <- setRefClass('cppNimbleListClass',
                                         listElementTable$addSymbol(cppSEXP(name = "S_newNimList"))
                                         listElementTable$addSymbol(cppSEXP(name = "S_listName"))
                                       
-                                        newListLine[[1]] <- substitute({PROTECT(S_listName <- Rf_allocVector(STRSXP, 1));
+                                        newListLine[[1]] <- substitute({S_listName <- PROTECT(Rf_allocVector(STRSXP, 1));
                                           SET_STRING_ELT(S_listName, 0, Rf_mkChar(LISTNAME));}, 
                                           list(LISTNAME = nimCompProc$nimbleListObj$className))
-                                        newListLine[[2]] <- substitute(PROTECT(S_newNimList <- makeNewNimbleList(S_listName)),
+                                        newListLine[[2]] <- substitute(S_newNimList <- PROTECT(makeNewNimbleList(S_listName)),
                                                                            list())
                                         newListLine[[3]] <- quote(cppLiteral('RObjectPointer = S_newNimList;'))
                                         newListLine[[4]] <-   substitute(UNPROTECT(2), list())
@@ -224,7 +224,7 @@ cppNimbleListClass <- setRefClass('cppNimbleListClass',
                                         conditionalClauseEnd <- list(quote(cppLiteral('}')))
                                         environmentCPPName <- Rname2CppName('S_.xData')  ## create SEXP for ref class environment 
                                         listElementTable$addSymbol(cppSEXP(name = environmentCPPName))
-                                        envLine <- substitute({PROTECT(ENVNAME <- Rf_allocVector(STRSXP, 1));
+                                        envLine <- substitute({ENVNAME <- PROTECT(Rf_allocVector(STRSXP, 1));
                                           SET_STRING_ELT(ENVNAME, 0, Rf_mkChar(".xData"));}, 
                                           list(ENVNAME = as.name(environmentCPPName)))
                                         
@@ -272,14 +272,14 @@ cppNimbleListClass <- setRefClass('cppNimbleListClass',
 
                                         environmentCPPName <- Rname2CppName('S_.xData')  ## create SEXP for ref class environment 
                                         listElementTable$addSymbol(cppSEXP(name = environmentCPPName))
-                                        envLine <- substitute({PROTECT(ENVNAME <- Rf_allocVector(STRSXP, 1));
+                                        envLine <- substitute({ENVNAME <- PROTECT(Rf_allocVector(STRSXP, 1));
                                           SET_STRING_ELT(ENVNAME, 0, Rf_mkChar(".xData"));}, 
                                           list(ENVNAME = as.name(environmentCPPName)))
 
                                         for(i in seq_along(argNames)) {
                                           Snames[i] <- Rname2CppName(paste0('S_', argNames[i]))
                                           listElementTable$addSymbol(cppSEXP(name = Snames[i]))
-                                            copyFromListLines[[i]] <- substitute(PROTECT(SVAR <- Rf_findVarInFrame(PROTECT(GET_SLOT(S_nimList_, XDATA)), Rf_install(ARGNAME))),
+                                            copyFromListLines[[i]] <- substitute(SVAR <- PROTECT(Rf_findVarInFrame(PROTECT(GET_SLOT(S_nimList_, XDATA)), Rf_install(ARGNAME))),
                                                                                list(ARGNAME = argNames[i], 
                                                                                     SVAR = as.name(Snames[i]),
                                                                                     XDATA = as.name(environmentCPPName)))

--- a/packages/nimble/inst/CppCode/RcppUtils.cpp
+++ b/packages/nimble/inst/CppCode/RcppUtils.cpp
@@ -897,20 +897,21 @@ SEXP makeParsedVarList(SEXP Sx) {
   varAndIndicesClass varAndInds;
   for(size_t i = 0; i < x.size(); ++i) {
     parseVarAndInds(x[i], varAndInds);
-    SETCAR(t, makeAsNumeric_LANGSXP(varAndIndices_2_LANGSXP(varAndInds))); t = CDR(t);
+    SETCAR(t, makeAsNumeric_LANGSXP(PROTECT(varAndIndices_2_LANGSXP(varAndInds)))); t = CDR(t);
   }
-  UNPROTECT(1);
+  UNPROTECT(2);
   return Sans;
 }
 
 SEXP makeNewNimbleList(SEXP S_listName) {
   SEXP SnimbleInternalFunctionsEnv;
   SEXP call;
-  PROTECT(SnimbleInternalFunctionsEnv =
-    Rf_eval(Rf_findVar(Rf_install("nimbleInternalFunctions"), R_GlobalEnv), R_GlobalEnv));
-  PROTECT(call = Rf_allocVector(LANGSXP, 2));
+  SnimbleInternalFunctionsEnv =
+    PROTECT(Rf_eval(PROTECT(Rf_findVar(Rf_install("nimbleInternalFunctions"), R_GlobalEnv)), R_GlobalEnv));
+  call = PROTECT(Rf_allocVector(LANGSXP, 2));
   SETCAR(call, Rf_install("makeNewNimListSEXPRESSIONFromC"));
   SETCADR(call, S_listName);
-  UNPROTECT(2);
-  return(Rf_eval(call, SnimbleInternalFunctionsEnv));
+  SEXP ans = PROTECT(Rf_eval(call, SnimbleInternalFunctionsEnv));
+  UNPROTECT(4);
+  return(ans);
 }

--- a/packages/nimble/inst/CppCode/RcppUtils.cpp
+++ b/packages/nimble/inst/CppCode/RcppUtils.cpp
@@ -899,7 +899,7 @@ SEXP makeParsedVarList(SEXP Sx) {
     parseVarAndInds(x[i], varAndInds);
     SETCAR(t, makeAsNumeric_LANGSXP(PROTECT(varAndIndices_2_LANGSXP(varAndInds)))); t = CDR(t);
   }
-  UNPROTECT(2);
+  UNPROTECT(1 + x.size());
   return Sans;
 }
 

--- a/packages/nimble/inst/CppCode/accessorClasses.cpp
+++ b/packages/nimble/inst/CppCode/accessorClasses.cpp
@@ -654,54 +654,34 @@ void populateNodeFxnVectorNew_internal(NodeVectorClassNew* nfv, SEXP S_GIDs, SEX
 void populateNodeFxnVectorNew_copyFromRobject(void *nodeFxnVec_to, SEXP S_nodeFxnVec_from ) {
   SEXP S_indexingInfo;
    SEXP S_pxData;
-   PROTECT(S_pxData = Rf_allocVector(STRSXP, 1));
+   S_pxData = PROTECT(Rf_allocVector(STRSXP, 1));
    SET_STRING_ELT(S_pxData, 0, Rf_mkChar(".xData"));
-  // SEXP S_xData;
-  // PROTECT(S_xData = GET_SLOT(S_nodeFxnVec_from, S_pxData));
-  //PROTECT(S_indexingInfo = Rf_findVarInFrame(S_xData,
-  //					     Rf_install("indexingInfo")));
-  PROTECT(S_indexingInfo = VECTOR_ELT(S_nodeFxnVec_from, 1));
+   S_indexingInfo = PROTECT(VECTOR_ELT(S_nodeFxnVec_from, 1));
   SEXP S_declIDs;
-  PROTECT(S_declIDs = VECTOR_ELT(S_indexingInfo, 0));
+  S_declIDs = PROTECT(VECTOR_ELT(S_indexingInfo, 0));
   SEXP S_rowIndices;
-  PROTECT(S_rowIndices = VECTOR_ELT(S_indexingInfo, 1));
+  S_rowIndices = PROTECT(VECTOR_ELT(S_indexingInfo, 1));
   SEXP S_numberedPtrs;
-  // PROTECT(S_numberedPtrs = Rf_findVarInFrame(PROTECT(GET_SLOT(
-  // 							      Rf_findVarInFrame(PROTECT(GET_SLOT(
-  // 												 Rf_findVarInFrame(PROTECT(GET_SLOT(
-  // 																    Rf_findVarInFrame(S_xData,
-  // 																		      Rf_install("model")
-  // 																		      ),
-  // 																    S_pxData)),
-  // 														   Rf_install("CobjectInterface")
-  // 														   ),
-  // 												 S_pxData)),
-  // 										Rf_install(".nodeFxnPointers_byDeclID")),
-  // 							      S_pxData)),
-  // 					     Rf_install(".ptr")
-  // 					     )
-  // 	  );
-
-  // equivalent to S_nodeFxnVec_from[["model"]]$CobjectInterface$.nodeFxnPointers_byDeclID$.ptr
+ // equivalent to S_nodeFxnVec_from[["model"]]$CobjectInterface$.nodeFxnPointers_byDeclID$.ptr
   // implemented by S_nodeFxnVec_from[[2]]@.xData[["CobjectInterface"]]@.xData[[".nodeFxnPointers_byDeclID"]]@.xData[[".ptr"]]
-  PROTECT(S_numberedPtrs = Rf_findVarInFrame(PROTECT(GET_SLOT(
-							      Rf_findVarInFrame(PROTECT(GET_SLOT(
-												 Rf_findVarInFrame(PROTECT(GET_SLOT(
+  S_numberedPtrs = PROTECT(Rf_findVarInFrame(PROTECT(GET_SLOT(
+							     PROTECT(Rf_findVarInFrame(PROTECT(GET_SLOT(
+													PROTECT(Rf_findVarInFrame(PROTECT(GET_SLOT(
 																    VECTOR_ELT(S_nodeFxnVec_from,
 																	       2
 																	       ),
 																    S_pxData)),
 														   Rf_install("CobjectInterface")
-														   ),
+														   )),
 												 S_pxData)),
-										Rf_install(".nodeFxnPointers_byDeclID")),
+										       Rf_install(".nodeFxnPointers_byDeclID"))),
 							      S_pxData)),
 					     Rf_install(".ptr")
 					     )
 	  );
   NodeVectorClassNew* nfv = static_cast<NodeVectorClassNew*>(nodeFxnVec_to);
   populateNodeFxnVectorNew_internal(nfv, S_declIDs, S_numberedPtrs, S_rowIndices);
-  UNPROTECT(8);
+  UNPROTECT(10);
 }
 
 SEXP populateNodeFxnVectorNew_byDeclID(SEXP SnodeFxnVec, SEXP S_GIDs, SEXP SnumberedObj, SEXP S_ROWINDS){

--- a/packages/nimble/inst/CppCode/predefinedNimbleLists.cpp
+++ b/packages/nimble/inst/CppCode/predefinedNimbleLists.cpp
@@ -19,8 +19,8 @@ SEXP new_EIGEN_EIGENCLASS() {
   newObj = new EIGEN_EIGENCLASS;
   ptrToSmartPtr = new nimSmartPtr<EIGEN_EIGENCLASS>;
   ptrToSmartPtr->setPtrFromT(newObj);
-  PROTECT(SptrToSmartPtr =
-              R_MakeExternalPtr(ptrToSmartPtr, R_NilValue, R_NilValue));
+  SptrToSmartPtr =
+    PROTECT(R_MakeExternalPtr(ptrToSmartPtr, R_NilValue, R_NilValue));
   UNPROTECT(1);
   return (EIGEN_EIGENCLASS_castDerivedPtrPtrToPairOfPtrsSEXP(SptrToSmartPtr));
 }
@@ -60,8 +60,8 @@ SEXP new_EIGEN_SVDCLASS() {
   newObj = new EIGEN_SVDCLASS;
   ptrToSmartPtr = new nimSmartPtr<EIGEN_SVDCLASS>;
   ptrToSmartPtr->setPtrFromT(newObj);
-  PROTECT(SptrToSmartPtr =
-              R_MakeExternalPtr(ptrToSmartPtr, R_NilValue, R_NilValue));
+  SptrToSmartPtr =
+	  PROTECT(R_MakeExternalPtr(ptrToSmartPtr, R_NilValue, R_NilValue));
   UNPROTECT(1);
   return (EIGEN_SVDCLASS_castDerivedPtrPtrToPairOfPtrsSEXP(SptrToSmartPtr));
 }
@@ -203,8 +203,8 @@ SEXP new_OptimResultNimbleList() {
   newObj = new OptimResultNimbleList;
   ptrToSmartPtr = new nimSmartPtr<OptimResultNimbleList>;
   ptrToSmartPtr->setPtrFromT(newObj);
-  PROTECT(SptrToSmartPtr =
-              R_MakeExternalPtr(ptrToSmartPtr, R_NilValue, R_NilValue));
+  SptrToSmartPtr =
+    PROTECT(R_MakeExternalPtr(ptrToSmartPtr, R_NilValue, R_NilValue));
   UNPROTECT(1);
   return (
       OptimResultNimbleList_castDerivedPtrPtrToPairOfPtrsSEXP(SptrToSmartPtr));
@@ -465,8 +465,8 @@ SEXP new_OptimControlNimbleList() {
   newObj = new OptimControlNimbleList;
   ptrToSmartPtr = new nimSmartPtr<OptimControlNimbleList>;
   ptrToSmartPtr->setPtrFromT(newObj);
-  PROTECT(SptrToSmartPtr =
-              R_MakeExternalPtr(ptrToSmartPtr, R_NilValue, R_NilValue));
+  SptrToSmartPtr =
+    PROTECT(R_MakeExternalPtr(ptrToSmartPtr, R_NilValue, R_NilValue));
   UNPROTECT(1);
   return (
       OptimControlNimbleList_castDerivedPtrPtrToPairOfPtrsSEXP(SptrToSmartPtr));
@@ -589,8 +589,8 @@ SEXP new_NIMBLE_ADCLASS() {
   newObj = new NIMBLE_ADCLASS;
   ptrToSmartPtr = new nimSmartPtr<NIMBLE_ADCLASS>;
   ptrToSmartPtr->setPtrFromT(newObj);
-  PROTECT(SptrToSmartPtr =
-              R_MakeExternalPtr(ptrToSmartPtr, R_NilValue, R_NilValue));
+  SptrToSmartPtr =
+    PROTECT(R_MakeExternalPtr(ptrToSmartPtr, R_NilValue, R_NilValue));
   UNPROTECT(1);
   return (NIMBLE_ADCLASS_castDerivedPtrPtrToPairOfPtrsSEXP(SptrToSmartPtr));
 }


### PR DESCRIPTION
rchk now issues warnings about PROTECT code patterns.  This PR attempts to resolve all warnings.

In our code, the majority of the warnings appear to be superfluous, but it is worth changing the usage pattern/style to satisfy rchk and conform to the recommended practices.

There were also cases where there might be a real issue, but no effort was made to determine if that was the case since it was easy to simply fix the usages.

