### PR TITLE
updated initializeModel() to always re-calculate deterministic nodes

### DIFF
--- a/packages/nimble/R/initializeModel.R
+++ b/packages/nimble/R/initializeModel.R
@@ -99,8 +99,7 @@ initializeModel <- nimbleFunction(
             model$calculate(LHSnodes[i])
             nodeValue <- values(model, LHSnodes[i])
             if(is.na.vec(nodeValue) | is.nan.vec(nodeValue)) {
-                if(is.na.vec(nodeValue) | is.nan.vec(nodeValue))
-                    print('warning: value of deterministic node ',LHSnodes[i],': value is NA or NaN even after trying to calculate.')
+                print('warning: value of deterministic node ',LHSnodes[i],': value is NA or NaN even after trying to calculate.')
             }
         },
         initialize_stoch_data_node = function(i = integer()) {

--- a/packages/nimble/R/initializeModel.R
+++ b/packages/nimble/R/initializeModel.R
@@ -91,14 +91,14 @@ initializeModel <- nimbleFunction(
                 }
             }
         }
-        model$calculate(LHSnodes)
+        ## removed trailing full model$calculate() -DT Feb. 2019
+        ##model$calculate(LHSnodes)
     },
     methods = list(
         initialize_deterministic = function(i = integer()) {
+            model$calculate(LHSnodes[i])
             nodeValue <- values(model, LHSnodes[i])
             if(is.na.vec(nodeValue) | is.nan.vec(nodeValue)) {
-                model$calculate(LHSnodes[i])
-                nodeValue <- values(model, LHSnodes[i])
                 if(is.na.vec(nodeValue) | is.nan.vec(nodeValue))
                     print('warning: value of deterministic node ',LHSnodes[i],': value is NA or NaN even after trying to calculate.')
             }


### PR DESCRIPTION
Per discussion.

Removed full `model$calculate()` call at the end of `initializeModel()`.

Replaced with so that the initialization routine for deterministic nodes **always** recalculates the value of the node (in topological order), to ensure the value is not only a "valid" number, but also correctly represents the upstream state of the model.

Also added a test, to check for this correct behaviour.
