### PR TITLE
In getNodeNames, only query isData if necessary

### DIFF
--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -400,12 +400,14 @@ Details: Multiple logical input arguments may be used simultaneously.  For examp
                                       if(determOnly)			validValues[modelDef$maps$types != 'determ']	<- FALSE
                                       if(stochOnly)			validValues[modelDef$maps$types != 'stoch']	<- FALSE
 
-                                      boolIsData <- rep(FALSE, length(modelDef$maps$graphIDs))
-                                      possibleDataIDs <- modelDef$maps$graphIDs[modelDef$maps$types == 'RHSonly' | modelDef$maps$types == 'stoch']
-                                      boolIsData[possibleDataIDs] <- isDataFromGraphID(possibleDataIDs)
-
-                                      if(!includeData)		        validValues[boolIsData] <- FALSE
-                                      if(dataOnly)			validValues[!boolIsData] <- FALSE
+                                      if(!includeData | dataOnly) {
+                                          boolIsData <- rep(FALSE, length(modelDef$maps$graphIDs))
+                                          possibleDataIDs <- modelDef$maps$graphIDs[modelDef$maps$types == 'RHSonly' | modelDef$maps$types == 'stoch']
+                                          boolIsData[possibleDataIDs] <- isDataFromGraphID(possibleDataIDs)
+                                          
+                                          if(!includeData)		        validValues[boolIsData] <- FALSE
+                                          if(dataOnly)			validValues[!boolIsData] <- FALSE
+                                      }
                                       if(topOnly)			validValues[-modelDef$maps$top_IDs] <- FALSE
                                       if(latentOnly)			validValues[-modelDef$maps$latent_IDs] <- FALSE
                                       if(endOnly)				validValues[-modelDef$maps$end_IDs] <- FALSE


### PR DESCRIPTION
In getNodeNames, most options (`determOnly`, `stochOnly`, etc) involve fast implementation because there are cached vectors of these labels in the `modelDef$maps`.  The `includeData` and `dataOnly` options involve slower implementation because data status is a model-level rather than modelDef-level state.  As a result, building the information to handle data status options is slower. 
 It only needs to be done if it is relevant, but currently it is always done even if not used.  With default arguments, it is not relevant.  This PR avoids building that information unless it is needed.

One place this will be felt is in default behavior of `configureMCMC`, which calls `model$getNodeNames`.  For a large model, this change should save seconds.
