### PR TITLE
added a space after commas in message about adding constants as data

### DIFF
--- a/packages/nimble/R/BUGS_readBUGS.R
+++ b/packages/nimble/R/BUGS_readBUGS.R
@@ -108,7 +108,7 @@ nimbleModel <- function(code,
         warning("BUGSmodel: found the same variable(s) in both 'data' and 'constants'; using variable(s) from 'data'.\n")
     if(sum(dataVarIndices)) {
         data <- c(data, constants[dataVarIndices])
-        if(nimbleOptions('verbose')) message("Adding ", paste(names(constants)[dataVarIndices], collapse = ','), " as data for building model.")
+        if(nimbleOptions('verbose')) message("Adding ", paste(names(constants)[dataVarIndices], collapse = ', '), " as data for building model.")
     }
     if(nimbleOptions('verbose')) message("building model...")
     model <- md$newModel(data=data, inits=inits, where=where, check=check, calculate = calculate, debug = debug)


### PR DESCRIPTION
Adds a space in the message while building models.

Changes **from**:
```
defining model...
Adding ones,dist1_3d,dist2_3d,dist12_3d,nID,cond_on_y as data for building model.
building model...
```

Changes this message **to**:
```
defining model...
Adding ones, dist1_3d, dist2_3d, dist12_3d, nID, cond_on_y as data for building model.
building model...
```