### PR TITLE
error trap when to/from arg to nimCopy is not legitimate model or modelValues

### DIFF
--- a/packages/nimble/R/nimbleFunction_keywordProcessing.R
+++ b/packages/nimble/R/nimbleFunction_keywordProcessing.R
@@ -431,6 +431,10 @@ nimCopy_keywordInfo <- keywordInfoClass(
 		accessTypes <- c('symbolModelVariableAccessorVector', 'symbolModelValuesAccessorVector')
 		from_ArgList <- list(name = code$from, class = symTypeFromSymTab(code$from, nfProc$setupSymTab, options = possibleObjects))
 		to_ArgList <- list(name = code$to, class = symTypeFromSymTab(code$to, nfProc$setupSymTab, options = possibleObjects))
+		if(is.null(from_ArgList$class)) 
+			stop("Error in nimCopy: '", code$from, "' is not a recognized model or modelValues object.") 		
+		if(is.null(to_ArgList$class)) 
+			stop("Error in nimCopy: '", code$to, "' is not a recognized model or modelValues object.") 		
 		if(from_ArgList$class %in% modelValuesTypes){
 			if(isCodeArgBlank(code, 'row'))		stop('row argument missing in copy call')
 			from_ArgList$row = code$row


### PR DESCRIPTION
Traps a previously uncaught error that led to an unhelpful R error message.