### PR TITLE
Make adaptation enforce an upper limit on proposal scale if reflective = TRUE

### DIFF
--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -236,7 +236,7 @@ sampler_RW <- nimbleFunction(
                     lower <- model$getBound(target, 'lower')
                     upper <- model$getBound(target, 'upper')
                     if(scale >= 0.5*(upper-lower)) {
-                        scale <- 0.5*(upper-lower)
+                        scale <<- 0.5*(upper-lower)
                     }
                 }
 

--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -221,11 +221,25 @@ sampler_RW <- nimbleFunction(
                     scaleHistory[timesAdapted] <<- scale        ## scaleHistory
                     setSize(acceptanceHistory, timesAdapted)         ## scaleHistory
                     acceptanceHistory[timesAdapted] <<- acceptanceRate  ## scaleHistory
-                }   
+                }
                 gamma1 <<- 1/((timesAdapted + 3)^0.8)
                 gamma2 <- 10 * gamma1
                 adaptFactor <- exp(gamma2 * (acceptanceRate - optimalAR))
                 scale <<- scale * adaptFactor
+                ## If there are upper and lower bounds, enforce a maximum scale of
+                ## 0.5 * (upper-lower).  This is arbitrary but reasonable.
+                ## Otherwise, for a poorly-informed posterior,
+                ## the scale could grow without bound to try to reduce
+                ## acceptance probability.  This creates enormous cost of
+                ## reflections.
+                if(reflective) {
+                    lower <- model$getBound(target, 'lower')
+                    upper <- model$getBound(target, 'upper')
+                    if(scale >= 0.5*(upper-lower)) {
+                        scale <- 0.5*(upper-lower)
+                    }
+                }
+
                 timesRan <<- 0
                 timesAccepted <<- 0
             }


### PR DESCRIPTION
Fixes #947 

This enforces a maximum proposal scale of half the distance between upper and lower bounds. 

@danielturek @paciorek Do you think this is a reasonable fix? 

I guess there could be strange behavior if the bounds are dynamic, but I am looking for a quick fix.
