### PR TITLE
insert isTRUE in calc/sim/calcDiff to avoid uncompiled errors with truncation/dyn idx

### DIFF
--- a/packages/nimble/R/nimbleFunction_nodeFunction.R
+++ b/packages/nimble/R/nimbleFunction_nodeFunction.R
@@ -14,7 +14,7 @@ ndf_createDetermSimulate <- function(LHS, RHS, dynamicIndexLimitsExpr, RHSnonRep
         ## error gracefully if dynamic index too small or large; we don't catch non-integers within the bounds though
         if(is.null(nodeDim)) {
             nanExpr <- NaN
-        } else nanExpr <- substitute(nimArray(NaN, LENGTH),
+        } else nanExpr <- substitute(nimRep(NaN, LENGTH),
                                      list(LENGTH = prod(nodeDim)))
         code <- substitute(if(isTRUE(CONDITION)) LHS <<- RHS
                            else {
@@ -394,7 +394,7 @@ ndf_createVirtualNodeFunctionDefinitionsList <- function(userAdded = FALSE) {
         }
     } else {
         # this deals with user-provided distributions
-        if(exists('distributions', nimbleUserNamespace)) {
+        if(exists('distributions', nimbleUserNamespace, inherits = FALSE)) {
             for(distName in getAllDistributionsInfo('namesVector', userOnly = TRUE))
                 defsList[[paste0('node_stoch_', distName)]] <- ndf_createVirtualNodeFunctionDefinition(getDistributionInfo(distName)$types)
         } else stop("ndf_createVirtualNodeFunctionDefinitionsList: no 'distributions' list in nimbleUserNamespace.")

--- a/packages/nimble/R/nimbleFunction_nodeFunction.R
+++ b/packages/nimble/R/nimbleFunction_nodeFunction.R
@@ -272,7 +272,7 @@ ndf_createStochCalculateTrunc <- function(logProbNodeExpr, LHS, RHS, diff = FALS
                                                )), list( e = substCode)))
         } else {
             if(discrete && lower != -Inf) {
-                substCode <- quote(if(TRUE(CONDITION)) {
+                substCode <- quote(if(isTRUE(CONDITION)) {
                                        if(isTRUE(LOWER <= VALUE & VALUE <= UPPER))
                                            LOGPROB <<- DENSITY - log(PDIST_UPPER - PDIST_LOWER + DDIST_LOWER)
                                        else LOGPROB <<- -Inf

--- a/packages/nimble/R/nimbleFunction_nodeFunction.R
+++ b/packages/nimble/R/nimbleFunction_nodeFunction.R
@@ -14,9 +14,9 @@ ndf_createDetermSimulate <- function(LHS, RHS, dynamicIndexLimitsExpr, RHSnonRep
         ## error gracefully if dynamic index too small or large; we don't catch non-integers within the bounds though
         if(is.null(nodeDim)) {
             nanExpr <- NaN
-        } else nanExpr <- substitute(rep(NaN, LENGTH),
+        } else nanExpr <- substitute(nimArray(NaN, LENGTH),
                                      list(LENGTH = prod(nodeDim)))
-        code <- substitute(if(CONDITION) LHS <<- RHS
+        code <- substitute(if(isTRUE(CONDITION)) LHS <<- RHS
                            else {
                                LHS <<- NANEXPR
                                print(TEXT) },  
@@ -45,7 +45,7 @@ ndf_createStochSimulate <- function(LHS, RHS, dynamicIndexLimitsExpr, RHSnonRepl
             nanExpr <- NaN
         } else nanExpr <- substitute(rep(NaN, LENGTH),
                                      list(LENGTH = prod(nodeDim)))
-        code <- substitute(if(CONDITION) LHS <<- RHS
+        code <- substitute(if(isTRUE(CONDITION)) LHS <<- RHS
                            else {
                                LHS <<- NANEXPR
                                print(TEXT) },  
@@ -142,14 +142,14 @@ ndf_createStochCalculate <- function(logProbNodeExpr, LHS, RHS, diff = FALSE, AD
         RHS <- addArg(RHS, 1, 'log')  # adds the last argument log=TRUE (log_value for user-defined) # This was changed to 1 from TRUE for easier C++ generation
         if(nimbleOptions()$allowDynamicIndexing && !is.null(dynamicIndexLimitsExpr)) {
             if(diff) {
-                code <- substitute(if(CONDITION) LocalNewLogProb <- STOCHCALC
+                code <- substitute(if(isTRUE(CONDITION)) LocalNewLogProb <- STOCHCALC
                                    else {LocalNewLogProb <- NaN
                                        print(TEXT)}, # LocalNewLogProb <- -Inf,
                                    list(STOCHCALC = RHS,
                                         CONDITION = dynamicIndexLimitsExpr,
                                         TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced))))
             } else if(ADFunc){  ## don't want global assignment for _AD_ functions.
-                code <- substitute(if(CONDITION) LOGPROB <- STOCHCALC
+                code <- substitute(if(isTRUE(CONDITION)) LOGPROB <- STOCHCALC
                                    else {LOGPROB <- NaN
                                        print(TEXT)},
                                    list(LOGPROB = logProbNodeExpr,
@@ -158,7 +158,7 @@ ndf_createStochCalculate <- function(logProbNodeExpr, LHS, RHS, diff = FALSE, AD
                                         TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced))))
             } else {
 
-                code <- substitute(if(CONDITION) LOGPROB <<- STOCHCALC
+                code <- substitute(if(isTRUE(CONDITION)) LOGPROB <<- STOCHCALC
                                    else {LOGPROB <<- NaN
                                        print(TEXT)}, # LOGPROB <<- -Inf,
                                    list(LOGPROB = logProbNodeExpr,
@@ -229,7 +229,7 @@ ndf_createStochCalculateTrunc <- function(logProbNodeExpr, LHS, RHS, diff = FALS
 
     RHS <- addArg(RHS, 1, logName)  # add log=1 now that pdist() created without 'log'
 
-                code <- substitute(if(CONDITION) LocalNewLogProb <- STOCHCALC
+                code <- substitute(if(isTRUE(CONDITION)) LocalNewLogProb <- STOCHCALC
                                    else { LocalNewLogProb <- NaN
                                        print(TEXT)}, # LocalNewLogProb <- -Inf,
                                    list(STOCHCALC = RHS,
@@ -240,8 +240,8 @@ ndf_createStochCalculateTrunc <- function(logProbNodeExpr, LHS, RHS, diff = FALS
     if(nimbleOptions()$allowDynamicIndexing && !is.null(dynamicIndexLimitsExpr)) {
         if(diff) {
             if(discrete && lower != -Inf) {
-                substCode <- quote(if(CONDITION) {
-                                       if(LOWER <= VALUE & VALUE <= UPPER)
+                substCode <- quote(if(isTRUE(CONDITION)) {
+                                       if(isTRUE(LOWER <= VALUE & VALUE <= UPPER))
                                            LocalNewLogProb <- DENSITY - log(PDIST_UPPER - PDIST_LOWER + DDIST_LOWER)
                                        else LocalNewLogProb <- -Inf
                                    } else {
@@ -249,8 +249,8 @@ ndf_createStochCalculateTrunc <- function(logProbNodeExpr, LHS, RHS, diff = FALS
                                        cat(TEXT) }
                                    )
             } else {
-                substCode <- quote(if(CONDITION) {
-                                       if(LOWER <= VALUE & VALUE <= UPPER)
+                substCode <- quote(if(isTRUE(CONDITION)) {
+                                       if(isTRUE(LOWER <= VALUE & VALUE <= UPPER))
                                            LocalNewLogProb <- DENSITY - log(PDIST_UPPER - PDIST_LOWER)
                                        else LocalNewLogProb <- -Inf
                                    } else {
@@ -272,8 +272,8 @@ ndf_createStochCalculateTrunc <- function(logProbNodeExpr, LHS, RHS, diff = FALS
                                                )), list( e = substCode)))
         } else {
             if(discrete && lower != -Inf) {
-                substCode <- quote(if(CONDITION) {
-                                       if(LOWER <= VALUE & VALUE <= UPPER)
+                substCode <- quote(if(TRUE(CONDITION)) {
+                                       if(isTRUE(LOWER <= VALUE & VALUE <= UPPER))
                                            LOGPROB <<- DENSITY - log(PDIST_UPPER - PDIST_LOWER + DDIST_LOWER)
                                        else LOGPROB <<- -Inf
                                    } else {
@@ -281,8 +281,8 @@ ndf_createStochCalculateTrunc <- function(logProbNodeExpr, LHS, RHS, diff = FALS
                                        cat(TEXT) }
                                    )
             } else {
-                substCode <- quote(if(CONDITION) {
-                                       if(LOWER <= VALUE & VALUE <= UPPER)
+                substCode <- quote(if(isTRUE(CONDITION)) {
+                                       if(isTRUE(LOWER <= VALUE & VALUE <= UPPER))
                                          LOGPROB <<- DENSITY - log(PDIST_UPPER - PDIST_LOWER)
                                    else LOGPROB <<- -Inf
                                    } else {
@@ -307,11 +307,11 @@ ndf_createStochCalculateTrunc <- function(logProbNodeExpr, LHS, RHS, diff = FALS
     } else {
         if(diff) {
             if(discrete && lower != -Inf) {
-                substCode <- quote(if(LOWER <= VALUE & VALUE <= UPPER)
+                substCode <- quote(if(isTRUE(LOWER <= VALUE & VALUE <= UPPER))
                                        LocalNewLogProb <- DENSITY - log(PDIST_UPPER - PDIST_LOWER + DDIST_LOWER)
                                    else LocalNewLogProb <- -Inf)
             } else {
-                substCode <- quote(if(LOWER <= VALUE & VALUE <= UPPER)
+                substCode <- quote(if(isTRUE(LOWER <= VALUE & VALUE <= UPPER))
                                        LocalNewLogProb <- DENSITY - log(PDIST_UPPER - PDIST_LOWER)
                                    else LocalNewLogProb <- -Inf)
             }
@@ -327,11 +327,11 @@ ndf_createStochCalculateTrunc <- function(logProbNodeExpr, LHS, RHS, diff = FALS
                                                )), list( e = substCode)))
         } else {
             if(discrete && lower != -Inf) {
-                substCode <- quote(if(LOWER <= VALUE & VALUE <= UPPER)
+                substCode <- quote(if(isTRUE(LOWER <= VALUE & VALUE <= UPPER))
                                        LOGPROB <<- DENSITY - log(PDIST_UPPER - PDIST_LOWER + DDIST_LOWER)
                                    else LOGPROB <<- -Inf)
             } else {
-                substCode <- quote(if(LOWER <= VALUE & VALUE <= UPPER)
+                substCode <- quote(if(isTRUE(LOWER <= VALUE & VALUE <= UPPER))
                                        LOGPROB <<- DENSITY - log(PDIST_UPPER - PDIST_LOWER)
                                    else LOGPROB <<- -Inf)
             }
@@ -394,7 +394,7 @@ ndf_createVirtualNodeFunctionDefinitionsList <- function(userAdded = FALSE) {
         }
     } else {
         # this deals with user-provided distributions
-        if(exists('distributions', nimbleUserNamespace, inherits = FALSE)) {
+        if(exists('distributions', nimbleUserNamespace)) {
             for(distName in getAllDistributionsInfo('namesVector', userOnly = TRUE))
                 defsList[[paste0('node_stoch_', distName)]] <- ndf_createVirtualNodeFunctionDefinition(getDistributionInfo(distName)$types)
         } else stop("ndf_createVirtualNodeFunctionDefinitionsList: no 'distributions' list in nimbleUserNamespace.")

--- a/packages/nimble/inst/CppCode/Utils.cpp
+++ b/packages/nimble/inst/CppCode/Utils.cpp
@@ -67,8 +67,6 @@ void nimStop() {NIMERROR("");}
 
 bool nimNot(bool x) {return(!x);}
 
-bool isTRUE(bool x) {return(x);}
-
 double ilogit(double x) {return(1./(1. + exp(-x)));}
 
 double icloglog(double x) {return(1.-exp(-exp(x)));}

--- a/packages/nimble/inst/CppCode/Utils.cpp
+++ b/packages/nimble/inst/CppCode/Utils.cpp
@@ -67,6 +67,8 @@ void nimStop() {NIMERROR("");}
 
 bool nimNot(bool x) {return(!x);}
 
+bool isTRUE(bool x) {return(x);}
+
 double ilogit(double x) {return(1./(1. + exp(-x)));}
 
 double icloglog(double x) {return(1.-exp(-exp(x)));}

--- a/packages/nimble/inst/include/nimble/Utils.h
+++ b/packages/nimble/inst/include/nimble/Utils.h
@@ -165,6 +165,8 @@ void nimStop();
 
 bool nimNot(bool x);
 
+bool isTRUE(bool x);
+
 // needed for link functions
 double ilogit(double x);
 double icloglog(double x);

--- a/packages/nimble/inst/include/nimble/Utils.h
+++ b/packages/nimble/inst/include/nimble/Utils.h
@@ -165,7 +165,7 @@ void nimStop();
 
 bool nimNot(bool x);
 
-bool isTRUE(bool x);
+static inline bool isTRUE(bool x) {return(x);}
 
 // needed for link functions
 double ilogit(double x);

--- a/packages/nimble/inst/tests/dynamicIndexingTestLists.R
+++ b/packages/nimble/inst/tests/dynamicIndexingTestLists.R
@@ -200,7 +200,7 @@ testsDynIndex <- list(
                             list(parent = 'mu', result = c(paste0('mu[', 1:5, ']'),
                                                            paste0('y[',1:4,']')))),
         validIndexes =list(list(var = c('k[8]','j[1]'), value = c(5,7))),
-        invalidIndexes = list(list(var = c('k[1]', 'j[1]'), value = c(1,8), expect_R_calc_error = TRUE),  ## mu[k[j[1]+1]] = mu[k[9]] = mu[NA]  ## with PR 920 no longer expect R error...
+        invalidIndexes = list(list(var = c('k[1]', 'j[1]'), value = c(1,8)),  ## mu[k[j[1]+1]] = mu[k[9]] = mu[NA] 
                               list(var = c('k[2]', 'j[1]'), value = c(6,1)))
     ),
     list(  
@@ -388,7 +388,7 @@ testsDynIndex <- list(
                             list(parent = 'mu', result = c(expandNames('mu', 1:2, 1:3),
                                                            expandNames('y', 1:4)))),
         validIndexes =list(list(var = c('j[1]','k[2,4]'), value = c(4, 3))),
-        invalidIndexes =list(list(var = c('j[1]','k[2,4]'), value = c(0,1), expect_R_calc_error = TRUE),  ## mu[1, k[2, j[1]]] = mu[1, k[2, 0]] = mu[1, NA]  ## with PR 920 no longer expect R error...
+        invalidIndexes =list(list(var = c('j[1]','k[2,4]'), value = c(0,1)),  ## mu[1, k[2, j[1]]] = mu[1, k[2, 0]] = mu[1, NA]  
                              list(var = c('j[1]','k[2,1]'), value = c(1,4)))
     ),
     list(  
@@ -536,7 +536,7 @@ testsDynIndex <- list(
         }), 
         inits = list(mu = array(rnorm(120), c(5,3,8)), k = rep(1,4), j = rep(1, 4), d = rep(1,4), p = rep(1/5, 5)),
         data = list(y = rnorm(4)),
-        invalidIndexes =list(list(var = c('d[1]', 'k[1]','j[1]'), value = c(5,4,4), expect_R_calc_error = TRUE))  ## mu[k[d[1]]] = mu[k[5]] = mu[NA]  ## with PR 920 no longer expect R error...
+        invalidIndexes =list(list(var = c('d[1]', 'k[1]','j[1]'), value = c(5,4,4)))  ## mu[k[d[1]]] = mu[k[5]] = mu[NA]  
     )
 )
 

--- a/packages/nimble/inst/tests/dynamicIndexingTestLists.R
+++ b/packages/nimble/inst/tests/dynamicIndexingTestLists.R
@@ -200,7 +200,7 @@ testsDynIndex <- list(
                             list(parent = 'mu', result = c(paste0('mu[', 1:5, ']'),
                                                            paste0('y[',1:4,']')))),
         validIndexes =list(list(var = c('k[8]','j[1]'), value = c(5,7))),
-        invalidIndexes = list(list(var = c('k[1]', 'j[1]'), value = c(1,8), expect_R_calc_error = TRUE),  ## mu[k[j[1]+1]] = mu[k[9]] = mu[NA] 
+        invalidIndexes = list(list(var = c('k[1]', 'j[1]'), value = c(1,8), expect_R_calc_error = TRUE),  ## mu[k[j[1]+1]] = mu[k[9]] = mu[NA]  ## with PR 920 no longer expect R error...
                               list(var = c('k[2]', 'j[1]'), value = c(6,1)))
     ),
     list(  
@@ -388,7 +388,7 @@ testsDynIndex <- list(
                             list(parent = 'mu', result = c(expandNames('mu', 1:2, 1:3),
                                                            expandNames('y', 1:4)))),
         validIndexes =list(list(var = c('j[1]','k[2,4]'), value = c(4, 3))),
-        invalidIndexes =list(list(var = c('j[1]','k[2,4]'), value = c(0,1), expect_R_calc_error = TRUE),  ## mu[1, k[2, j[1]]] = mu[1, k[2, 0]] = mu[1, NA] 
+        invalidIndexes =list(list(var = c('j[1]','k[2,4]'), value = c(0,1), expect_R_calc_error = TRUE),  ## mu[1, k[2, j[1]]] = mu[1, k[2, 0]] = mu[1, NA]  ## with PR 920 no longer expect R error...
                              list(var = c('j[1]','k[2,1]'), value = c(1,4)))
     ),
     list(  
@@ -536,7 +536,7 @@ testsDynIndex <- list(
         }), 
         inits = list(mu = array(rnorm(120), c(5,3,8)), k = rep(1,4), j = rep(1, 4), d = rep(1,4), p = rep(1/5, 5)),
         data = list(y = rnorm(4)),
-        invalidIndexes =list(list(var = c('d[1]', 'k[1]','j[1]'), value = c(5,4,4), expect_R_calc_error = TRUE))  ## mu[k[d[1]]] = mu[k[5]] = mu[NA]
+        invalidIndexes =list(list(var = c('d[1]', 'k[1]','j[1]'), value = c(5,4,4), expect_R_calc_error = TRUE))  ## mu[k[d[1]]] = mu[k[5]] = mu[NA]  ## with PR 920 no longer expect R error...
     )
 )
 

--- a/packages/nimble/inst/tests/test-bnp.R
+++ b/packages/nimble/inst/tests/test-bnp.R
@@ -4532,7 +4532,7 @@ test_that("Testing sampler assignment and misspecification of priors for conc pa
   ## we do not warn of negative concentration values because there could be many such
   ## warnings in certain MCMC samplers for the concentration parameter
   expect_failure(expect_output(m$simulate(), "value of concentration parameter"))
-  expect_error(m$calculate())
+  expect_output(out <- m$calculate(), "Warning: dynamic index out of bounds")
   ## think about better way to tell the user that the prior for alpha is wrong
   
   
@@ -4548,7 +4548,7 @@ test_that("Testing sampler assignment and misspecification of priors for conc pa
   ## we do not warn of negative concentration values because there could be many such
   ## warnings in certain MCMC samplers for the concentration parameter
   expect_failure(expect_output(m$simulate(), "value of concentration parameter has to be larger than zero"))
-  expect_error(m$calculate())
+  expect_output(out <- m$calculate(), "Warning: dynamic index out of bounds")
   
 })
 

--- a/packages/nimble/inst/tests/test-dynamicIndexing.R
+++ b/packages/nimble/inst/tests/test-dynamicIndexing.R
@@ -277,9 +277,7 @@ test_that("Testing initialization of uninitialized dynamic indexes", {
     consts <- list(n = n, K = K)
     data <- list(y = y1, alpha = rep(1,K))
 
-    if(nimbleOptions('verbose')) {
-        expect_message(model1 <- nimbleModel(code = mix_normal, constants = consts, data = data), "missing value where TRUE/FALSE needed")
-    } else expect_silent(model1 <- nimbleModel(code = mix_normal, constants = consts, data = data))
+    expect_output(model1 <- nimbleModel(code = mix_normal, constants = consts, data = data), "Warning: dynamic index out of bounds")
     
     conf1 <- configureMCMC(model1)
     Rmcmc <- buildMCMC(model1)

--- a/packages/nimble/inst/tests/test_utils.R
+++ b/packages/nimble/inst/tests/test_utils.R
@@ -1298,15 +1298,8 @@ test_dynamic_indexing_model_internal <- function(param) {
                     
                     cm[[param$invalidIndexes[[i]]$var[j]]] <- param$invalidIndexes[[i]]$value[j]
                 }
-                ## use expect_equal not expect_identical because in certain cases we get NA not NaN (having to do with other components of calc/sim output)
-                if(any(is.na(param$invalidIndexes[[i]]$value)) || (!is.null(param$invalidIndexes[[i]]$expect_R_calc_error) && param$invalidIndexes[[i]]$expect_R_calc_error)) {
-                    expect_error(calculate(m), "(missing value where|argument is of length zero)", info = paste0("problem with lack of error in R calculate with NA indexes, case: ", i))
-                    ## When NA is given, R calculate fails with missing value and dynamic index error not flagged explicitly
-                    ## When 0 is the nested index, R calculate fails with length zero argument and dynamic index error not flagged
-                } else {
-                    expect_output(out <- calculate(m), "dynamic index out of bounds", info = paste0("problem with lack of warning in R calculate with non-NA invalid indexes, case: ", i))
-                    expect_equal(out, NaN, info = paste0("problem with lack of NaN in R calculate with non-NA invalid indexes, case: ", i))
-                }
+                expect_output(out <- calculate(m), "dynamic index out of bounds", info = paste0("problem with lack of warning in R calculate with non-NA invalid indexes, case: ", i))
+                expect_equal(out, NaN, info = paste0("problem with lack of NaN in R calculate with non-NA invalid indexes, case: ", i))
                 expect_output(out <- calculate(cm), "dynamic index out of bounds", info = paste0("problem with lack of warning in C calculate with invalid indexes, case: ", i))
                 expect_equal(out, NaN, info = paste0("problem with lack of NaN in C calculate with invalid indexes, case: ", i))
                 expect_output(out <- calculateDiff(cm), "dynamic index out of bounds", info = paste0("problem with lack of warning in C calculateDiff with invalid indexes, case: ", i))


### PR DESCRIPTION
FRO-DNM

This inserts isTRUE in calculate/simulate/calculateDiff nodefunctions so that under truncation (if a node value is NA) or dyn idx (if an index is NA) users don't see untrapped R errors from `if(NA)`. 

This also creates an `isTRUE` identity function in our C++ code. Presumably this will have negligible effect on compiled run times but worth discussion.

Before merging, check line 17 of nimbleFunction_nodeFunction to see why there is an unexpected change relative to devel.