### PR TITLE
add check for missing returnType in user-defined dists

### DIFF
--- a/packages/nimble/R/distributions_processInputList.R
+++ b/packages/nimble/R/distributions_processInputList.R
@@ -265,7 +265,7 @@ checkDistributionFunctions <- function(distributionInput, userEnv) {
         if(!is.rcf(rcf)) {
             nofun <- TRUE
         } else if(environment(rcf)$nfMethodRCobject$returnType != quote(double()) &&
-                  environment(rcf)$nfMethodRCobject$returnType != quote(double()))
+                  environment(rcf)$nfMethodRCobject$returnType != quote(double(0)))
               stop(paste0("checkDistributionFunctions: density function for ", densityName,
                           " has invalid or missing returnType, which must be 'double(0)' (or equivalently 'double()')."))
     } else nofun <- TRUE

--- a/packages/nimble/R/distributions_processInputList.R
+++ b/packages/nimble/R/distributions_processInputList.R
@@ -259,8 +259,17 @@ checkDistributionFunctions <- function(distributionInput, userEnv) {
         densityName <- as.character(parse(text = inputString)[[1]][[1]])
     } else densityName <- distributionInput
     simulateName <- sub('^d', 'r', densityName)
-    if(!exists(densityName, where = userEnv) ||
-        !is.rcf(get(densityName, pos = userEnv)))
+    nofun <- FALSE
+    if(exists(densityName, where = userEnv)) {
+        rcf <- get(densityName, pos = userEnv)
+        if(!is.rcf(rcf)) {
+            nofun <- TRUE
+        } else if(environment(rcf)$nfMethodRCobject$returnType != quote(double()) &&
+                  environment(rcf)$nfMethodRCobject$returnType != quote(double()))
+              stop(paste0("checkDistributionFunctions: density function for ", densityName,
+                          " has invalid or missing returnType, which must be 'double(0)' (or equivalently 'double()')."))
+    } else nofun <- TRUE
+    if(nofun)
         stop(paste0("checkDistributionFunctions: density function for ", densityName,
                     " is not available.  It must be a nimbleFunction (with no setup code)."))
     if(!exists(simulateName, where = userEnv) || !is.rcf(get(simulateName, pos = userEnv))) {

--- a/packages/nimble/inst/tests/test-mcmc.R
+++ b/packages/nimble/inst/tests/test-mcmc.R
@@ -109,7 +109,7 @@ test_that('ice example reworked', {
 })
 
 test_mcmc('beetles', model = 'beetles-logit.bug', inits = 'beetles-inits.R',
-          data = 'beetles-data.R', numItsC = 1000, resampleData = TRUE, avoidNestedTest = TRUE)
+          data = 'beetles-data.R', numItsC = 1000, resampleData = TRUE)
                                         # getting warning; deterministic model node is NA or NaN in model initialization
                                         # weirdness with llike.sat[8] being NaN on init (actually that makes sense), and with weird lifting of RHS of llike.sat
 


### PR DESCRIPTION
This traps a previously uncaught error that resulted in an unhelpful R error message.