### PR TITLE
allow (scalar) multiplicative link in wish and invwish conjugacies

### DIFF
--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -146,7 +146,7 @@ conjugacyRelationshipsInputList <- list(
          ## changing to only use link='identity' case, since the link='linear' case was not correct.
          ## -DT March 2017
          ## link = 'linear',
-         link = 'identity',
+         link = 'multiplicative',
          dependents = list(
              ## parentheses added to the contribution_R calculation:
              ## colVec * (rowVec * matrix)
@@ -155,16 +155,16 @@ conjugacyRelationshipsInputList <- list(
              ## changing to only use link='identity' case, since the link='linear' case was not correct
              ## -DT March 2017
              ## dmnorm = list(param = 'prec', contribution_R = 'asCol(value-mean) %*% (asRow(value-mean) %*% coeff)', contribution_df = '1')),
-             dmnorm = list(param = 'prec', contribution_R = 'asCol(value-mean) %*% asRow(value-mean)', contribution_df = '1')),
+             dmnorm = list(param = 'prec', contribution_R = 'coeff * asCol(value-mean) %*% asRow(value-mean)', contribution_df = '1')),
          posterior = 'dwish_chol(cholesky    = chol(prior_R + contribution_R),
                                  df          = prior_df + contribution_df,
                                  scale_param = 0)'),
 
     ## inverse wishart
     list(prior = 'dinvwish',
-         link = 'identity',
+         link = 'multiplicative',
          dependents = list(
-             dmnorm = list(param = 'cov', contribution_S = 'asCol(value-mean) %*% asRow(value-mean)', contribution_df = '1')),
+             dmnorm = list(param = 'cov', contribution_S = 'asCol(value-mean) %*% asRow(value-mean) / coeff', contribution_df = '1')),
          posterior = 'dinvwish_chol(cholesky    = chol(prior_S + contribution_S),
                                     df          = prior_df + contribution_df,
                                     scale_param = 1)')

--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -1125,7 +1125,8 @@ cc_linkCheck <- function(linearityCheck, link) {
     offset      <- linearityCheck$offset
     scale       <- linearityCheck$scale
     if(link == 'identity'       && offset == 0 && scale == 1)                  return(TRUE)
-    ## We currently have no conjugacies where the scale can be a matrix.
+    ## We currently have no conjugacies where the scale can be a matrix, so check
+    ## that 'scale' is a scalar.
     ## In particular we want to avoid that case when dealing with Wishart-related conjugacies.
     if(link == 'multiplicative' && offset == 0 && cc_checkScalar(scale))       return(TRUE)
     if(link == 'linear' || link == 'linear_plus_inprod')                       return(TRUE)

--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -1135,10 +1135,12 @@ cc_linkCheck <- function(linearityCheck, link) {
 
 cc_checkScalar <- function(expr) {
     if(length(expr) == 1) return(TRUE)
-    if(expr[[1]] == '[') return(FALSE)
+    if(expr[[1]] == '[') {
+        if(length(expr) == 3 && length(expr[[3]]) == 1)
+            return(TRUE) else return(FALSE)
+    }
     if(expr[[1]] == '(') return(cc_checkScalar(expr[[2]]))
-    if(length(expr) != 3) stop("cc_checkScalar: found unexpected expression: ", deparse(expr), ".")
-    return(all(sapply(expr[2:3], cc_checkScalar)))
+    return(all(sapply(expr[2:length(expr)], cc_checkScalar)))
 }
 
 ## checks the parameter expressions in the stochastic distribution of depNode

--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -901,7 +901,7 @@ conjugacyClass <- setRefClass(
                     if(!(contributionName %in% dependents[[distName]]$contributionNames))     next
                     contributionExpr <- eval(substitute(substitute(EXPR, subList), list(EXPR=dependents[[distName]]$contributionExprs[[contributionName]])))
                     if(nimbleOptions()$allowDynamicIndexing && doDependentScreen) { ## FIXME: would be nice to only have one if() here when we loop through multiple parameters
-                        if(targetNdim == 0)
+                        if(targetCoeffNdim == 0)
                             forLoopBody$addCode(if(COEFF_EXPR != 0) CONTRIB_NAME <<- CONTRIB_NAME + CONTRIB_EXPR,
                                                 list(COEFF_EXPR = subList$coeff, CONTRIB_NAME = as.name(contributionName), CONTRIB_EXPR = contributionExpr))
                         else forLoopBody$addCode(if(min(COEFF_EXPR) != 0 | max(COEFF_EXPR) != 0) CONTRIB_NAME <<- CONTRIB_NAME + CONTRIB_EXPR,

--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -824,11 +824,11 @@ conjugacyClass <- setRefClass(
                            if(!all(links == 'multiplicative')) stop("Found non-multiplicative link for 2-d variable.")
 
                            functionBody$addCode({
-                               model[[target]] <<- matrix(0, d, d)
+                               model[[target]] <<- diag(d)
                                calculate(model, calcNodesDeterm)
                            })
 
-                           ## Use _COEFF_VAR to store value when target is zero; we need this for stoch indexing case
+                           ## Use _COEFF_VAR to store value; we need this for stoch indexing case
                            ## where we determine that coeff = 0 because the potential dependency is not a dependency
                            ## given current index values.
                            for(iDepCount in seq_along(dependentCounts)) {
@@ -845,7 +845,9 @@ conjugacyClass <- setRefClass(
                            }
 
                            functionBody$addCode({
-                               model[[target]] <<- diag(d)  
+                               ## Can't use zeros matrix as Cholesky fails; this is solely to determine if
+                               ## potential dependency is not a dependency of target (due to stochastic indexing).
+                               model[[target]] <<- 2*diag(d)  
                                calculate(model, calcNodesDeterm)
                            })
 

--- a/packages/nimble/inst/tests/test-mcmc.R
+++ b/packages/nimble/inst/tests/test-mcmc.R
@@ -1779,7 +1779,7 @@ test_that('cc_checkScalar operates correctly', {
     expect_false(cc_checkScalar(quote(lambda[1:2,1:2]/eta)))
     expect_false(cc_checkScalar(quote(eta*(theta*lambda[1:2,1:2]))))
     expect_false(cc_checkScalar(quote(lambda[1:2,1:2,1:5])))
-}
+})
 
 sink(NULL)
 

--- a/packages/nimble/inst/tests/test-mcmc.R
+++ b/packages/nimble/inst/tests/test-mcmc.R
@@ -966,7 +966,7 @@ test_that('detect conjugacy when scaling Wishart, inverse Wishart cases', {
     })
     m  <- nimbleModel(code, constants = list(p = 3))
     expect_identical(length(m$checkConjugacy('Sigma')), 0L, 'Wishart case')
-}
+})
 
 
 ## testing conjugate MVN updating with ragged dependencies;
@@ -1038,9 +1038,8 @@ test_that('conjugate MVN with ragged dependencies', {
     
 
     expect_true(all(abs(pmean - obsmean) / pmean < 0.01), info = 'ragged dmnorm conjugate posterior mean')
-    expect_true(all(abs(pprec - obsprec) / pprec < 0.005), info = 'ragged dmnorm conjugate posterior precision')
-    
-    })
+    expect_true(all(abs(pprec - obsprec) / pprec < 0.005), info = 'ragged dmnorm conjugate posterior precision')  
+})
     
 ## testing binary sampler
 test_that('binary sampler setup', {
@@ -1779,6 +1778,17 @@ test_that('cc_checkScalar operates correctly', {
     expect_false(cc_checkScalar(quote(lambda[1:2,1:2]/eta)))
     expect_false(cc_checkScalar(quote(eta*(theta*lambda[1:2,1:2]))))
     expect_false(cc_checkScalar(quote(lambda[1:2,1:2,1:5])))
+
+    expect_true(cc_checkScalar(quote(lambda[xi[i]])))
+    expect_true(cc_checkScalar(quote(lambda[xi[i],xi[j]])))
+    expect_false(cc_checkScalar(quote(lambda[xi[i]:3])))
+    expect_false(cc_checkScalar(quote(lambda[xi[i]:3,2])))
+
+    ## Ideally this case would evaluate to TRUE, but we would
+    ## have to handle knowing output dims of user-defined fxns.
+    expect_false(cc_checkScalar(quote(sum(lambda[1:5]))))
+    expect_false(cc_checkScalar(quote(foo(lambda))))
+
 })
 
 sink(NULL)


### PR DESCRIPTION
Do not merge: this is just the initial steps of allowing this and not functional yet.

For some functionality for BNP, we want to recognize conjugacies like this:
```
y[1:p] ~ dmnorm(z[1:p], cov = lambda * Sigma[1:p,1:p])
Sigma[1:p,1:p] ~ dinvwish(S[1:p,1:p, nu)
```
and similarly for dwish.

I've started on this by changing the invwish and wish links in MCMC_conjugacy.R to 'multiplicative' and adding 'coeff' to the posterior calculation but the heavier lift is to detect that in this situation the 'coeff' is scalar (unlike in the dmnorm linear link conjugacy case) and to calculate coeff based on the [1,1] elements of the dependent covariance and the value of the target node.

@danielturek let's discuss whether you or I should finish this off.