### PR TITLE
enhance max contractions warning in slice sampler

### DIFF
--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -554,7 +554,7 @@ sampler_slice <- nimbleFunction(
         }
         if((R-L)/(abs(R)+abs(L)+eps) <= eps | numContractions == maxContractions) {
             if(maxContractionsWarning)
-                cat("Warning: slice sampler reached maximum number of contractions.\n")
+                cat("Warning: slice sampler reached maximum number of contractions for '", target, "'. Current parameter value is ", x0, ".\n")
             nimCopy(from = mvSaved, to = model, row = 1, nodes = calcNodes, logProb = TRUE)
         } else {
             nimCopy(from = model, to = mvSaved, row = 1, nodes = calcNodes, logProb = TRUE)


### PR DESCRIPTION
Currently we just warn that max contractions is reached. This changes the warning to say what parameter this is occurring for and the current value of the parameter in hopes that will help users understand what is wrong with their model that this would occur.