### PR TITLE
updated assignment of data values to not overwrite data list

### DIFF
--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -604,7 +604,11 @@ Details: If a provided value (or the current value in the model when only a name
                                               scalarize <- FALSE else scalarize <- TRUE  ## if non-scalar, check actual dimensionality of input
                                           if(length(nimbleInternalFunctions$dimOrLength(varValue, scalarize = scalarize)) != length(isDataVars[[varName]]))   stop(paste0('incorrect size or dim in data: ', varName))
                                           if(!(all(nimbleInternalFunctions$dimOrLength(varValue, scalarize = scalarize) == isDataVars[[varName]])))   stop(paste0('incorrect size or dim in data: ', varName))
-                                          assign(varName, varValue, inherits = TRUE)
+                                          ##assign(varName, varValue, inherits = TRUE)   ## formerly
+                                          ## assigns the "varName" variable in *enclosing* environment,
+                                          ## to prevent assigning over the local "data" list, defined here,
+                                          ## in the case where one of the "data list" elements is named "data":
+                                          assign(varName, varValue, inherits = TRUE, pos = parent.env(environment()))
                                           isDataVarValue <- !is.na(varValue)
                                           assign(varName, isDataVarValue, envir = isDataEnv)
                                       }


### PR DESCRIPTION
@perrydv @paciorek 

Fixes #941

I made a change.  It's a one-liner, but make no mistake, this is **deeply rooted**.  If either of you guys are uncomfortable with this, I will not take offense.

It changes how the "data" variables are assigned into the model.  Changes the `assign()` statement to begin looking "up" one environment, so as not to over-write the local variables, in this case, the `data` list, but there's also the potential for other conflicts (with other local variables) depending on what users name their model (data) variables.

Anyway, if testing passes, then I'll have confidence in it, but you'd better both take a look, and please weigh in here.
