### PR TITLE
Samplers by type

### DIFF
--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -457,7 +457,7 @@ byType: A logical argument, specifying whether the nodes being sampled should be
                 typeInd <- unique(unname(unlist(lapply(type, grep, x = lapply(conf$samplerConfs, `[[`, 'name')))))
                 ind <- intersect(ind, typeInd)
             }
-            if(byType) {
+            if(byType && length(ind) > 0) {
                 samplerTypes <- unlist(lapply(ind, function(i) conf$samplerConfs[[i]]$name))
                 uniqueSamplerTypes <- sort(unique(samplerTypes), decreasing = TRUE)
                 nodesSortedBySamplerType <- lapply(uniqueSamplerTypes, function(type) sapply(conf$samplerConfs[which(samplerTypes == type)], `[[`, 'target'))

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -430,7 +430,7 @@ print: A logical argument specifying whether to print the new list of samplers (
             return(invisible(NULL))
         },
         
-        printSamplers = function(ind, type, displayControlDefaults = FALSE, displayNonScalars = FALSE, displayConjugateDependencies = FALSE, executionOrder = FALSE) {
+        printSamplers = function(ind, type, displayControlDefaults = FALSE, displayNonScalars = FALSE, displayConjugateDependencies = FALSE, executionOrder = FALSE, byType = FALSE) {
             '
 Prints details of the MCMC samplers.
 
@@ -445,6 +445,8 @@ displayConjugateDependencies: A logical argument, specifying whether to display 
 displayNonScalars: A logical argument, specifying whether to display the values of non-scalar control list elements (default FALSE).
 
 executionOrder: A logical argument, specifying whether to print the sampler functions in the (possibly modified) order of execution (default FALSE).
+
+byType: A logical argument, specifying whether the nodes being sampled should be printed, sorted and organized according to the type of sampler (the sampling algorithm) which is acting on the nodes (default FALSE).
 '
             if(missing(ind))        ind <- seq_along(samplerConfs)
             if(is.character(ind))   ind <- findSamplersOnNodes(ind)
@@ -454,6 +456,20 @@ executionOrder: A logical argument, specifying whether to print the sampler func
                 ## find sampler indices with 'name' matching anything in 'type' argument:
                 typeInd <- unique(unname(unlist(lapply(type, grep, x = lapply(conf$samplerConfs, `[[`, 'name')))))
                 ind <- intersect(ind, typeInd)
+            }
+            if(byType) {
+                samplerTypes <- unlist(lapply(ind, function(i) conf$samplerConfs[[i]]$name))
+                uniqueSamplerTypes <- sort(unique(samplerTypes), decreasing = TRUE)
+                nodesSortedBySamplerType <- lapply(uniqueSamplerTypes, function(type) sapply(conf$samplerConfs[which(samplerTypes == type)], `[[`, 'target'))
+                names(nodesSortedBySamplerType) <- uniqueSamplerTypes
+                cat('\n')
+                for(i in seq_along(nodesSortedBySamplerType)) {
+                    theseSampledNodes <- nodesSortedBySamplerType[[i]]
+                    cat(paste0(names(nodesSortedBySamplerType)[i], ' sampler (', length(theseSampledNodes), '):  '))
+                    cat(paste0(theseSampledNodes, collapse = ', '))
+                    cat('\n\n')
+                }
+                return(invisible(NULL))
             }
             makeSpaces <- if(length(ind) > 0) newSpacesFunction(max(ind)) else NULL
             if(executionOrder)      ind <- samplerExecutionOrder[samplerExecutionOrder %in% ind]


### PR DESCRIPTION
Added a new display option argument for the `printSamplers` method of MCMC configuration objects.

The option is called `byType`, and specifying `printSamplers(byType = TRUE)` will print the sampled nodes, grouped by the sampling algorithm assigned to them.

Example:

```
> conf$printSamplers(byType = TRUE)
## 
## conjugate_dnorm_dnorm sampler (2):  a[1], a[2]
## 
## conjugate_dgamma_dnorm sampler (1):  b
## 
## RW sampler (10):  x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10]
## 
```