### PR TITLE
Fix handling of rate vs. scale in uncompiled and/or compiled for ddexp and dsqrtinvgamma

### DIFF
--- a/packages/nimble/R/distributions_implementations.R
+++ b/packages/nimble/R/distributions_implementations.R
@@ -480,7 +480,11 @@ ddexp <- function(x, location = 0, scale = 1, rate = 1/scale, log = FALSE) {
           warning("specify 'scale' or 'rate' but not both")
       else stop("specify 'scale' or 'rate' but not both")
   }
-  .Call(C_ddexp, as.double(x), as.double(location), as.double(scale), as.logical(log))
+  if(missing(rate)) {
+    .Call(C_ddexp, as.double(x), as.double(location), as.double(scale), as.logical(log))
+  } else {
+    .Call(C_ddexp, as.double(x), as.double(location), as.double(1/rate), as.logical(log))
+  }
 }
 
 #' @rdname Double-Exponential
@@ -491,7 +495,11 @@ rdexp <- function(n, location = 0, scale = 1, rate = 1/scale) {
           warning("specify 'scale' or 'rate' but not both")
       else stop("specify 'scale' or 'rate' but not both")
   }
-  .Call(C_rdexp, as.integer(n), as.double(location), as.double(scale))
+  if(missing(rate)) {
+    .Call(C_rdexp, as.integer(n), as.double(location), as.double(scale))
+  } else {
+    .Call(C_rdexp, as.integer(n), as.double(location), as.double(1/rate))
+  }
 }
 
 #' @rdname Double-Exponential
@@ -502,7 +510,11 @@ pdexp <- function(q, location = 0, scale = 1, rate = 1/scale, lower.tail = TRUE,
           warning("specify 'scale' or 'rate' but not both")
       else stop("specify 'scale' or 'rate' but not both")
   }
-  .Call(C_pdexp, as.double(q), as.double(location), as.double(scale), as.logical(lower.tail), as.logical(log.p))
+  if(missing(rate)) {
+    .Call(C_pdexp, as.double(q), as.double(location), as.double(scale), as.logical(lower.tail), as.logical(log.p))
+  } else {
+    .Call(C_pdexp, as.double(q), as.double(location), as.double(1/rate), as.logical(lower.tail), as.logical(log.p))
+  }
 }
 
 #' @rdname Double-Exponential
@@ -513,7 +525,11 @@ qdexp <- function(p, location = 0, scale = 1, rate = 1/scale, lower.tail = TRUE,
           warning("specify 'scale' or 'rate' but not both")
       else stop("specify 'scale' or 'rate' but not both")
   }
-  .Call(C_qdexp, as.double(p), as.double(location), as.double(scale), as.logical(lower.tail), as.logical(log.p))
+  if(missing(rate)) {
+    .Call(C_qdexp, as.double(p), as.double(location), as.double(scale), as.logical(lower.tail), as.logical(log.p))
+  } else {
+    .Call(C_qdexp, as.double(p), as.double(location), as.double(1/rate), as.logical(lower.tail), as.logical(log.p))    
+  }
 }
 
 

--- a/packages/nimble/R/nimbleFunction_keywordProcessing.R
+++ b/packages/nimble/R/nimbleFunction_keywordProcessing.R
@@ -793,6 +793,10 @@ keywordList[['dinvgamma']] <- d_gamma_keywordInfo
 keywordList[['pinvgamma']] <- pq_gamma_keywordInfo
 keywordList[['qinvgamma']] <- pq_gamma_keywordInfo
 keywordList[['rinvgamma']] <- rgamma_keywordInfo
+keywordList[['dsqrtinvgamma']] <- d_gamma_keywordInfo
+keywordList[['psqrtinvgamma']] <- pq_gamma_keywordInfo
+keywordList[['qsqrtinvgamma']] <- pq_gamma_keywordInfo
+keywordList[['rsqrtinvgamma']] <- rgamma_keywordInfo
 keywordList[['ddexp']] <- d_gamma_keywordInfo
 keywordList[['pdexp']] <- pq_gamma_keywordInfo
 keywordList[['qdexp']] <- pq_gamma_keywordInfo
@@ -849,10 +853,10 @@ matchFunctions[['dgamma']] <- function(x, shape, rate = 1, scale, log = FALSE){}
 matchFunctions[['rgamma']] <- function(n, shape, rate = 1, scale){}
 matchFunctions[['qgamma']] <- function(p, shape, rate = 1, scale, lower.tail = TRUE, log.p = FALSE){}
 matchFunctions[['pgamma']] <- function(q, shape, rate = 1, scale, lower.tail = TRUE, log.p = FALSE){}
-matchFunctions[['dinvgamma']] <- function(x, shape, scale = 1, rate, log = FALSE){}
-matchFunctions[['rinvgamma']] <- function(n, shape, scale = 1, rate){}
-matchFunctions[['qinvgamma']] <- function(p, shape, scale = 1, rate, lower.tail = TRUE, log.p = FALSE){}
-matchFunctions[['pinvgamma']] <- function(q, shape, scale = 1, rate, lower.tail = TRUE, log.p = FALSE){}
+matchFunctions[['dinvgamma']] <- matchFunctions[['dsqrtinvgamma']] <- function(x, shape, scale = 1, rate, log = FALSE){}
+matchFunctions[['rinvgamma']] <- matchFunctions[['rsqrtinvgamma']] <- function(n, shape, scale = 1, rate){}
+matchFunctions[['qinvgamma']] <- matchFunctions[['qsqrtinvgamma']] <- function(p, shape, scale = 1, rate, lower.tail = TRUE, log.p = FALSE){}
+matchFunctions[['pinvgamma']] <- matchFunctions[['psqrtinvgamma']] <- function(q, shape, scale = 1, rate, lower.tail = TRUE, log.p = FALSE){}
 matchFunctions[['dexp']] <- function(x, rate = 1, log = FALSE){}
 matchFunctions[['rexp']] <- function(n, rate = 1){}
 matchFunctions[['qexp']] <- function(p, rate = 1, lower.tail = TRUE, log.p = FALSE){}
@@ -1621,28 +1625,42 @@ makeSingleIndexAccessCodeNames <- function(baseName) {
 }
 
 handleScaleAndRateForGamma <- function(code){
-    ## also handles core R dexp, as well as ddexp, and dinvgamma
-    scaleArg <- code$scale
-    rateArg <- code$rate
-    if(is.null(scaleArg) && is.null(rateArg))	stop('neither scale nor rate defined in dgamma, invgamma, dexp, or ddexp')
-    codeName <- deparse(code[[1]])
-    dist <- substring(codeName, 2, nchar(codeName))
-    if(dist == 'invgamma') {
-            if(is.null(rateArg)) {
-            rateArg <- substitute(1.0/(A), list(A = code$scale)) 
-            code$scale <- rateArg
-            names(code)[which(names(code) == 'scale')] <- 'rate'  # to preserve correct order
-        }
-        code$scale <- NULL
-    } else {
-        if(is.null(scaleArg)) {
-            scaleArg <- substitute(1.0/(A), list(A = code$rate)) 
-            code$rate <- scaleArg
-            names(code)[which(names(code) == 'rate')] <- 'scale'  # to preserve correct order
-        }
-        code$rate <- NULL
+  ## also handles core R dexp, as well as ddexp, and dinvgamma
+  scaleArg <- code$scale
+  rateArg <- code$rate
+  if(is.null(scaleArg) && is.null(rateArg))	stop('neither scale nor rate defined in dgamma, invgamma, dexp, or ddexp')
+  codeName <- deparse(code[[1]])
+  dist <- substring(codeName, 2, nchar(codeName))
+  if(dist == 'invgamma' || dist == 'sqrtinvgamma') {  ## For [drpq]invgamma
+    if(is.null(rateArg)) {
+      rateArg <- substitute(1.0/(A), list(A = code$scale)) 
+      code$scale <- rateArg
+      names(code)[which(names(code) == 'scale')] <- 'rate'  # to preserve correct order
     }
-    return(code)
+    code$scale <- NULL
+  } else if(dist == 'dexp') { ## This is for [drpq]dexp
+    ## The logic here is trickier.  scale has a default value and is canonical (what is needed for C).
+    ## If rate was provided, then by the time we are here, matchFunctions has been used (matchAndFill.call),
+    ## so there will also be a scale, since it has a default
+    setScaleArg <- FALSE
+    if(is.null(scaleArg)) setScaleArg <- TRUE ## scale is not expected to be null ever (see previous comment), but this is defensive.
+    if(!is.null(scaleArg) & !is.null(rateArg)) setScaleArg <- TRUE ## Both are there, so set scale from the provided rate
+    if(setScaleArg) {
+      code$scale <- NULL
+      scaleArg <- substitute(1.0/(A), list(A = code$rate)) 
+      code$rate <- scaleArg
+      names(code)[which(names(code) == 'rate')] <- 'scale'  # to preserve correct order
+    }
+    code$rate <- NULL
+  } else { # dgamma
+    if(is.null(scaleArg)) {
+      scaleArg <- substitute(1.0/(A), list(A = code$rate)) 
+      code$rate <- scaleArg
+      names(code)[which(names(code) == 'rate')] <- 'scale'  # to preserve correct order
+    }
+    code$rate <- NULL
+  }
+  return(code)
 }
 
 handleScaleAndRateForExpNimble <- function(code){


### PR DESCRIPTION
Fixes #949 

This also handles what appears to have been lack of complete handling of parameterizations for dsqrtinvgamma. @paciorek do you want to check on whether we had testing coverage of that?

NB in case we have future cases, unfortunately for dists with scale vs rate parameterizations, there are extra steps that need to happen in keyword processing.
