### PR TITLE
revert addMonitors default behavior to what it has been

### DIFF
--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -606,7 +606,7 @@ Details: See the initialize() function
                 if(getNimbleOption('MCMCmonitorAllSampledNodes')) {
                     vars <- model$getNodeNames(stochOnly = TRUE, includeData = FALSE)
                 } else {
-                    vars <- model$getNodeNames(stochOnly = TRUE, includeData = FALSE, topOnly = TRUE)
+                    vars <- model$getNodeNames(stochOnly = TRUE, topOnly = TRUE)
                 }
             } else {
                 vars <- unlist(vars)


### PR DESCRIPTION
Per discussion this morning, we will revert to previous (until a recent commit) default behavior for addMonitors in configureMCMC.

This will benefit from efficiency improvement in model$getNodeNames.  In the future, we may add back this includeData = FALSE flag.

It is only relevant if a model has a top-level data node, which is not typical.
