### PR TITLE
allow logical values in model code

### DIFF
--- a/packages/nimble/R/BUGS_BUGSdecl.R
+++ b/packages/nimble/R/BUGS_BUGSdecl.R
@@ -658,7 +658,7 @@ getSymbolicParentNodesRecurse <- function(code, constNames = list(), indexNames 
     ##                indexing, not dynamic indexing
     ## - hasIndex: is there an index inside
     ## numeric constant
-    if(is.numeric(code) ||
+    if(is.numeric(code) || is.logical(code) || 
        (nimbleOptions()$allowDynamicIndexing &&
                        length(code) > 1 &&
                        code[[1]] == ".DYN_INDEXED")
@@ -906,7 +906,7 @@ genReplacementsAndCodeRecurse <- function(code,
                                           replaceVariableLHS = TRUE,
                                           debug = FALSE) {
     if(debug) browser()
-    if(is.numeric(code) ||
+    if(is.numeric(code) || is.logical(code) ||
        (nimbleOptions()$allowDynamicIndexing &&
                        length(code) > 1 &&
                        code[[1]] == '.DYN_INDEXED')

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -917,7 +917,7 @@ replaceConstantsRecurse <- function(code, constEnv, constNames, do.eval = TRUE) 
             return(list(code = code,
                         replaceable = FALSE))
         }
-        if( is.numeric(code)) {
+        if( is.numeric(code) || is.logical(code) ) {
             return(list(code = code,
                         replaceable = TRUE))
         }
@@ -1047,6 +1047,8 @@ isExprLiftable <- function(paramExpr, type = NULL) {
     ## determines whether a parameter expression is worthy of lifiting up to a new node
     if(is.name(paramExpr))       return(FALSE)
     if(is.numeric(paramExpr))    return(FALSE)
+    if(is.logical(paramExpr))
+        stop("isExprLiftable: NIMBLE is not expecting a logical/boolean value; please use a numeric value in place of ", paramExpr, ".") 
     if(is.call(paramExpr)) {
         callText <- getCallText(paramExpr)
         if(callText == 'chol')         return(TRUE)    ## do lift calls to chol(...)
@@ -1069,7 +1071,7 @@ isExprLiftable <- function(paramExpr, type = NULL) {
         if(is.vectorized(paramExpr))        return(FALSE)   ## don't lift any expression with vectorized indexing,  funName(x[1:10])
         return(TRUE)
     }
-    stop(paste0('error, I need to figure out how to process this parameter expression: ', deparse(paramExpr)))
+    stop(paste0('isExprLiftable: NIMBLE cannot process this parameter expression: ', deparse(paramExpr)))
 }
 addNecessaryIndexingToNewNode <- function(newNodeNameExpr, paramExpr, indexVarExprs) {
     if(is.call(paramExpr) && deparse(paramExpr[[1]]) %in% names(liftedCallsGetIndexingFromArgumentNumbers))


### PR DESCRIPTION
This fixes issue #875 modifies: replaceConstantsRecurse, genReplacementsAndCodeRecurse, getSymbolicVariablesRecurse, so that logical values will pass through, treated
as numeric values are. 

@perrydv would be great if you take a look in case you think of any cases this would cause problems in for compilation. 

This PR allows this code  to work (instead of requiring that users say `lower.tail=0` and returning an unhelpful error message if they don't (see issue #875 ).
```
code = nimbleCode({
   y ~ dnorm(0,1)
   a <- pnorm(y, mu, 1, lower.tail=FALSE)
   mu ~ dnorm(0, 1)
 })
m = nimbleModel(code, data = list(y=0), inits = list(mu = 1))
cm = compileNimble(m)
cm$a
```

Note that in the process I also modified what happens when TRUE/FALSE is used as a parameter value. Previously that was erroring out as:
```
code = nimbleCode({
     a ~ dnorm(TRUE, 1)
 })
m = nimbleModel(code)
Error in replaceConstantsRecurse(x, constEnv, constNames) : 
  Error, hit end
```

Now we trap it in in `isExprLiftable`:
```
code = nimbleCode({
      a ~ dnorm(TRUE, 1)
  })
 m = nimbleModel(code)
defining model...
Error in isExprLiftable(paramExpr, types[[paramName]]) : 
  isExprLiftable: NIMBLE is not expecting a logical/boolean value; please use a numeric value in place of TRUE.
```
