### PR TITLE
added nimble package option MCMCmultivariateNodesAsScalars

### DIFF
--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -1058,8 +1058,9 @@ nimbleOptions(MCMCdefaultSamplerAssignmentRules = samplerAssignmentRules())
 #'@seealso \code{\link{samplerAssignmentRules}} \code{\link{buildMCMC}} \code{\link{runMCMC}} \code{\link{nimbleMCMC}}
 configureMCMC <- function(model, nodes, control = list(), 
                           monitors, thin = 1, monitors2 = character(), thin2 = 1,
-                          useConjugacy = TRUE, onlyRW = FALSE, onlySlice = FALSE, multivariateNodesAsScalars = FALSE,
-                          enableWAIC = nimbleOptions('enableWAIC'),
+                          useConjugacy = TRUE, onlyRW = FALSE, onlySlice = FALSE,
+                          multivariateNodesAsScalars = getNimbleOption('MCMCmultivariateNodesAsScalars'),
+                          enableWAIC = getNimbleOption('enableWAIC'),
                           print = FALSE, autoBlock = FALSE, oldConf,
                           rules = getNimbleOption('MCMCdefaultSamplerAssignmentRules'),
                           warnNoSamplerAssigned = TRUE, ...) {

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -94,8 +94,8 @@ MCMCconf <- setRefClass(
             useConjugacy = TRUE,
             onlyRW = FALSE,
             onlySlice = FALSE,
-            multivariateNodesAsScalars = FALSE,
-            enableWAIC = nimbleOptions('enableWAIC'),
+            multivariateNodesAsScalars = getNimbleOption('MCMCmultivariateNodesAsScalars'),
+            enableWAIC = getNimbleOption('enableWAIC'),
             warnNoSamplerAssigned = TRUE,
             print = FALSE, ...) {
             '

--- a/packages/nimble/R/MCMC_run.R
+++ b/packages/nimble/R/MCMC_run.R
@@ -23,7 +23,7 @@
 #'
 #' @param setSeed Logical or numeric argument.  If a single numeric value is provided, R's random number seed will be set to this value at the onset of each MCMC chain.  If a numeric vector of length \code{nchains} is provided, then each element of this vector is provided as R's random number seed at the onset of the corresponding MCMC chain.  Otherwise, in the case of a logical value, if \code{TRUE}, then R's random number seed for the ith chain is set to be \code{i}, at the onset of each MCMC chain.  Note that specifying the argument \code{setSeed = 0} does not prevent setting the RNG seed, but rather sets the random number generation seed to \code{0} at the beginning of each MCMC chain.  Default value is \code{FALSE}.
 #'
-#' @param progressBar Logical argument.  If \code{TRUE}, an MCMC progress bar is displayed during execution of each MCMC chain.  Default value is \code{TRUE}.
+#' @param progressBar Logical argument.  If \code{TRUE}, an MCMC progress bar is displayed during execution of each MCMC chain.  Default value is defined by the nimble package option MCMCprogressBar.
 #'
 #' @param samples Logical argument.  If \code{TRUE}, then posterior samples are returned from each MCMC chain.  These samples are optionally returned as \code{coda} \code{mcmc} objects, depending on the \code{samplesAsCodaMCMC} argument.  Default value is \code{TRUE}.  See details.
 #'
@@ -90,7 +90,7 @@ runMCMC <- function(mcmc,
                     ## reinstate samplerExecutionOrder as a runtime argument, once we support non-scalar default values for runtime arguments:
                     ##samplerExecutionOrder,
                     setSeed = FALSE,
-                    progressBar = TRUE,
+                    progressBar = getNimbleOption('MCMCprogressBar'),
                     samples = TRUE,
                     samplesAsCodaMCMC = FALSE,
                     summary = FALSE,
@@ -212,7 +212,7 @@ runMCMC <- function(mcmc,
 #' 
 #' @param setSeed Logical or numeric argument.  If a single numeric value is provided, R's random number seed will be set to this value at the onset of each MCMC chain.  If a numeric vector of length \code{nchains} is provided, then each element of this vector is provided as R's random number seed at the onset of the corresponding MCMC chain.  Otherwise, in the case of a logical value, if \code{TRUE}, then R's random number seed for the ith chain is set to be \code{i}, at the onset of each MCMC chain.  Note that specifying the argument \code{setSeed = 0} does not prevent setting the RNG seed, but rather sets the random number generation seed to \code{0} at the beginning of each MCMC chain.  Default value is \code{FALSE}.
 #'
-#' @param progressBar Logical argument.  If \code{TRUE}, an MCMC progress bar is displayed during execution of each MCMC chain.  Default value is \code{TRUE}.
+#' @param progressBar Logical argument.  If \code{TRUE}, an MCMC progress bar is displayed during execution of each MCMC chain.  Default value is defined by the nimble package option MCMCprogressBar..
 #'
 #' @param samples Logical argument.  If \code{TRUE}, then posterior samples are returned from each MCMC chain.  These samples are optionally returned as \code{coda} \code{mcmc} objects, depending on the \code{samplesAsCodaMCMC} argument.  Default value is \code{TRUE}.  See details.
 #'
@@ -277,7 +277,7 @@ nimbleMCMC <- function(code,
                        nchains = 1,
                        check = TRUE,
                        setSeed = FALSE,
-                       progressBar = TRUE,
+                       progressBar = getNimbleOption('MCMCprogressBar'),
                        samples = TRUE,
                        samplesAsCodaMCMC = FALSE,
                        summary = FALSE,

--- a/packages/nimble/R/options.R
+++ b/packages/nimble/R/options.R
@@ -58,7 +58,9 @@ nimbleUserNamespace <- as.environment(list(sessionSpecificDll = NULL))
         MCMCuseSamplerAssignmentRules = FALSE,
         saveMCMChistory = FALSE,
         MCMCdefaultSamplerAssignmentRules = NULL,
-        
+
+        MCMCmultivariateNodesAsScalars = FALSE,
+
         enableWAIC = FALSE
         ## default settings for MCMC samplers
         ## control list defaults for MCMC samplers are


### PR DESCRIPTION
Do not merge.  Created PR to trigger testing.

Introduces a new `nimble` package option, to control the MCMC behaviour of multivariateNodesAsScalars, whether multivariate nodes are sampled as scalars.
