### PR TITLE
avoid conjugacy detection when there is data node scaling in bnp dnorm_invgamma_dnorm case

### DIFF
--- a/packages/nimble/R/BNP_samplers.R
+++ b/packages/nimble/R/BNP_samplers.R
@@ -1678,8 +1678,6 @@ checkNormalInvGammaConjugacy <- function(model, clusterVarInfo) {
         if(length(unique(valueExprs)) != 1)
             conjugate <- FALSE
 
-#        browser()
-        
         ## Check that dependent nodes ('observations') from same declaration.
         ## This should ensure they have same distribution and parameters are being
         ## clustered in same way.

--- a/packages/nimble/R/BNP_samplers.R
+++ b/packages/nimble/R/BNP_samplers.R
@@ -1678,11 +1678,20 @@ checkNormalInvGammaConjugacy <- function(model, clusterVarInfo) {
         if(length(unique(valueExprs)) != 1)
             conjugate <- FALSE
 
+#        browser()
+        
         ## Check that dependent nodes ('observations') from same declaration.
         ## This should ensure they have same distribution and parameters are being
         ## clustered in same way.
         depNodes <- model$getDependencies(clusterNodes1, stochOnly = TRUE, self = FALSE)
         if(length(unique(model$getDeclID(depNodes))) != 1)
+            conjugate <- FALSE
+
+        ## Check that dependent node variance is simply the variance of the cluster and not,
+        ## e.g., scaled, such as 'dnorm(mu[xi[i]], var = lambda * s2[xi[i]])'.
+        varExprs <- sapply(seq_along(depNodes), function(i) cc_expandDetermNodesInExpr(model,
+                                  model$getParamExpr(depNodes[i], 'var'), clusterNodes2[i]))
+        if(!identical(sapply(varExprs, deparse), clusterNodes2))
             conjugate <- FALSE
 
     }

--- a/packages/nimble/R/BNP_samplers.R
+++ b/packages/nimble/R/BNP_samplers.R
@@ -1687,12 +1687,10 @@ checkNormalInvGammaConjugacy <- function(model, clusterVarInfo) {
 
         ## Check that dependent node variance is simply the variance of the cluster and not,
         ## e.g., scaled, such as 'dnorm(mu[xi[i]], var = lambda * s2[xi[i]])'.
-        if(length(depNodes) == length(clusterNodes2)) {
-            varExprs <- sapply(seq_along(depNodes), function(i) cc_expandDetermNodesInExpr(model,
-                                       model$getParamExpr(depNodes[i], 'var'), clusterNodes2[i]))
-            if(!identical(sapply(varExprs, deparse), clusterNodes2))
-                conjugate <- FALSE
-        } else conjugate <- FALSE ## mismatch of number of clusterNodes1 and clusterNodes2 will be trapped in sampler_CRP_setup
+        varExprs <- sapply(seq_along(depNodes), function(i) cc_expandDetermNodesInExpr(model,
+                    model$getParamExpr(depNodes[i], 'var'), clusterNodes2[1])) ## use first as we may have ntilde < n
+        if(!identical(unique(sapply(varExprs, deparse)), clusterNodes2[1]))
+            conjugate <- FALSE
     }
     return(conjugate)
 }

--- a/packages/nimble/R/BNP_samplers.R
+++ b/packages/nimble/R/BNP_samplers.R
@@ -1687,11 +1687,12 @@ checkNormalInvGammaConjugacy <- function(model, clusterVarInfo) {
 
         ## Check that dependent node variance is simply the variance of the cluster and not,
         ## e.g., scaled, such as 'dnorm(mu[xi[i]], var = lambda * s2[xi[i]])'.
-        varExprs <- sapply(seq_along(depNodes), function(i) cc_expandDetermNodesInExpr(model,
-                                  model$getParamExpr(depNodes[i], 'var'), clusterNodes2[i]))
-        if(!identical(sapply(varExprs, deparse), clusterNodes2))
-            conjugate <- FALSE
-
+        if(length(depNodes) == length(clusterNodes2)) {
+            varExprs <- sapply(seq_along(depNodes), function(i) cc_expandDetermNodesInExpr(model,
+                                       model$getParamExpr(depNodes[i], 'var'), clusterNodes2[i]))
+            if(!identical(sapply(varExprs, deparse), clusterNodes2))
+                conjugate <- FALSE
+        } else conjugate <- FALSE ## mismatch of number of clusterNodes1 and clusterNodes2 will be trapped in sampler_CRP_setup
     }
     return(conjugate)
 }


### PR DESCRIPTION
This fixes NCT issue 166.