### PR TITLE
added special case for printing dependent nodes of crossLevel sampler

### DIFF
--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -14,6 +14,7 @@ samplerConf <- setRefClass(
             samplerFunction <<- samplerFunction
             target <<- target
             control <<- control
+            if(name == 'crossLevel')   control <<- c(control, list(dependent_nodes = model$getDependencies(target, self = FALSE, stochOnly = TRUE)))  ## special case for printing dependents of crossLevel sampler (only)
             targetAsScalar <<- model$expandNodeNames(target, returnScalarComponents = TRUE)
         },
         setName = function(name) name <<- name,


### PR DESCRIPTION
Title says it all.

Addresses / fixes issue 155 from `nimbleCoreTeam`.

@paciorek Take a look and see if this (the output from `printSamplers`) is roughly what you were thinking.