### PR TITLE
add check for clustering of deterministic nodes in BNP models

### DIFF
--- a/packages/nimble/R/BNP_samplers.R
+++ b/packages/nimble/R/BNP_samplers.R
@@ -1503,8 +1503,6 @@ findClusterNodes <- function(model, target) {
     if(nTilde[[varIdx]]) {
         if(any(is.na(clusterNodes[[varIdx]])))  
             stop("findClusterNodes: fewer cluster IDs in ", target, " than elements being clustered.")
-        if(any(model$isDeterm(clusterNodes[[varIdx]])))
-            stop("findClusterNodes: detected that deterministic nodes are being clustered. Please use the dCRP node to cluster stochastic nodes.")
         if(!all(clusterNodes[[varIdx]] %in% modelNodes)) {  # i.e., truncated representation
             cnt <- nTilde[varIdx]
             while(cnt > 0) {
@@ -1528,6 +1526,10 @@ findClusterNodes <- function(model, target) {
         }
     }
   }
+  for(varIdx in seq_along(clusterVars)) 
+      if(any(model$isDeterm(clusterNodes[[varIdx]])))
+          stop("findClusterNodes: detected that deterministic nodes are being clustered. Please use the dCRP node to cluster stochastic nodes.")
+
   return(list(clusterNodes = clusterNodes, clusterVars = clusterVars, nTilde = nTilde,
               targetIsIndex = targetIsIndex, indexPosition = indexPosition, indexExpr = indexExpr,
               numIndexes = numIndexes, targetIndexedByFunction = targetIndexedByFunction,

--- a/packages/nimble/R/BNP_samplers.R
+++ b/packages/nimble/R/BNP_samplers.R
@@ -1503,6 +1503,8 @@ findClusterNodes <- function(model, target) {
     if(nTilde[[varIdx]]) {
         if(any(is.na(clusterNodes[[varIdx]])))  
             stop("findClusterNodes: fewer cluster IDs in ", target, " than elements being clustered.")
+        if(any(model$isDeterm(clusterNodes[[varIdx]])))
+            stop("findClusterNodes: detected that deterministic nodes are being clustered. Please use the dCRP node to cluster stochastic nodes.")
         if(!all(clusterNodes[[varIdx]] %in% modelNodes)) {  # i.e., truncated representation
             cnt <- nTilde[varIdx]
             while(cnt > 0) {


### PR DESCRIPTION
This adds a check in `findClusterNodes` to address NCT issue 122.