### PR TITLE
Mcmc conf dotdotdot args

### DIFF
--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -521,7 +521,7 @@ print: A logical argument specifying whether to print the current list of sample
             if(missing(ind)) {
                 ind <- list(...)
                 ind <- unname(unlist(ind))
-                if(length(ind) == 0)   ind <- seq_along(samplerConfs)
+                if(is.null(ind))   ind <- seq_along(samplerConfs)
             }
             if(is.character(ind))   ind <- findSamplersOnNodes(ind)
             if(length(ind) > 0 && max(ind) > length(samplerConfs)) stop('MCMC configuration doesn\'t have that many samplers')

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -553,7 +553,11 @@ As another alternative, a list of samplerConf objects may be used as the argumen
 
 print: A logical argument specifying whether to print the new list of samplers (default FALSE).
 '   
-            if(missing(ind))        ind <- numeric(0)
+            if(missing(ind)) {
+                ind <- list(...)
+                ind <- unname(unlist(ind))
+                if(length(ind) == 0)   ind <- numeric(0)
+            }
             if(is.list(ind)) {
                 if(!all(sapply(ind, class) == 'samplerConf')) stop('item in list argument to setSamplers is not a samplerConf object')
                 samplerConfs <<- ind

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -538,7 +538,7 @@ Alias for removeSamplers method
             removeSamplers(...)
         },
         
-        setSamplers = function(ind, print = FALSE) {
+        setSamplers = function(..., ind, print = FALSE) {
             '
 Sets the ordering of the list of MCMC samplers.
 

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -504,7 +504,7 @@ For internal use only
             samplerExecutionOrder <<- c(samplerExecutionOrder, newSamplerInd)
         },
         
-        removeSamplers = function(ind, print = FALSE) {
+        removeSamplers = function(..., ind, print = FALSE) {
             '
 Removes one or more samplers from an MCMCconf object.
 
@@ -516,7 +516,11 @@ ind: A numeric vector or character vector specifying the samplers to remove.  A 
 
 print: A logical argument specifying whether to print the current list of samplers once the removal has been done (default FALSE).
 '      
-            if(missing(ind))        ind <- seq_along(samplerConfs)
+            if(missing(ind)) {
+                ind <- list(...)
+                ind <- unname(unlist(ind))
+                if(length(ind) == 0)   ind <- seq_along(samplerConfs)
+            }
             if(is.character(ind))   ind <- findSamplersOnNodes(ind)
             if(length(ind) > 0 && max(ind) > length(samplerConfs)) stop('MCMC configuration doesn\'t have that many samplers')
             samplerConfs[ind] <<- NULL

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -582,11 +582,13 @@ Alias for setSamplers method
             setSamplers(...)
         },
         
-        printSamplers = function(ind, type, displayControlDefaults = FALSE, displayNonScalars = FALSE, displayConjugateDependencies = FALSE, executionOrder = FALSE, byType = FALSE) {
+        printSamplers = function(..., ind, type, displayControlDefaults = FALSE, displayNonScalars = FALSE, displayConjugateDependencies = FALSE, executionOrder = FALSE, byType = FALSE) {
             '
 Prints details of the MCMC samplers.
 
 Arguments:
+
+...: Character node or variable names, or numeric indices.  Numeric indices may be used to specify the indices of the samplers to print, or character strings may be used to indicate a set of target nodes and/or variables, for which all samplers acting on these nodes will be printed. For example, printSamplers(\'x\') will print all samplers whose target is model node \'x\', or whose targets are contained (entirely or in part) in the model variable \'x\'.  If omitted, then all samplers are printed.
 
 ind: A numeric vector or character vector.  A numeric vector may be used to specify the indices of the samplers to print, or a character vector may be used to indicate a set of target nodes and/or variables, for which all samplers acting on these nodes will be printed. For example, printSamplers(\'x\') will print all samplers whose target is model node \'x\', or whose targets are contained (entirely or in part) in the model variable \'x\'.  If omitted, then all samplers are printed.
 
@@ -600,7 +602,11 @@ executionOrder: A logical argument, specifying whether to print the sampler func
 
 byType: A logical argument, specifying whether the nodes being sampled should be printed, sorted and organized according to the type of sampler (the sampling algorithm) which is acting on the nodes (default FALSE).
 '
-            if(missing(ind))        ind <- seq_along(samplerConfs)
+            if(missing(ind)) {
+                ind <- list(...)
+                ind <- unname(unlist(ind))
+                if(length(ind) == 0)   ind <- seq_along(samplerConfs)
+            }
             if(is.character(ind))   ind <- findSamplersOnNodes(ind)
             if(length(ind) > 0 && max(ind) > length(samplerConfs)) stop('MCMC configuration doesn\'t have that many samplers')
             if(!missing(type)) {

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -529,7 +529,7 @@ print: A logical argument specifying whether to print the current list of sample
             return(invisible(NULL))
         },
 
-        removeSampler = function(...){
+        removeSampler = function(...) {
             '
 Alias for removeSamplers method
 '
@@ -565,6 +565,13 @@ print: A logical argument specifying whether to print the new list of samplers (
             samplerExecutionOrder <<- seq_along(samplerConfs)
             if(print) printSamplers()
             return(invisible(NULL))
+        },
+
+        setSampler = function(...) {
+            '
+Alias for setSamplers method
+'
+            setSamplers(...)
         },
         
         printSamplers = function(ind, type, displayControlDefaults = FALSE, displayNonScalars = FALSE, displayConjugateDependencies = FALSE, executionOrder = FALSE, byType = FALSE) {

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -512,6 +512,8 @@ Arguments:
 
 This function also has the side effect of resetting the sampler execution ordering so as to iterate over the remaining set of samplers, sequentially, executing each sampler once.
 
+...: Character node names or numeric indices.  Character node names specify the node names for samplers to remove, or numeric indices can provide the indices of samplers to remove.
+
 ind: A numeric vector or character vector specifying the samplers to remove.  A numeric vector may specify the indices of the samplers to be removed.  Alternatively, a character vector may be used to specify a set of model nodes and/or variables, and all samplers whose \'target\' is among these nodes will be removed.  If omitted, then all samplers are removed.
 
 print: A logical argument specifying whether to print the current list of samplers once the removal has been done (default FALSE).
@@ -543,6 +545,8 @@ Sets the ordering of the list of MCMC samplers.
 This function also has the side effect of resetting the sampler execution ordering so as to iterate over the specified set of samplers, sequentially, executing each sampler once.
 
 Arguments:
+
+...: Chracter strings or numeric indices.  Character names may be used to specify the node names for samplers to retain.  A numeric indices may be used to specify the indicies for the new list of MCMC samplers, in terms of the current ordered list of samplers.
 
 ind: A numeric vector or character vector.  A numeric vector may be used to specify the indicies for the new list of MCMC samplers, in terms of the current ordered list of samplers.
 For example, if the MCMCconf object currently has 3 samplers, then the ordering may be reversed by calling MCMCconf$setSamplers(3:1), or all samplers may be removed by calling MCMCconf$setSamplers(numeric(0)).

--- a/packages/nimble/inst/NEWS
+++ b/packages/nimble/inst/NEWS
@@ -3,7 +3,7 @@ USER LEVEL CHANGES
 
 -- Added the scalarComponents argument to addSampler method of MCMC configuration objects, which enables adding independent univariate samplers to all scalar componets of a specified target node or variable.
 
--- removeSamplers method of MCMC configuration object now also accepts node names (or sampler indices) through the "..." argument.
+-- removeSamplers and setSamplers methods of MCMC configuration object now also accepts node names (or sampler indices) through the "..." argument.
 
 BUG FIXES
 

--- a/packages/nimble/inst/NEWS
+++ b/packages/nimble/inst/NEWS
@@ -3,6 +3,8 @@ USER LEVEL CHANGES
 
 -- Added the scalarComponents argument to addSampler method of MCMC configuration objects, which enables adding independent univariate samplers to all scalar componets of a specified target node or variable.
 
+-- removeSamplers method of MCMC configuration object now also accepts node names (or sampler indices) through the "..." argument.
+
 BUG FIXES
 
 -- Fixed a bug in corner case of MCMC conjugacy checking system, when linear scale of target node is identically equal to zero.

--- a/packages/nimble/inst/NEWS
+++ b/packages/nimble/inst/NEWS
@@ -3,7 +3,7 @@ USER LEVEL CHANGES
 
 -- Added the scalarComponents argument to addSampler method of MCMC configuration objects, which enables adding independent univariate samplers to all scalar componets of a specified target node or variable.
 
--- removeSamplers and setSamplers methods of MCMC configuration object now also accepts node names (or sampler indices) through the "..." argument.
+-- removeSamplers, setSamplers, and printSamplers methods of MCMC configuration object now also accepts node names (or sampler indices) through the "..." argument.
 
 BUG FIXES
 

--- a/packages/nimble/inst/tests/test_utils.R
+++ b/packages/nimble/inst/tests/test_utils.R
@@ -519,7 +519,7 @@ test_mcmc_internal <- function(Rmodel, ##data = NULL, inits = NULL,
     # single multivar sampler: samplers(type = "RW_block", target = 'x')
     # multiple multivar samplers: samplers(type = "RW_block", target = list('x', c('theta', 'mu')))
 
-    setSampler <- function(var, conf) {
+    setSampler_testing_method <- function(var, conf) {
         currentTargets <- sapply(conf$samplerConfs, function(x) x$target)
                                         # remove already defined scalar samplers
         inds <- which(unlist(var$target) %in% currentTargets)
@@ -550,7 +550,7 @@ test_mcmc_internal <- function(Rmodel, ##data = NULL, inits = NULL,
     if(removeAllDefaultSamplers) mcmcConf$removeSamplers()
     
     if(!is.null(samplers)) {
-        sapply(samplers, setSampler, mcmcConf)
+        sapply(samplers, setSampler_testing_method, mcmcConf)
             cat("Setting samplers to:\n")
             print(mcmcConf$getSamplers())
     }

--- a/packages/nimble/inst/tests/test_utils.R
+++ b/packages/nimble/inst/tests/test_utils.R
@@ -519,7 +519,7 @@ test_mcmc_internal <- function(Rmodel, ##data = NULL, inits = NULL,
     # single multivar sampler: samplers(type = "RW_block", target = 'x')
     # multiple multivar samplers: samplers(type = "RW_block", target = list('x', c('theta', 'mu')))
 
-    setSampler_testing_method <- function(var, conf) {
+    setSampler <- function(var, conf) {
         currentTargets <- sapply(conf$samplerConfs, function(x) x$target)
                                         # remove already defined scalar samplers
         inds <- which(unlist(var$target) %in% currentTargets)
@@ -550,7 +550,7 @@ test_mcmc_internal <- function(Rmodel, ##data = NULL, inits = NULL,
     if(removeAllDefaultSamplers) mcmcConf$removeSamplers()
     
     if(!is.null(samplers)) {
-        sapply(samplers, setSampler_testing_method, mcmcConf)
+        sapply(samplers, setSampler, mcmcConf)
             cat("Setting samplers to:\n")
             print(mcmcConf$getSamplers())
     }


### PR DESCRIPTION
Added `...` args to many remaining methods of MCMC configuration `conf` objects.

@paciorek If this passes testing, could we get this into the next release?