### PR TITLE
add handling of `(expression)[indexing]` in addMissingIndexingRecurse

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -566,7 +566,7 @@ addMissingIndexingRecurse <- function(code, dimensionsList) {
     ## handle cases like (x[1:2]%*%y[1:2, i])[1,1]
     if(length(code[[2]]) > 1 && code[[2]][[1]] == '(') {
         if(any(unlist(lapply(as.list(code[3:length(code)]), is.blank))))
-            stop(paste0('addMissingIndexingRecurse: the model definition includes the code ', deparse(code), ', which contains missing indices. When indexing expressions (as opposed to explicit variables), all indices must be provided.'), call. = FALSE)
+            # stop(paste0('addMissingIndexingRecurse: the model definition includes the code ', deparse(code), ', which contains missing indices. When indexing expressions (as opposed to explicit variables), all indices must be provided.'), call. = FALSE)
         code[[2]][[2]] <- addMissingIndexingRecurse(code[[2]][[2]], dimensionsList)
         return(code)
     }

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -563,6 +563,13 @@ addMissingIndexingRecurse <- function(code, dimensionsList) {
       code[[2]][[2]] <- addMissingIndexingRecurse(code[[2]][[2]], dimensionsList)
       return(code)
     }
+    ## handle cases like (x[1:2]%*%y[1:2, i])[1,1]
+    if(length(code[[2]]) > 1 && code[[2]][[1]] == '(') {
+        if(any(unlist(lapply(as.list(code[3:length(code)]), is.blank))))
+            stop(paste0('addMissingIndexingRecurse: the model definition includes the code ', deparse(code), ', which contains missing indices. When indexing expressions (as opposed to explicit variables), all indices must be provided.'), call. = FALSE)
+        code[[2]][[2]] <- addMissingIndexingRecurse(code[[2]][[2]], dimensionsList)
+        return(code)
+    }
     if(!any(code[[2]] == names(dimensionsList))) {
       ## dimension information was NOT provided for this variable
       ## let's check to make sure all indexes are present

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -558,16 +558,19 @@ addMissingIndexingRecurse <- function(code, dimensionsList) {
         return(code)
     }
     if(code[[1]] != '[')   stop('something went wrong: expecting a [')
-    ## code must be an indexing call, e.g. x[.....]
-    if(length(code[[2]]) > 1 && code[[2]][[1]] == '$'){
-      code[[2]][[2]] <- addMissingIndexingRecurse(code[[2]][[2]], dimensionsList)
-      return(code)
-    }
+
     ## handle cases like (x[1:2]%*%y[1:2, i])[1,1]
     if(length(code[[2]]) > 1 && code[[2]][[1]] == '(') {
-        if(any(unlist(lapply(as.list(code[3:length(code)]), is.blank))))
-            # stop(paste0('addMissingIndexingRecurse: the model definition includes the code ', deparse(code), ', which contains missing indices. When indexing expressions (as opposed to explicit variables), all indices must be provided.'), call. = FALSE)
+        ## if(any(unlist(lapply(as.list(code[3:length(code)]), is.blank))))
+            ## stop(paste0('addMissingIndexingRecurse: the model definition includes the code ', deparse(code), ', which contains missing indices. When indexing expressions (as opposed to explicit variables), all indices must be provided.'), call. = FALSE)
         code[[2]][[2]] <- addMissingIndexingRecurse(code[[2]][[2]], dimensionsList)
+        ## handle missing indexes within the indexing of an expression, e.g.,
+        ## the 'k[ , 1]' in (x[1:2,1:2]%*%y[1:2,1:2])[k[ , 1], ]
+        len <- length(code)
+        if(len > 2) {
+            for(idx in 3:len)
+                if(is.call(code[[idx]]))
+                    code[[idx]] <- addMissingIndexingRecurse(code[[idx]], dimensionsList)
         return(code)
     }
     if(!any(code[[2]] == names(dimensionsList))) {

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -567,7 +567,7 @@ addMissingIndexingRecurse <- function(code, dimensionsList) {
         ## handle missing indexes within the indexing of an expression, e.g.,
         ## the 'k[ , 1]' in (x[1:2,1:2]%*%y[1:2,1:2])[k[ , 1], ]
         len <- length(code)
-        if(len > 2) {
+        if(len > 2) 
             for(idx in 3:len)
                 if(is.call(code[[idx]]))
                     code[[idx]] <- addMissingIndexingRecurse(code[[idx]], dimensionsList)

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -558,6 +558,13 @@ addMissingIndexingRecurse <- function(code, dimensionsList) {
         return(code)
     }
     if(code[[1]] != '[')   stop('something went wrong: expecting a [')
+    ## code must be an indexing call, e.g. x[.....]
+
+    ## handle cases like covMat[1:5,1:5] <- eigen(constMat[1:5,])$vectors[1:5,1:5]%*%t(eigen(constMat[1:5,1:5])$vectors[,])
+    if(length(code[[2]]) > 1 && code[[2]][[1]] == '$'){
+      code[[2]][[2]] <- addMissingIndexingRecurse(code[[2]][[2]], dimensionsList)
+      return(code)
+    }
 
     ## handle cases like (x[1:2]%*%y[1:2, i])[1,1]
     if(length(code[[2]]) > 1 && code[[2]][[1]] == '(') {

--- a/packages/nimble/inst/tests/test-models.R
+++ b/packages/nimble/inst/tests/test-models.R
@@ -604,7 +604,7 @@ test_that("handling of missing indexes of expressions:", {
     mn[1:2] <- (X[1:2,] %*% beta[1:2,1:2])[,1]
     y[1:2] ~ dmnorm( mn[1:2], pr[1:2,1:2])
     })
-    expect_output(m <- nimbleModel(code, data = list(y = rnorm(2)),
+    expect_message(m <- nimbleModel(code, data = list(y = rnorm(2)),
                     inits = list(beta = matrix(2,2,2), pr = diag(2)),
                     dimensions = list(X = c(2,2))), "model building finished",
                   info = "incorrectly handling missing indices with dims present")
@@ -624,7 +624,7 @@ test_that("handling of missing indexes of expressions:", {
     m = nimbleModel(code, data = list(y = rnorm(2)),
                     inits = list(X = matrix(1, 2, 2), beta = matrix(2,2,2), pr = diag(2)),
                     dimensions = list(k = c(2,2)))
-    expect_message(cm <- compileNimble(m), "compilation finished",
+    expect_silent(cm <- compileNimble(m), "compilation finished",
                   info = "incorrectly not using dim to fill in missing index model variable within indexing of ()")
 })
 

--- a/packages/nimble/inst/tests/test-models.R
+++ b/packages/nimble/inst/tests/test-models.R
@@ -573,6 +573,43 @@ test_that("warnings for multiply-defined model nodes:", {
     expect_warning(m <- nimbleModel(code), "'j,k' on the left-hand side of 'mu[i + 2, 1, 1] ~ ", fixed = TRUE)
 })
 
+test_that("handling of missing indexes:", {
+    code = nimbleCode({
+    mn[1:2] <- (X[1:2,1:2] %*% beta[1:2,1:2])[,1]
+    y[1:2] ~ dmnorm( mn[1:2], pr[1:2,1:2])
+    })
+    m = nimbleModel(code, data = list(y = rnorm(2)),
+                    inits = list(X = matrix(1, 2,2), beta = matrix(2,2,2), pr = diag(2)))
+    cm <- compileNimble(m)
+    expect_true(is.numeric(cm$calculate('y')), "incorrectly not dealing with missing index in ()[] expression")
+
+    code = nimbleCode({
+    mn[1:2] <- (X[1:2,] %*% beta[1:2,1:2])[,1]
+    y[1:2] ~ dmnorm( mn[1:2], pr[1:2,1:2])
+    })
+    m = nimbleModel(code, data = list(y = rnorm(2)),
+                    inits = list(X = matrix(1, 2,2), beta = matrix(2,2,2), pr = diag(2)))
+    cm <- compileNimble(m)
+    expect_true(is.numeric(cm$calculate('y')), "incorrectly not dealing with missing index in ()[] expression")
+    
+    code = nimbleCode({
+    mn[1:2] <- (X[1:2,] %*% beta[1:2,1:2])[,1]
+    y[1:2] ~ dmnorm( mn[1:2], pr[1:2,1:2])
+    })
+    m = nimbleModel(code, data = list(y = rnorm(2)),
+                    inits = list(beta = matrix(2,2,2), pr = diag(2)))
+    cm <- compileNimble(m)
+    expect_true(is.numeric(cm$calculate('y')), "incorrectly not dealing with missing index in ()[] expression")
+
+    code = nimbleCode({
+    mn[1:2] <- (X[1:2,] %*% beta[1:2,1:2])[,1]
+    y[1:2] ~ dmnorm( mn[1:2], pr[1:2,1:2])
+    })
+    m = nimbleModel(code, data = list(y = rnorm(2)),
+                    inits = list(beta = matrix(2,2,2), pr = diag(2)),
+                    dimensions = list(X = c(2,2))
+    cm <- compileNimble(m)
+    expect_true(is.numeric(cm$calculate('y')), "incorrectly not dealing with missing index in ()[] expression")
 
 
 sink(NULL)

--- a/packages/nimble/inst/tests/test-models.R
+++ b/packages/nimble/inst/tests/test-models.R
@@ -604,10 +604,13 @@ test_that("handling of missing indexes of expressions:", {
     mn[1:2] <- (X[1:2,] %*% beta[1:2,1:2])[,1]
     y[1:2] ~ dmnorm( mn[1:2], pr[1:2,1:2])
     })
-    expect_message(m <- nimbleModel(code, data = list(y = rnorm(2)),
+    ## Having trouble with consistency in whether output or message is produced,
+    ## so just run nimbleModel and test_that should fail if error occurs.
+    m <- nimbleModel(code, data = list(y = rnorm(2)),
                     inits = list(beta = matrix(2,2,2), pr = diag(2)),
-                    dimensions = list(X = c(2,2))), "model building finished",
-                  info = "incorrectly handling missing indices with dims present")
+                    dimensions = list(X = c(2,2)))
+                  ## "model building finished",
+                  ## info = "incorrectly handling missing indices with dims present")
 
     code = nimbleCode({
     mn[1:2] <- (X[1:2,1:2] %*% beta[1:2,1:2])[k[,1],1]
@@ -624,7 +627,7 @@ test_that("handling of missing indexes of expressions:", {
     m = nimbleModel(code, data = list(y = rnorm(2)),
                     inits = list(X = matrix(1, 2, 2), beta = matrix(2,2,2), pr = diag(2)),
                     dimensions = list(k = c(2,2)))
-    expect_silent(cm <- compileNimble(m), "compilation finished",
+    expect_silent(cm <- compileNimble(m)),
                   info = "incorrectly not using dim to fill in missing index model variable within indexing of ()")
 })
 

--- a/packages/nimble/inst/tests/test-models.R
+++ b/packages/nimble/inst/tests/test-models.R
@@ -575,8 +575,8 @@ test_that("warnings for multiply-defined model nodes:", {
 
 test_that("handling of missing indexes of expressions:", {
     code = nimbleCode({
-    mn[1:2] <- (X[1:2,1:2] %*% beta[1:2,1:2])[,1]
-    y[1:2] ~ dmnorm( mn[1:2], pr[1:2,1:2])
+        mn[1:2] <- (X[1:2,1:2] %*% beta[1:2,1:2])[,1]
+        y[1:2] ~ dmnorm( mn[1:2], pr[1:2,1:2])
     })
     m = nimbleModel(code, data = list(y = rnorm(2)),
                     inits = list(X = matrix(1, 2,2), beta = matrix(2,2,2), pr = diag(2)))
@@ -584,8 +584,8 @@ test_that("handling of missing indexes of expressions:", {
     expect_true(is.numeric(cm$calculate('y')), "incorrectly not dealing with missing index in ()[] expression")
 
     code = nimbleCode({
-    mn[1:2] <- (X[1:2,] %*% beta[1:2,1:2])[,1]
-    y[1:2] ~ dmnorm( mn[1:2], pr[1:2,1:2])
+        mn[1:2] <- (X[1:2,] %*% beta[1:2,1:2])[,1]
+        y[1:2] ~ dmnorm( mn[1:2], pr[1:2,1:2])
     })
     m = nimbleModel(code, data = list(y = rnorm(2)),
                     inits = list(X = matrix(1, 2,2), beta = matrix(2,2,2), pr = diag(2)))
@@ -593,8 +593,8 @@ test_that("handling of missing indexes of expressions:", {
     expect_true(is.numeric(cm$calculate('y')), "incorrectly not dealing with missing index in ()[] expression")
     
     code = nimbleCode({
-    mn[1:2] <- (X[1:2,] %*% beta[1:2,1:2])[,1]
-    y[1:2] ~ dmnorm( mn[1:2], pr[1:2,1:2])
+        mn[1:2] <- (X[1:2,] %*% beta[1:2,1:2])[,1]
+        y[1:2] ~ dmnorm( mn[1:2], pr[1:2,1:2])
     })
     expect_error(m <- nimbleModel(code, data = list(y = rnorm(2)),
                                   inits = list(beta = matrix(2,2,2), pr = diag(2))),
@@ -613,22 +613,21 @@ test_that("handling of missing indexes of expressions:", {
                   ## info = "incorrectly handling missing indices with dims present")
 
     code = nimbleCode({
-    mn[1:2] <- (X[1:2,1:2] %*% beta[1:2,1:2])[k[,1],1]
-    y[1:2] ~ dmnorm( mn[1:2], pr[1:2,1:2])
+        mn[1:2] <- (X[1:2,1:2] %*% beta[1:2,1:2])[k[,1],1]
+        y[1:2] ~ dmnorm( mn[1:2], pr[1:2,1:2])
     })
     expect_error(m <- nimbleModel(code, data = list(y = rnorm(2)),
                                   inits = list(X = matrix(1, 2, 2), beta = matrix(2,2,2), pr = diag(2))),
                  "missing indices", info = "not catching missing indices in model variable within indexing of ()")
     
     code = nimbleCode({
-    mn[1:2] <- (X[1:2,1:2] %*% beta[1:2,1:2])[k[,1],1]
-    y[1:2] ~ dmnorm( mn[1:2], pr[1:2,1:2])
+        mn[1:2] <- (X[1:2,1:2] %*% beta[1:2,1:2])[k[,1],1]
+        y[1:2] ~ dmnorm( mn[1:2], pr[1:2,1:2])
     })
     m = nimbleModel(code, data = list(y = rnorm(2)),
                     inits = list(X = matrix(1, 2, 2), beta = matrix(2,2,2), pr = diag(2)),
                     dimensions = list(k = c(2,2)))
-    expect_silent(cm <- compileNimble(m)),
-                  info = "incorrectly not using dim to fill in missing index model variable within indexing of ()")
+    cm <- compileNimble(m)  # use expect_message?
 })
 
 sink(NULL)


### PR DESCRIPTION
FRO-DNM

This looks for cases like `(x[1:2]%*%y[1:2])[1,1]` based on `(` and `[` and if found, checks no missing indices and then runs `addMissingIndexingRecurse` on the parenthesized expression being indexed.

Before finalizing this I would also like to resolve the question raised in NCT issue 141 regarding whether the stanza beginning line 562 of BUGS_modelDef.R that checks for `$` is needed.

Will need to add testing, including testing for correct trapping of missing indexing and vector version of this situation, namely something like `(y[1:2]*x[1:2])[2]`

