### PR TITLE
new MCMC option: MCMCmonitorAllSampledNodes

### DIFF
--- a/UserManual/src/chapter_MCMC.Rmd
+++ b/UserManual/src/chapter_MCMC.Rmd
@@ -451,7 +451,7 @@ Rmcmc <- buildMCMC(mcmcConf, enableWAIC = TRUE)
 
 `buildMCMC` is a nimbleFunction.  The returned object `Rmcmc` is an instance  of the nimbleFunction specific to configuration `mcmcConf` (and of course its associated model).  
 
-Note that if you would like to be able to calculate the WAIC of the model after the MCMC function has been run, you must set `enableWAIC = TRUE` as an argument to either `configureMCMC` or `buildMCMC`, or set `nimbleOptions(enableWAIC = TRUE)`, which will enable WAIC calculations for all subsequently built MCMC functions.  For more information on WAIC calculations, see Section \@ref(sec:WAIC) or `help(buildMCMC)` in R.
+Note that if you would like to be able to calculate the WAIC of the model after the MCMC function has been run, you must set `enableWAIC = TRUE` as an argument to either `configureMCMC` or `buildMCMC`, or set `nimbleOptions(MCMCenableWAIC = TRUE)`, which will enable WAIC calculations for all subsequently built MCMC functions.  For more information on WAIC calculations, see Section \@ref(sec:WAIC) or `help(buildMCMC)` in R.
 
 When no customization is needed, one can skip `configureMCMC` and simply provide a model object to `buildMCMC`. The following two MCMC functions will be identical:
 

--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -108,7 +108,7 @@ buildMCMC <- nimbleFunction(
     	if(inherits(conf, 'modelBaseClass'))   conf <- configureMCMC(conf, ...)
     	else if(!inherits(conf, 'MCMCconf')) stop('conf must either be a nimbleModel or a MCMCconf object (created by configureMCMC(...) )')
         dotdotdotArgs <- list(...)
-        enableWAICargument <- if(!is.null(dotdotdotArgs$enableWAIC)) dotdotdotArgs$enableWAIC else nimbleOptions('enableWAIC')    ## accept enableWAIC argument regardless
+        enableWAICargument <- if(!is.null(dotdotdotArgs$enableWAIC)) dotdotdotArgs$enableWAIC else nimbleOptions('MCMCenableWAIC')    ## accept enableWAIC argument regardless
         model <- conf$model
         my_initializeModel <- initializeModel(model)
         mvSaved <- modelValues(model)

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -95,7 +95,7 @@ MCMCconf <- setRefClass(
             onlyRW = FALSE,
             onlySlice = FALSE,
             multivariateNodesAsScalars = getNimbleOption('MCMCmultivariateNodesAsScalars'),
-            enableWAIC = getNimbleOption('enableWAIC'),
+            enableWAIC = getNimbleOption('MCMCenableWAIC'),
             warnNoSamplerAssigned = TRUE,
             print = FALSE, ...) {
             '
@@ -134,7 +134,7 @@ onlySlice: A logical argument, with default value FALSE.  If specified as TRUE, 
 
 multivariateNodesAsScalars: A logical argument, with default value FALSE.  If specified as TRUE, then non-terminal multivariate stochastic nodes will have scalar samplers assigned to each of the scalar components of the multivariate node.  The default value of FALSE results in a single block sampler assigned to the entire multivariate node.  Note, multivariate nodes appearing in conjugate relationships will be assigned the corresponding conjugate sampler (provided useConjugacy == TRUE), regardless of the value of this argument.
 
-enableWAIC: A logical argument, specifying whether to enable WAIC calculations for the resulting MCMC algorithm.  Defaults to the value of nimbleOptions(\'enableWAIC\'), which in turn defaults to FALSE.  Setting nimbleOptions(\'enableWAIC\' = TRUE) will ensure that WAIC is enabled for all calls to configureMCMC and buildMCMC.
+enableWAIC: A logical argument, specifying whether to enable WAIC calculations for the resulting MCMC algorithm.  Defaults to the value of nimbleOptions(\'MCMCenableWAIC\'), which in turn defaults to FALSE.  Setting nimbleOptions(\'MCMCenableWAIC\' = TRUE) will ensure that WAIC is enabled for all calls to configureMCMC and buildMCMC.
 
 warnNoSamplerAssigned: A logical argument specifying whether to issue a warning when no sampler is assigned to a node, meaning there is no matching sampler assignment rule. Default is TRUE.
 
@@ -560,7 +560,11 @@ Details: See the initialize() function
 
             vars <- list(...)
             if(length(vars) == 1 && is.null(vars[[1]])) {
-                vars <- model$getNodeNames(topOnly = TRUE, stochOnly = TRUE)
+                if(getNimbleOption('MCMCmonitorAllSampledNodes')) {
+                    vars <- model$getNodeNames(stochOnly = TRUE, includeData = FALSE)
+                } else {
+                    vars <- model$getNodeNames(stochOnly = TRUE, includeData = FALSE, topOnly = TRUE)
+                }
             } else {
                 vars <- unlist(vars)
             }
@@ -1045,7 +1049,7 @@ nimbleOptions(MCMCdefaultSamplerAssignmentRules = samplerAssignmentRules())
 #'@param onlyRW A logical argument, with default value FALSE.  If specified as TRUE, then Metropolis-Hastings random walk samplers (\link{sampler_RW}) will be assigned for all non-terminal continuous-valued nodes nodes. Discrete-valued nodes are assigned a slice sampler (\link{sampler_slice}), and terminal nodes are assigned a posterior_predictive sampler (\link{sampler_posterior_predictive}).
 #'@param onlySlice A logical argument, with default value FALSE.  If specified as TRUE, then a slice sampler is assigned for all non-terminal nodes. Terminal nodes are still assigned a posterior_predictive sampler.
 #'@param multivariateNodesAsScalars A logical argument, with default value FALSE.  If specified as TRUE, then non-terminal multivariate stochastic nodes will have scalar samplers assigned to each of the scalar components of the multivariate node.  The default value of FALSE results in a single block sampler assigned to the entire multivariate node.  Note, multivariate nodes appearing in conjugate relationships will be assigned the corresponding conjugate sampler (provided \code{useConjugacy == TRUE}), regardless of the value of this argument.
-#' @param enableWAIC A logical argument, specifying whether to enable WAIC calculations for the resulting MCMC algorithm.  Defaults to the value of \code{nimbleOptions('enableWAIC')}, which in turn defaults to FALSE.  Setting \code{nimbleOptions('enableWAIC' = TRUE)} will ensure that WAIC is enabled for all calls to \code{configureMCMC} and \code{buildMCMC}.
+#' @param enableWAIC A logical argument, specifying whether to enable WAIC calculations for the resulting MCMC algorithm.  Defaults to the value of \code{nimbleOptions('MCMCenableWAIC')}, which in turn defaults to FALSE.  Setting \code{nimbleOptions('enableWAIC' = TRUE)} will ensure that WAIC is enabled for all calls to \code{configureMCMC} and \code{buildMCMC}.
 #'@param rules An object of class samplerAssignmentRules, which governs the assigment of MCMC sampling algorithms to stochastic model nodes.  The default set of sampler assignment rules is specified by the nimble option \'MCMCdefaultSamplerAssignmentRules\'.
 #'@param warnNoSamplerAssigned A logical argument, with default value TRUE.  This specifies whether to issue a warning when no sampler is assigned to a node, meaning there is no matching sampler assignment rule.
 #'@param print A logical argument, specifying whether to print the ordered list of default samplers.
@@ -1060,7 +1064,7 @@ configureMCMC <- function(model, nodes, control = list(),
                           monitors, thin = 1, monitors2 = character(), thin2 = 1,
                           useConjugacy = TRUE, onlyRW = FALSE, onlySlice = FALSE,
                           multivariateNodesAsScalars = getNimbleOption('MCMCmultivariateNodesAsScalars'),
-                          enableWAIC = getNimbleOption('enableWAIC'),
+                          enableWAIC = getNimbleOption('MCMCenableWAIC'),
                           print = FALSE, autoBlock = FALSE, oldConf,
                           rules = getNimbleOption('MCMCdefaultSamplerAssignmentRules'),
                           warnNoSamplerAssigned = TRUE, ...) {

--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -164,7 +164,7 @@ sampler_RW <- nimbleFunction(
         timesAdapted  <- 0
         scaleHistory  <- c(0, 0)   ## scaleHistory
         acceptanceHistory  <- c(0, 0)   ## scaleHistory
-        if(nimbleOptions('saveMCMChistory')) {
+        if(nimbleOptions('MCMCsaveHistory')) {
             saveMCMChistory <- TRUE
         } else saveMCMChistory <- FALSE
         optimalAR     <- 0.44
@@ -235,7 +235,7 @@ sampler_RW <- nimbleFunction(
             if(saveMCMChistory) {
                 return(scaleHistory)
             } else {
-                print("Please set 'nimbleOptions(saveMCMChistory = TRUE)' before building the MCMC")
+                print("Please set 'nimbleOptions(MCMCsaveHistory = TRUE)' before building the MCMC")
                 return(numeric(1, 0))
             }
         },          
@@ -244,7 +244,7 @@ sampler_RW <- nimbleFunction(
             if(saveMCMChistory) {
                 return(acceptanceHistory)
             } else {
-                print("Please set 'nimbleOptions(saveMCMChistory = TRUE)' before building the MCMC")
+                print("Please set 'nimbleOptions(MCMCsaveHistory = TRUE)' before building the MCMC")
                 return(numeric(1, 0))
             }
         },          
@@ -307,7 +307,7 @@ sampler_RW_block <- nimbleFunction(
         scaleHistory  <- c(0, 0)                                                 ## scaleHistory
         acceptanceHistory  <- c(0, 0)                                            ## scaleHistory
         propCovHistory <- if(d<=10) array(0, c(2,d,d)) else array(0, c(2,2,2))   ## scaleHistory
-        saveMCMChistory <- if(nimbleOptions('saveMCMChistory')) TRUE else FALSE
+        saveMCMChistory <- if(nimbleOptions('MCMCsaveHistory')) TRUE else FALSE
         if(is.character(propCov) && propCov == 'identity')     propCov <- diag(d)
         propCovOriginal <- propCov
         chol_propCov <- chol(propCov)
@@ -394,17 +394,17 @@ sampler_RW_block <- nimbleFunction(
             }
         },
         getScaleHistory = function() {  ## scaleHistory
-            if(!saveMCMChistory)   print("Please set 'nimbleOptions(saveMCMChistory = TRUE)' before building the MCMC")
+            if(!saveMCMChistory)   print("Please set 'nimbleOptions(MCMCsaveHistory = TRUE)' before building the MCMC")
             returnType(double(1))
             return(scaleHistory)
         },          
         getAcceptanceHistory = function() {  ## scaleHistory
             returnType(double(1))
-            if(!saveMCMChistory)   print("Please set 'nimbleOptions(saveMCMChistory = TRUE)' before building the MCMC")
+            if(!saveMCMChistory)   print("Please set 'nimbleOptions(MCMCsaveHistory = TRUE)' before building the MCMC")
             return(acceptanceHistory)
         },                  
         getPropCovHistory = function() { ## scaleHistory
-            if(!saveMCMChistory | d > 10)   print("Please set 'nimbleOptions(saveMCMChistory = TRUE)' before building the MCMC and note that to reduce memory use we only save the proposal covariance history for parameter vectors of length 10 or less")
+            if(!saveMCMChistory | d > 10)   print("Please set 'nimbleOptions(MCMCsaveHistory = TRUE)' before building the MCMC and note that to reduce memory use we only save the proposal covariance history for parameter vectors of length 10 or less")
             returnType(double(3))
             return(propCovHistory)
         },

--- a/packages/nimble/R/options.R
+++ b/packages/nimble/R/options.R
@@ -51,17 +51,17 @@ nimbleUserNamespace <- as.environment(list(sessionSpecificDll = NULL))
         ## update May 2016: old (non-dynamic) system is no longer supported -DT
         ##useDynamicConjugacy = TRUE,
 
-        MCMCprogressBar = TRUE,
 
         ## samplerAssignmentRules object that controls the default sampler assignments by configureMCMC.
         ## value is set to samplerAssignmentRules() (the defaults) in MCMC_configuration.R
+        MCMCprogressBar = TRUE,
         MCMCuseSamplerAssignmentRules = FALSE,
-        saveMCMChistory = FALSE,
+        MCMCsaveHistory = FALSE,
         MCMCdefaultSamplerAssignmentRules = NULL,
-
         MCMCmultivariateNodesAsScalars = FALSE,
-
-        enableWAIC = FALSE
+        MCMCmonitorAllSampledNodes = FALSE,
+        MCMCenableWAIC = FALSE
+        
         ## default settings for MCMC samplers
         ## control list defaults for MCMC samplers are
         ## now part of the sampler functions (setup code).


### PR DESCRIPTION
Opening PR to trigger testing.

Adds a new package MCMC option `MCMCmonitorAllSampledNodes` (default FALSE).

When TRUE, by default the MCMC will monitor all latent states that are being sampled, in addition to the top level nodes (the usual default behaviour).

