### PR TITLE
Trap NA/NaN/-Inf/Inf values in log-lik calc in MCEM

### DIFF
--- a/packages/nimble/R/MCEM_build.R
+++ b/packages/nimble/R/MCEM_build.R
@@ -58,7 +58,7 @@ calc_E_llk_gen = nimbleFunction(
       }
       sample_LL = calculate(model, latentCalcNodes)
       if(is.na(sample_LL) | is.nan(sample_LL) | sample_LL == -Inf | sample_LL == Inf)
-          stop("Non-finite log-likelihood occurred; the MCEM optimization cannot continue. Please check the state of the compiled model (accessible as 'name_of_model$CobjectInterface') and determine which parameter values are causing the invalid log-likelihood by calling 'calculate' with subsets of the model parameters. Note that if your model is maximizing over parameters whose bounds are not constant (depend on other parameters), this is one possible cause of such problems; in that case you might try running the MCEM without bounds, by setting 'forceNoConstraints = TRUE'.")
+            stop("Non-finite log-likelihood occurred; the MCEM optimization cannot continue. Please check the state of the compiled model (accessible as 'name_of_model$CobjectInterface') and determine which parameter values are causing the invalid log-likelihood by calling 'calculate' with subsets of the model parameters (e.g., 'name_of_model$CobjectInterface$calculate(\"y[3]\")' to see if node 'y[3]' is the cause of the problem). Note that if your model is maximizing over parameters whose bounds are not constant (i.e., depend on other parameters), this is one possible cause of such problems; in that case you might try running the MCEM without bounds, by setting 'forceNoConstraints = TRUE'.")
       mean_LL = mean_LL + sample_LL
       if(diff == 1){
         values(model, fixedNodes) <<- oldParamValues #now old params
@@ -70,7 +70,7 @@ calc_E_llk_gen = nimbleFunction(
         }
         sample_LL = calculate(model, latentCalcNodes)
         if(is.na(sample_LL) | is.nan(sample_LL) | sample_LL == -Inf | sample_LL == Inf)
-            stop("Non-finite log-likelihood occurred; the MCEM optimization cannot continue. Please check the state of the compiled model (accessible as 'name_of_model$CobjectInterface') and determine which parameter values are causing the invalid log-likelihood by calling 'calculate' with subsets of the model parameters (e.g., 'name_of_model$CobjectInterface$calculate(\"y[3]\")'). Note that if your model is maximizing over parameters whose bounds are not constant (depend on other parameters), this is one possible cause of such problems; in that case you might try running the MCEM without bounds, by setting 'forceNoConstraints = TRUE'.")
+            stop("Non-finite log-likelihood occurred; the MCEM optimization cannot continue. Please check the state of the compiled model (accessible as 'name_of_model$CobjectInterface') and determine which parameter values are causing the invalid log-likelihood by calling 'calculate' with subsets of the model parameters (e.g., 'name_of_model$CobjectInterface$calculate(\"y[3]\")'). Note that if your model is maximizing over parameters whose bounds are not constant (i.e., depend on other parameters), this is one possible cause of such problems; in that case you might try running the MCEM without bounds, by setting 'forceNoConstraints = TRUE'.")
         mean_LL = mean_LL - sample_LL
       }
     }

--- a/packages/nimble/R/MCEM_build.R
+++ b/packages/nimble/R/MCEM_build.R
@@ -58,7 +58,7 @@ calc_E_llk_gen = nimbleFunction(
       }
       sample_LL = calculate(model, latentCalcNodes)
       if(is.na(sample_LL) | is.nan(sample_LL) | sample_LL == -Inf | sample_LL == Inf)
-            stop("Non-finite log-likelihood occurred; the MCEM optimization cannot continue. Please check the state of the compiled model (accessible as 'name_of_model$CobjectInterface') and determine which parameter values are causing the invalid log-likelihood by calling 'calculate' with subsets of the model parameters (e.g., 'name_of_model$CobjectInterface$calculate(\"y[3]\")' to see if node 'y[3]' is the cause of the problem). Note that if your model is maximizing over parameters whose bounds are not constant (i.e., depend on other parameters), this is one possible cause of such problems; in that case you might try running the MCEM without bounds, by setting 'forceNoConstraints = TRUE'.")
+            stop("Non-finite log-likelihood occurred; the MCEM optimization cannot continue. Please check the state of the compiled model (accessible as 'name_of_model$CobjectInterface') and determine which parameter values are causing the invalid log-likelihood by calling 'calculate' with subsets of the model parameters (e.g., 'name_of_model$CobjectInterface$calculate('y[3]')' to see if node 'y[3]' is the cause of the problem). Note that if your model is maximizing over parameters whose bounds are not constant (i.e., depend on other parameters), this is one possible cause of such problems; in that case you might try running the MCEM without bounds, by setting 'forceNoConstraints = TRUE'.")
       mean_LL = mean_LL + sample_LL
       if(diff == 1){
         values(model, fixedNodes) <<- oldParamValues #now old params
@@ -70,7 +70,7 @@ calc_E_llk_gen = nimbleFunction(
         }
         sample_LL = calculate(model, latentCalcNodes)
         if(is.na(sample_LL) | is.nan(sample_LL) | sample_LL == -Inf | sample_LL == Inf)
-            stop("Non-finite log-likelihood occurred; the MCEM optimization cannot continue. Please check the state of the compiled model (accessible as 'name_of_model$CobjectInterface') and determine which parameter values are causing the invalid log-likelihood by calling 'calculate' with subsets of the model parameters (e.g., 'name_of_model$CobjectInterface$calculate(\"y[3]\")'). Note that if your model is maximizing over parameters whose bounds are not constant (i.e., depend on other parameters), this is one possible cause of such problems; in that case you might try running the MCEM without bounds, by setting 'forceNoConstraints = TRUE'.")
+            stop("Non-finite log-likelihood occurred; the MCEM optimization cannot continue. Please check the state of the compiled model (accessible as 'name_of_model$CobjectInterface') and determine which parameter values are causing the invalid log-likelihood by calling 'calculate' with subsets of the model parameters (e.g., 'name_of_model$CobjectInterface$calculate('y[3]')'). Note that if your model is maximizing over parameters whose bounds are not constant (i.e., depend on other parameters), this is one possible cause of such problems; in that case you might try running the MCEM without bounds, by setting 'forceNoConstraints = TRUE'.")
         mean_LL = mean_LL - sample_LL
       }
     }


### PR DESCRIPTION
At present, we are not trapping values of model$calculate that cause optim() to fail with this (relatively unhelpful) R error message
```
Error in optim(par = theta, fn = cCalc_E_llk$run, oldParamValues = thetaPrev,  : 
  non-finite finite-difference value [3]
```

We've gotten two user group messages asking about this, which required in-depth debugging by us.

Trapping this within NIMBLE is tricky because in cases where we have constraints and use L-BFGS-B, we had been catching errors in optim() with try() and when finding them, defaulting back to BFGS because we had determined that when the constraints depend on the values of other parameters that that seemed to help. I wasn't involved in that decision, so I'm not sure of the thought process there.

I've now done this:

1) As before, we use L-BFGS-B if a user provides boxConstraints or NIMBLE determines there are finite parameter bounds. But now we now longer default back to BFGS if it fails. Instead we stop and give the user an error message. (And we have this same error trap and message when optim() uses BFGS.)
2) The error message indicates that they can call calculate on the compiled model (which is now accessible from within the uncompiled model they created) to determine which node(s) produce the NA/NaN/-Inf/Inf.
3) To address the case of constraints depending on other parameters, I added an argument 'forceNoConstraints' that allows a user to go back to the previous behavior of defaulting back to BFGS if L-BFGS-B fails.  This is not exactly as before as it uses BFGS for all iterations, while before it would only start to use BFGS when L-BFGS-B experiences a failure. It may be feasible to mimic previous behavior, but for the moment seems cleanest to me to do this.