### PR TITLE
Fix configureMCMC slowdown due to dCRP checking (even when there is no dCRP)

### DIFF
--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -196,7 +196,9 @@ print: A logical argument specifying whether to print the ordered list of defaul
                 ## use old (static) system for assigning default samplers
                 isEndNode <- model$isEndNode(nodes)
                 if(useConjugacy) conjugacyResultsAll <- model$checkConjugacy(nodes)
-                
+                allDists <- unlist(lapply(model$modelDef$declInfo, `[[`, 'distributionName'))
+                allDists <- allDists[!is.na(allDists)]
+                check_dCRP <- any(allDists == "dCRP")
                 for(i in seq_along(nodes)) {
                     node <- nodes[i]
                     discrete <- model$isDiscrete(node)
@@ -250,13 +252,17 @@ print: A logical argument specifying whether to print the ordered list of defaul
                     if(discrete) { addSampler(target = node, type = 'slice');     next }
                     
                     ## if node distribution is dgamma and its dependency is dCRP, assign 'augmented_BetaGamma' sampler
-                    if(nodeDist == 'dgamma'){
-                      depNode <- model$getDependencies(node, self=FALSE)
-                      depNodeDist <- model$getDistribution(depNode)
-                      if(length(depNodeDist) == 1 && depNodeDist == 'dCRP'){
-                        addSampler(target = node, type = 'CRP_concentration')
-                        next
-                      }
+                    if(check_dCRP) {
+                        if(nodeDist == 'dgamma'){
+                            depNode <- model$getDependencies(node, self=FALSE)
+                            if(length(depNode) == 1) {
+                                depNodeDist <- model$getDistribution(depNode)
+                                if(!is.na(depNodeDist[1]) & depNodeDist[1] == 'dCRP'){  ## depNodeDist should be length 1
+                                    addSampler(target = node, type = 'CRP_concentration')
+                                    next
+                                }
+                            }
+                        }
                     }
                     
                     ## default: 'RW' sampler


### PR DESCRIPTION
Checking for `dCRP` created a potentially catastrophic slowdown for models with many gamma nodes or gamma nodes with many dependencies.  This PR helps this in two ways:

- If there is no use of `dCRP` in a model, the relevant checking is skipped entirely.
- The `getDistribution` step can be slow.  Therefore this PR first checks if there is only one dependency and then checks its distribution, rather than (as it was) getting all dependency distributions, then checking if that has length one and matches `dCRP`.

This issue merits further attention.  This PR is a quick fix.
