### PR TITLE
Faster getDependencyPaths

### DIFF
--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -682,7 +682,16 @@ Details: This provides a fairly raw representation of the graph (model) structur
                                           stop("getDependencyPathCountOneNode: argument 'node' should be a character node name or a numeric node ID.")
                                       modelDef$maps$nimbleGraph$getDependencyPathCountOneNode(node = node)
                                   },
-
+getDependencyPaths = function(node) {
+    if(length(node) > 1)
+        stop("getDependencyPaths: argument 'node' should provide a single node.")
+    if(inherits(node, 'character')) {
+        node <- modelDef$nodeName2GraphIDs(node)
+    }
+    if(!inherits(node, 'numeric'))
+        stop("getDependencyPaths: argument 'node' should be a character node name or a numeric node ID.")
+    modelDef$maps$nimbleGraph$getDependencyPaths(node = node)
+},
                                   getDependencies = function(nodes, omit = character(), self = TRUE,
                                       determOnly = FALSE, stochOnly = FALSE,
                                       includeData = TRUE, dataOnly = FALSE,

--- a/packages/nimble/R/BUGS_nimbleGraph.R
+++ b/packages/nimble/R/BUGS_nimbleGraph.R
@@ -33,12 +33,16 @@ nimbleGraphClass <- setRefClass(
                     }
                 }
             }
-
             .Call(C_getDependencies, graphExtPtr, nodes, omit, downstream)
         },
         getDependencyPathCountOneNode = function(node) {
             if(length(node) > 1)
                 stop("getDependencyPathCountOneNode: argument 'node' should provide a single node.")
             .Call(C_getDependencyPathCountOneNode, graphExtPtr, node)
+        },
+        getDependencyPaths = function(node) {
+            if(length(node) > 1)
+                stop("getDependencyPaths: argument 'node' should provide a single node.")
+            .Call(C_getDependencyPaths, graphExtPtr, node)  
         }
     ))

--- a/packages/nimble/R/options.R
+++ b/packages/nimble/R/options.R
@@ -7,6 +7,7 @@ nimbleUserNamespace <- as.environment(list(sessionSpecificDll = NULL))
 # These options are for development use at this point.
 .nimbleOptions <- as.environment(
     list(
+        oldConjugacyChecking = TRUE,
         disallow_multivariate_argument_expressions = TRUE,
         stop_after_processing_model_code = FALSE,
         enableModelMacros = FALSE,

--- a/packages/nimble/R/options.R
+++ b/packages/nimble/R/options.R
@@ -7,7 +7,7 @@ nimbleUserNamespace <- as.environment(list(sessionSpecificDll = NULL))
 # These options are for development use at this point.
 .nimbleOptions <- as.environment(
     list(
-        oldConjugacyChecking = FALSE,
+        oldConjugacyChecking = TRUE,
         disallow_multivariate_argument_expressions = TRUE,
         stop_after_processing_model_code = FALSE,
         enableModelMacros = FALSE,

--- a/packages/nimble/R/options.R
+++ b/packages/nimble/R/options.R
@@ -7,7 +7,7 @@ nimbleUserNamespace <- as.environment(list(sessionSpecificDll = NULL))
 # These options are for development use at this point.
 .nimbleOptions <- as.environment(
     list(
-        oldConjugacyChecking = TRUE,
+        oldConjugacyChecking = FALSE,
         disallow_multivariate_argument_expressions = TRUE,
         stop_after_processing_model_code = FALSE,
         enableModelMacros = FALSE,

--- a/packages/nimble/inst/CppCode/nimbleGraph.cpp
+++ b/packages/nimble/inst/CppCode/nimbleGraph.cpp
@@ -470,15 +470,15 @@ void nimbleGraph::getDependenciesOneNode(vector<int> &deps,
 /**********************/
 
 class depStep_class {
- private:
+private:
   int nodeID_and_parentExprID[2]; // nodeID is first element.  parentExprID is second element
-
+public:
   int& nodeID() {return nodeID_and_parentExprID[0];}
   const int& nodeID() const {return nodeID_and_parentExprID[0];}
   int& parentExprID() {return nodeID_and_parentExprID[1];}
   const int& parentExprID() const {return nodeID_and_parentExprID[1];}
-  oneDepStep_class() {};
-  oneDepStep_class(int nodeID_, int parentExprID_) {
+  depStep_class() {};
+  depStep_class(int nodeID_, int parentExprID_) {
     nodeID() = nodeID_;
     parentExprID() = parentExprID_;
   }
@@ -487,53 +487,100 @@ class depStep_class {
 typedef vector<depStep_class> depPath;
 typedef vector<depPath> multipleDepPaths;
 
+multipleDepPaths getDependencyPaths_recurse(const graphNode *currentNode, depPath &root_path, int parentExprID) {
+  //PRINTF("F\n");
+
+  multipleDepPaths result;
+  depStep_class thisStep(currentNode->RgraphID, parentExprID);
+  // PRINTF("Adding %i => %i\n", currentNode->RgraphID, root_path.size()); 
+  root_path.push_back(thisStep);
+  if((currentNode->type == STOCH && root_path.size() > 1)) { // stop at non-first stochastic node
+    //    PRINTF("G\n");
+    
+    result.push_back(root_path);
+  } else {
+    // Recurse through child nodes, if there are any.
+    // If there are zero children, we have a terminal deterministic node, which should not be recorded.
+    for(unsigned int i = 0; i < currentNode->numChildren; ++i) {
+      //      PRINTF("H %i\n", result.size());
+      
+      multipleDepPaths result_oneChild = getDependencyPaths_recurse(currentNode->children[i],
+								    root_path,
+								    currentNode->childrenParentExpressionIDs[i]);
+      // PRINTF("I %i\n", result_oneChild.size());
+      // for(int k = 0; k < result_oneChild.size(); ++k) {
+      // 	for(int j = 0; j < result_oneChild[k].size(); ++j) {
+      // 	  PRINTF("%i %i\n", result_oneChild[k][j].nodeID(), result_oneChild[k][j].parentExprID());
+      // 	}
+      // }
+      
+      for(int j = 0; j < result_oneChild.size(); ++j) {
+	result.push_back( result_oneChild[j] );
+      }
+      // PRINTF("J %i\n", result.size());
+      // for(int k = 0; k < result.size(); ++k) {
+      // 	for(int j = 0; j < result[k].size(); ++j) {
+      // 	  PRINTF("%i %i\n", result[k][j].nodeID(), result[k][j].parentExprID());
+      // 	}
+      // }
+    }
+  }
+  root_path.pop_back();
+  // PRINTF("returning\n");
+  // for(int k = 0; k < result.size(); ++k) {
+  //   for(int j = 0; j < result[k].size(); ++j) {
+  //     PRINTF("%i %i\n", result[k][j].nodeID(), result[k][j].parentExprID());
+  //   }
+  // }  
+  return result;
+}
+
 SEXP C_getDependencyPaths(SEXP SgraphExtPtr, SEXP Snodes) {
-  const nimbleGraph *graphPtr = static_cast<const nimbleGraph *>(R_ExternalPtrAddr(SgraphExtPtr));
+  //PRINTF("A\n");
+  nimbleGraph *graphPtr = static_cast<nimbleGraph *>(R_ExternalPtrAddr(SgraphExtPtr));
   vector<int> nodes = SEXP_2_vectorInt(Snodes, -1); // subtract 1 index for C
+  //PRINTF("B\n");
   if(nodes.size() != 1) {
     PRINTF("Input to C_getDependencyPaths should be one and only one nodeID.");
     return R_NilValue;
   }
-  //  depStep_class root_step(nodes[0], INT_MIN); //R_defines.h says INT_MIN is NA_INTEGER
+  if(nodes[0] >= graphPtr->graphNodeVec.size()) {
+    PRINTF("Input to C_getDependencyPaths has a nodeID that is too large.");
+    return R_NilValue;
+
+  }
+  if(graphPtr->graphNodeVec[ nodes[0] ]->numChildren == 0) {
+    return R_NilValue;
+  }
   depPath root_path;
-  // root_path[0] = root_step;
+  //  PRINTF("C\n");
+  //  std::cout<< nodes[0] <<std::endl;
   multipleDepPaths result = getDependencyPaths_recurse(graphPtr->graphNodeVec[ nodes[0] ],
-						       root_path,
-						       INT_MIN); //R_defines.h says INT_MIN is NA_INTEGER
+  						       root_path,
+  						       INT_MIN); //R_defines.h says INT_MIN is NA_INTEGER
+  //  PRINTF("D\n");
+
   SEXP Sresult = PROTECT(Rf_allocVector(VECSXP, result.size()));
+  //  PRINTF("W %i\n", result.size());
+  SEXP Sdim;
   for(int i = 0; i < result.size(); ++i) {
     SEXP SdepPath = PROTECT(Rf_allocVector(INTSXP, 2*result[i].size()));
     int *depPathPtr = INTEGER(SdepPath);
-    int thisResultSize = result[i].size()
-    for(j = 0; j < thisResultSize; ++j) {
+    int thisResultSize = result[i].size();
+    //  PRINTF("X %i\n", thisResultSize);
+    for(int j = 0; j < thisResultSize; ++j) {
       depPathPtr[j] = result[i][j].nodeID();
       depPathPtr[j + thisResultSize] = result[i][j].parentExprID();
     }
+    Sdim = PROTECT(Rf_allocVector(INTSXP, 2));
+    INTEGER(Sdim)[0] = thisResultSize;
+    INTEGER(Sdim)[1] = 2;
+    Rf_setAttrib(SdepPath, R_DimSymbol, Sdim);
     SET_VECTOR_ELT(Sresult, i, SdepPath);
-    UNPROTECT(1);
+    UNPROTECT(2);
   }
+  PRINTF("E\n");
+  //
   UNPROTECT(1);
   return Sresult;
-}
-
-multipleDepPaths getDependencyPaths_recurse(const graphNode *currentNode, depPath &root_path, int parentExprID) {
-  //  const graphNode *currentNode = graphPtr->graphNodeVec[ root_path.nodeID() ];
-  depStep_class thisStep(currentNode->CgraphID, parentExprID);
-  root_path.push_back(thisStep);
-  if(currentNode->type == STOCH | currentNode->numChildren == 0) { // stop at stochastic node or if there are no children
-    multipleDepPaths result(1);
-    result[0] = root_path;
-    return result;
-  } else { // recurse through non-stochastic child nodes, if there are any
-    multipleDepPaths result;
-    for(int i = 0; i < currentNode->numChildren; ++i) {
-      multipleDepPaths result_oneChild = getDependencyPaths_recurse(currentNode->children[i],
-								    currentNode->childrenParentExpressionIDs[i]);
-      for(j = 0; j < result_oneChild.size(); ++j) {
-	result.push_back( result_oneChild[j] );
-	result_oneChild.pop_back();
-      }
-    }
-    return result;
-  }
 }

--- a/packages/nimble/inst/include/nimble/nimbleGraph.h
+++ b/packages/nimble/inst/include/nimble/nimbleGraph.h
@@ -84,4 +84,13 @@ extern "C" {
   SEXP C_getDependencyPathCountOneNode(SEXP SgraphExtPtr, SEXP Snode);
 }
 
+
+/**********************/
+/* getDependencyPaths */
+/**********************/
+
+extern "C" {
+  SEXP C_getDependencyPaths(SEXP SgraphExtPtr, SEXP Snodes);
+}
+
 #endif

--- a/packages/nimble/src/nimble.cpp
+++ b/packages/nimble/src/nimble.cpp
@@ -66,6 +66,7 @@ R_CallMethodDef CallEntries[] = {
  FUN(C_anyStochDependencies, 1),
  FUN(C_anyStochParents, 1),
  FUN(C_getDependencies, 4),
+ FUN(C_getDependencyPaths, 2), 
  FUN(C_getDependencyPathCountOneNode, 2), 
  {NULL, NULL, 0}
 };


### PR DESCRIPTION
getDependencyPaths is the slowest step of conjugacy checking.  I wrote a C++ version that works on a set of classic BUGS models and makes configureMCMC faster by model-specific factors, typically around 2x.  This PR will check whether the new system matches the current system across the wider range of models in our test suite.