### PR TITLE
add warning if inits is not a list

### DIFF
--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -821,7 +821,7 @@ Arguments:
 
 inits: A named list.  The names of list elements must correspond to model variable names.  The elements of the list must be of class numeric, with size and dimension each matching the corresponding model variable.
 '
-                                      if(is.list(inits) && length(inits) > 0 && is.null(names(inits))) {
+                                      if(!is.list(inits) || (is.list(inits) && length(inits) > 0 && is.null(names(inits)))) {
                                           warning('inits argument should be a named list; not adding initial values to model.')
                                           return(invisible(NULL))
                                       }


### PR DESCRIPTION
As it says, changes check in setInits to make sure user-provided inits are a list.