### PR TITLE
allow full recycling where param length is longer than main arg

### DIFF
--- a/packages/nimble/inst/CppCode/dists.cpp
+++ b/packages/nimble/inst/CppCode/dists.cpp
@@ -1359,13 +1359,16 @@ SEXP C_dt_nonstandard(SEXP x, SEXP df, SEXP mu, SEXP sigma, SEXP return_log) {
     for(int i = 0; i < n_x; i++) 
       REAL(ans)[i] = dt_nonstandard(c_x[i], *c_df, *c_mu, *c_sigma, give_log);
   } else {
+    int i_x = 0;
     int i_mu = 0;
     int i_sigma = 0;
     int i_df = 0;
-    for(int i = 0; i < n_x; i++) {
-      REAL(ans)[i] = dt_nonstandard(c_x[i], c_df[i_df++], c_mu[i_mu++], c_sigma[i_sigma++], give_log);
+    int n_max = max(n_x, max(n_mu, max(n_sigma, n_df)));
+    for(int i = 0; i < n_max; i++) {
+      REAL(ans)[i] = dt_nonstandard(c_x[i_x++], c_df[i_df++], c_mu[i_mu++], c_sigma[i_sigma++], give_log);
       //c_mu[i_mu++] + c_sigma[i_sigma++] * rt(c_df[i_df++]);
       // implement recycling:
+      if(i_x == n_x) i_x = 0;
       if(i_mu == n_mu) i_mu = 0;
       if(i_sigma == n_sigma) i_sigma = 0;
       if(i_df == n_df) i_df = 0;
@@ -1451,13 +1454,16 @@ SEXP C_pt_nonstandard(SEXP q, SEXP df, SEXP mu, SEXP sigma, SEXP lower_tail, SEX
     for(int i = 0; i < n_q; i++) 
       REAL(ans)[i] = pt_nonstandard(c_q[i], *c_df, *c_mu, *c_sigma, c_lower_tail, c_log_p);
   } else {
+    int i_q = 0;
     int i_mu = 0;
     int i_sigma = 0;
     int i_df = 0;
-    for(int i = 0; i < n_q; i++) {
-      REAL(ans)[i] = pt_nonstandard(c_q[i], c_df[i_df++], c_mu[i_mu++], c_sigma[i_sigma++], c_lower_tail, c_log_p);
+    int n_max = max(n_q, max(n_mu, max(n_sigma, n_df)));
+    for(int i = 0; i < n_max; i++) {
+      REAL(ans)[i] = pt_nonstandard(c_q[i_q++], c_df[i_df++], c_mu[i_mu++], c_sigma[i_sigma++], c_lower_tail, c_log_p);
       //c_mu[i_mu++] + c_sigma[i_sigma++] * rt(c_df[i_df++]);
       // implement recycling:
+      if(i_q == n_q) i_q = 0;
       if(i_mu == n_mu) i_mu = 0;
       if(i_sigma == n_sigma) i_sigma = 0;
       if(i_df == n_df) i_df = 0;
@@ -1495,13 +1501,16 @@ SEXP C_qt_nonstandard(SEXP p, SEXP df, SEXP mu, SEXP sigma, SEXP lower_tail, SEX
     for(int i = 0; i < n_p; i++) 
       REAL(ans)[i] = qt_nonstandard(c_p[i], *c_df, *c_mu, *c_sigma, c_lower_tail, c_log_p);
   } else {
+    int i_p = 0;
     int i_mu = 0;
     int i_sigma = 0;
     int i_df = 0;
-    for(int i = 0; i < n_p; i++) {
-      REAL(ans)[i] = qt_nonstandard(c_p[i], c_df[i_df++], c_mu[i_mu++], c_sigma[i_sigma++], c_lower_tail, c_log_p);
+    int n_max = max(n_p, max(n_mu, max(n_sigma, n_df)));
+    for(int i = 0; i < n_max; i++) {
+      REAL(ans)[i] = qt_nonstandard(c_p[i_p++], c_df[i_df++], c_mu[i_mu++], c_sigma[i_sigma++], c_lower_tail, c_log_p);
       //c_mu[i_mu++] + c_sigma[i_sigma++] * rt(c_df[i_df++]);
       // implement recycling:
+      if(i_p == n_p) i_p = 0;
       if(i_mu == n_mu) i_mu = 0;
       if(i_sigma == n_sigma) i_sigma = 0;
       if(i_df == n_df) i_df = 0;
@@ -1573,15 +1582,20 @@ SEXP C_dinterval(SEXP x, SEXP t, SEXP c, SEXP return_log) {
   double* c_c = REAL(c);
 
   // FIXME: abstract the recycling as a function
+  // Doesn't really make sense to have recycling as only presumably would only
+  // use this when lengths of x and t are the same, but have it for consistency.
   if(n_t == 1) {
     // if no parameter vectors, more efficient not to deal with multiple indices
     for(int i = 0; i < n_x; i++) 
       REAL(ans)[i] = dinterval(c_x[i], *c_t, c_c, n_c, give_log);
   } else {
+    int i_x = 0;
     int i_t = 0;
-    for(int i = 0; i < n_x; i++) {
-      REAL(ans)[i] = dinterval(c_x[i], c_t[i_t++], c_c, n_c, give_log);
+    int n_max = max(n_x, n_t);
+    for(int i = 0; i < n_max; i++) {
+      REAL(ans)[i] = dinterval(c_x[i_x++], c_t[i_t++], c_c, n_c, give_log);
       // implement recycling:
+      if(i_x == n_x) i_x = 0;
       if(i_t == n_t) i_t = 0;
     }
   }
@@ -1698,9 +1712,12 @@ SEXP C_dexp_nimble(SEXP x, SEXP rate, SEXP return_log) {
     for(int i = 0; i < n_x; i++) 
       REAL(ans)[i] = dexp_nimble(c_x[i], *c_rate, give_log);
   } else {
+    int i_x = 0;
     int i_rate = 0;
-    for(int i = 0; i < n_x; i++) {
-      REAL(ans)[i] = dexp_nimble(c_x[i], c_rate[i_rate++], give_log);
+    int n_max = max(n_x, n_rate);
+    for(int i = 0; i < n_max; i++) {
+      REAL(ans)[i] = dexp_nimble(c_x[i_x++], c_rate[i_rate++], give_log);
+      if(i_x == n_x) i_x = 0;
       if(i_rate == n_rate) i_rate = 0;
     }
   }
@@ -1771,9 +1788,12 @@ SEXP C_pexp_nimble(SEXP q, SEXP rate, SEXP lower_tail, SEXP log_p) {
     for(int i = 0; i < n_q; i++) 
       REAL(ans)[i] = pexp_nimble(c_q[i], *c_rate, c_lower_tail, c_log_p);
   } else {
+    int i_q = 0;
     int i_rate = 0;
-    for(int i = 0; i < n_q; i++) {
-      REAL(ans)[i] = pexp_nimble(c_q[i], c_rate[i_rate++], c_lower_tail, c_log_p);
+    int n_max = max(n_q, n_rate);
+    for(int i = 0; i < n_max; i++) {
+      REAL(ans)[i] = pexp_nimble(c_q[i_q++], c_rate[i_rate++], c_lower_tail, c_log_p);
+      if(i_q == n_q) i_q = 0;
       if(i_rate == n_rate) i_rate = 0;
     }
   }
@@ -1805,9 +1825,12 @@ SEXP C_qexp_nimble(SEXP p, SEXP rate, SEXP lower_tail, SEXP log_p) {
     for(int i = 0; i < n_p; i++) 
       REAL(ans)[i] = qexp_nimble(c_p[i], *c_rate, c_lower_tail, c_log_p);
   } else {
+    int i_p = 0;
     int i_rate = 0;
-    for(int i = 0; i < n_p; i++) {
-      REAL(ans)[i] = qexp_nimble(c_p[i], c_rate[i_rate++], c_lower_tail, c_log_p);
+    int n_max = max(n_p, n_rate);
+    for(int i = 0; i < n_max; i++) {
+      REAL(ans)[i] = qexp_nimble(c_p[i_p++], c_rate[i_rate++], c_lower_tail, c_log_p);
+      if(i_p == n_p) i_p = 0;
       if(i_rate == n_rate) i_rate = 0;
     }
   }
@@ -1912,11 +1935,14 @@ SEXP C_ddexp(SEXP x, SEXP location, SEXP scale, SEXP return_log) {
     for(int i = 0; i < n_x; i++) 
       REAL(ans)[i] = ddexp(c_x[i], *c_location, *c_scale, give_log);
   } else {
+    int i_x = 0;
     int i_location = 0;
     int i_scale = 0;
-    for(int i = 0; i < n_x; i++) {
-      REAL(ans)[i] = ddexp(c_x[i], c_location[i_location++], c_scale[i_scale++], give_log);
+    int n_max = max(n_x, max(n_location, n_scale));
+    for(int i = 0; i < n_max; i++) {
+      REAL(ans)[i] = ddexp(c_x[i_x++], c_location[i_location++], c_scale[i_scale++], give_log);
       // implement recycling:
+      if(i_x == n_x) i_x = 0;
       if(i_location == n_location) i_location = 0;
       if(i_scale == n_scale) i_scale = 0;
     }
@@ -1993,11 +2019,14 @@ SEXP C_pdexp(SEXP q, SEXP location, SEXP scale, SEXP lower_tail, SEXP log_p) {
     for(int i = 0; i < n_q; i++) 
       REAL(ans)[i] = pdexp(c_q[i], *c_location, *c_scale, c_lower_tail, c_log_p);
   } else {
+    int i_q = 0;
     int i_location = 0;
     int i_scale = 0;
-    for(int i = 0; i < n_q; i++) {
-      REAL(ans)[i] = pdexp(c_q[i], c_location[i_location++], c_scale[i_scale++], c_lower_tail, c_log_p);
+    int n_max = max(n_q, max(n_location, n_scale));
+    for(int i = 0; i < n_max; i++) {
+      REAL(ans)[i] = pdexp(c_q[i_q++], c_location[i_location++], c_scale[i_scale++], c_lower_tail, c_log_p);
       // implement recycling:
+      if(i_q == n_q) i_q = 0;
       if(i_location == n_location) i_location = 0;
       if(i_scale == n_scale) i_scale = 0;
     }
@@ -2032,11 +2061,14 @@ SEXP C_qdexp(SEXP p, SEXP location, SEXP scale, SEXP lower_tail, SEXP log_p) {
     for(int i = 0; i < n_p; i++) 
       REAL(ans)[i] = qdexp(c_p[i], *c_location, *c_scale, c_lower_tail, c_log_p);
   } else {
+    int i_p = 0;
     int i_location = 0;
     int i_scale = 0;
-    for(int i = 0; i < n_p; i++) {
-      REAL(ans)[i] = qdexp(c_p[i], c_location[i_location++], c_scale[i_scale++], c_lower_tail, c_log_p);
+    int n_max = max(n_p, max(n_location, n_scale));
+    for(int i = 0; i < n_max; i++) {
+      REAL(ans)[i] = qdexp(c_p[i_p++], c_location[i_location++], c_scale[i_scale++], c_lower_tail, c_log_p);
       // implement recycling:
+      if(i_p == n_p) i_p = 0;
       if(i_location == n_location) i_location = 0;
       if(i_scale == n_scale) i_scale = 0;
     }
@@ -2092,11 +2124,14 @@ SEXP C_dsqrtinvgamma(SEXP x, SEXP shape, SEXP rate, SEXP return_log) {
     for(int i = 0; i < n_x; i++) 
       REAL(ans)[i] = dsqrtinvgamma(c_x[i], *c_shape, *c_rate, give_log);
   } else {
+    int i_x = 0;
     int i_shape = 0;
     int i_rate = 0;
-    for(int i = 0; i < n_x; i++) {
-      REAL(ans)[i] = dsqrtinvgamma(c_x[i], c_shape[i_shape++], c_rate[i_rate++], give_log);
+    int n_max = max(n_x, max(n_shape, n_rate));
+    for(int i = 0; i < n_max; i++) {
+      REAL(ans)[i] = dsqrtinvgamma(c_x[i_x++], c_shape[i_shape++], c_rate[i_rate++], give_log);
       // implement recycling:
+      if(i_x == n_x) i_x = 0;
       if(i_shape == n_shape) i_shape = 0;
       if(i_rate == n_rate) i_rate = 0;
     }
@@ -2253,11 +2288,14 @@ SEXP C_dinvgamma(SEXP x, SEXP shape, SEXP rate, SEXP return_log) {
     for(int i = 0; i < n_x; i++) 
       REAL(ans)[i] = dinvgamma(c_x[i], *c_shape, *c_rate, give_log);
   } else {
+    int i_x = 0;
     int i_shape = 0;
     int i_rate = 0;
-    for(int i = 0; i < n_x; i++) {
-      REAL(ans)[i] = dinvgamma(c_x[i], c_shape[i_shape++], c_rate[i_rate++], give_log);
+    int n_max = max(n_x, max(n_shape, n_rate));
+    for(int i = 0; i < n_max; i++) {
+      REAL(ans)[i] = dinvgamma(c_x[i_x++], c_shape[i_shape++], c_rate[i_rate++], give_log);
       // implement recycling:
+      if(i_x == n_x) i_x = 0;
       if(i_shape == n_shape) i_shape = 0;
       if(i_rate == n_rate) i_rate = 0;
     }
@@ -2334,11 +2372,14 @@ SEXP C_pinvgamma(SEXP q, SEXP shape, SEXP rate, SEXP lower_tail, SEXP log_p) {
     for(int i = 0; i < n_q; i++) 
       REAL(ans)[i] = pinvgamma(c_q[i], *c_shape, *c_rate, c_lower_tail, c_log_p);
   } else {
+    int i_q = 0;
     int i_shape = 0;
     int i_rate = 0;
-    for(int i = 0; i < n_q; i++) {
-      REAL(ans)[i] = pinvgamma(c_q[i], c_shape[i_shape++], c_rate[i_rate++], c_lower_tail, c_log_p);
+    int n_max = max(n_q, max(n_shape, n_rate));
+    for(int i = 0; i < n_max; i++) {
+      REAL(ans)[i] = pinvgamma(c_q[i_q++], c_shape[i_shape++], c_rate[i_rate++], c_lower_tail, c_log_p);
       // implement recycling:
+      if(i_q == n_q) i_q = 0;
       if(i_shape == n_shape) i_shape = 0;
       if(i_rate == n_rate) i_rate = 0;
     }
@@ -2373,11 +2414,14 @@ SEXP C_qinvgamma(SEXP p, SEXP shape, SEXP rate, SEXP lower_tail, SEXP log_p) {
     for(int i = 0; i < n_p; i++) 
       REAL(ans)[i] = qinvgamma(c_p[i], *c_shape, *c_rate, c_lower_tail, c_log_p);
   } else {
+    int i_p = 0;
     int i_shape = 0;
     int i_rate = 0;
-    for(int i = 0; i < n_p; i++) {
-      REAL(ans)[i] = qinvgamma(c_p[i], c_shape[i_shape++], c_rate[i_rate++], c_lower_tail, c_log_p);
+    int n_max = max(n_p, max(n_shape, n_rate));
+    for(int i = 0; i < n_max; i++) {
+      REAL(ans)[i] = qinvgamma(c_p[i_p++], c_shape[i_shape++], c_rate[i_rate++], c_lower_tail, c_log_p);
       // implement recycling:
+      if(i_p == n_p) i_p = 0;
       if(i_shape == n_shape) i_shape = 0;
       if(i_rate == n_rate) i_rate = 0;
     }

--- a/packages/nimble/inst/CppCode/dists.cpp
+++ b/packages/nimble/inst/CppCode/dists.cpp
@@ -1346,8 +1346,9 @@ SEXP C_dt_nonstandard(SEXP x, SEXP df, SEXP mu, SEXP sigma, SEXP return_log) {
   if(n_x == 0) {
     return x;
   }
-    
-  PROTECT(ans = Rf_allocVector(REALSXP, n_x));  
+
+  int n_max = max(n_x, max(n_mu, max(n_sigma, n_df)));
+  PROTECT(ans = Rf_allocVector(REALSXP, n_max));  
   double* c_x = REAL(x);
   double* c_mu = REAL(mu);
   double* c_sigma = REAL(sigma);
@@ -1363,7 +1364,6 @@ SEXP C_dt_nonstandard(SEXP x, SEXP df, SEXP mu, SEXP sigma, SEXP return_log) {
     int i_mu = 0;
     int i_sigma = 0;
     int i_df = 0;
-    int n_max = max(n_x, max(n_mu, max(n_sigma, n_df)));
     for(int i = 0; i < n_max; i++) {
       REAL(ans)[i] = dt_nonstandard(c_x[i_x++], c_df[i_df++], c_mu[i_mu++], c_sigma[i_sigma++], give_log);
       //c_mu[i_mu++] + c_sigma[i_sigma++] * rt(c_df[i_df++]);
@@ -1441,8 +1441,9 @@ SEXP C_pt_nonstandard(SEXP q, SEXP df, SEXP mu, SEXP sigma, SEXP lower_tail, SEX
   if(n_q == 0) {
     return q;
   }
-    
-  PROTECT(ans = Rf_allocVector(REALSXP, n_q));  
+
+  int n_max = max(n_q, max(n_mu, max(n_sigma, n_df)));
+  PROTECT(ans = Rf_allocVector(REALSXP, n_max));  
   double* c_q = REAL(q);
   double* c_mu = REAL(mu);
   double* c_sigma = REAL(sigma);
@@ -1458,7 +1459,6 @@ SEXP C_pt_nonstandard(SEXP q, SEXP df, SEXP mu, SEXP sigma, SEXP lower_tail, SEX
     int i_mu = 0;
     int i_sigma = 0;
     int i_df = 0;
-    int n_max = max(n_q, max(n_mu, max(n_sigma, n_df)));
     for(int i = 0; i < n_max; i++) {
       REAL(ans)[i] = pt_nonstandard(c_q[i_q++], c_df[i_df++], c_mu[i_mu++], c_sigma[i_sigma++], c_lower_tail, c_log_p);
       //c_mu[i_mu++] + c_sigma[i_sigma++] * rt(c_df[i_df++]);
@@ -1488,8 +1488,9 @@ SEXP C_qt_nonstandard(SEXP p, SEXP df, SEXP mu, SEXP sigma, SEXP lower_tail, SEX
   if(n_p == 0) {
     return p;
   }
-    
-  PROTECT(ans = Rf_allocVector(REALSXP, n_p));  
+
+  int n_max = max(n_p, max(n_mu, max(n_sigma, n_df)));
+  PROTECT(ans = Rf_allocVector(REALSXP, n_max));  
   double* c_p = REAL(p);
   double* c_mu = REAL(mu);
   double* c_sigma = REAL(sigma);
@@ -1505,7 +1506,6 @@ SEXP C_qt_nonstandard(SEXP p, SEXP df, SEXP mu, SEXP sigma, SEXP lower_tail, SEX
     int i_mu = 0;
     int i_sigma = 0;
     int i_df = 0;
-    int n_max = max(n_p, max(n_mu, max(n_sigma, n_df)));
     for(int i = 0; i < n_max; i++) {
       REAL(ans)[i] = qt_nonstandard(c_p[i_p++], c_df[i_df++], c_mu[i_mu++], c_sigma[i_sigma++], c_lower_tail, c_log_p);
       //c_mu[i_mu++] + c_sigma[i_sigma++] * rt(c_df[i_df++]);
@@ -1575,8 +1575,9 @@ SEXP C_dinterval(SEXP x, SEXP t, SEXP c, SEXP return_log) {
   if(n_x == 0) {
     return x;
   }
-    
-  PROTECT(ans = Rf_allocVector(REALSXP, n_x));  
+
+  int n_max = max(n_x, n_t);
+  PROTECT(ans = Rf_allocVector(REALSXP, n_max));  
   double* c_x = REAL(x);
   double* c_t = REAL(t);
   double* c_c = REAL(c);
@@ -1591,7 +1592,6 @@ SEXP C_dinterval(SEXP x, SEXP t, SEXP c, SEXP return_log) {
   } else {
     int i_x = 0;
     int i_t = 0;
-    int n_max = max(n_x, n_t);
     for(int i = 0; i < n_max; i++) {
       REAL(ans)[i] = dinterval(c_x[i_x++], c_t[i_t++], c_c, n_c, give_log);
       // implement recycling:
@@ -1701,8 +1701,9 @@ SEXP C_dexp_nimble(SEXP x, SEXP rate, SEXP return_log) {
   if(n_x == 0) {
     return x;
   }
-    
-  PROTECT(ans = Rf_allocVector(REALSXP, n_x));  
+
+  int n_max = max(n_x, n_rate);
+  PROTECT(ans = Rf_allocVector(REALSXP, n_max));  
   double* c_x = REAL(x);
   double* c_rate = REAL(rate);
 
@@ -1714,7 +1715,6 @@ SEXP C_dexp_nimble(SEXP x, SEXP rate, SEXP return_log) {
   } else {
     int i_x = 0;
     int i_rate = 0;
-    int n_max = max(n_x, n_rate);
     for(int i = 0; i < n_max; i++) {
       REAL(ans)[i] = dexp_nimble(c_x[i_x++], c_rate[i_rate++], give_log);
       if(i_x == n_x) i_x = 0;
@@ -1777,8 +1777,9 @@ SEXP C_pexp_nimble(SEXP q, SEXP rate, SEXP lower_tail, SEXP log_p) {
   if(n_q == 0) {
     return q;
   }
-    
-  PROTECT(ans = Rf_allocVector(REALSXP, n_q));  
+
+  int n_max = max(n_q, n_rate);
+  PROTECT(ans = Rf_allocVector(REALSXP, n_max));  
   double* c_q = REAL(q);
   double* c_rate = REAL(rate);
 
@@ -1790,7 +1791,6 @@ SEXP C_pexp_nimble(SEXP q, SEXP rate, SEXP lower_tail, SEXP log_p) {
   } else {
     int i_q = 0;
     int i_rate = 0;
-    int n_max = max(n_q, n_rate);
     for(int i = 0; i < n_max; i++) {
       REAL(ans)[i] = pexp_nimble(c_q[i_q++], c_rate[i_rate++], c_lower_tail, c_log_p);
       if(i_q == n_q) i_q = 0;
@@ -1814,8 +1814,9 @@ SEXP C_qexp_nimble(SEXP p, SEXP rate, SEXP lower_tail, SEXP log_p) {
   if(n_p == 0) {
     return p;
   }
-    
-  PROTECT(ans = Rf_allocVector(REALSXP, n_p));  
+
+  int n_max = max(n_p, n_rate);
+  PROTECT(ans = Rf_allocVector(REALSXP, n_max));  
   double* c_p = REAL(p);
   double* c_rate = REAL(rate);
 
@@ -1827,7 +1828,6 @@ SEXP C_qexp_nimble(SEXP p, SEXP rate, SEXP lower_tail, SEXP log_p) {
   } else {
     int i_p = 0;
     int i_rate = 0;
-    int n_max = max(n_p, n_rate);
     for(int i = 0; i < n_max; i++) {
       REAL(ans)[i] = qexp_nimble(c_p[i_p++], c_rate[i_rate++], c_lower_tail, c_log_p);
       if(i_p == n_p) i_p = 0;
@@ -1923,8 +1923,9 @@ SEXP C_ddexp(SEXP x, SEXP location, SEXP scale, SEXP return_log) {
   if(n_x == 0) {
     return x;
   }
-    
-  PROTECT(ans = Rf_allocVector(REALSXP, n_x));  
+
+  int n_max = max(n_x, max(n_location, n_scale));
+  PROTECT(ans = Rf_allocVector(REALSXP, n_max));  
   double* c_x = REAL(x);
   double* c_location = REAL(location);
   double* c_scale = REAL(scale);
@@ -1938,7 +1939,6 @@ SEXP C_ddexp(SEXP x, SEXP location, SEXP scale, SEXP return_log) {
     int i_x = 0;
     int i_location = 0;
     int i_scale = 0;
-    int n_max = max(n_x, max(n_location, n_scale));
     for(int i = 0; i < n_max; i++) {
       REAL(ans)[i] = ddexp(c_x[i_x++], c_location[i_location++], c_scale[i_scale++], give_log);
       // implement recycling:
@@ -2007,8 +2007,9 @@ SEXP C_pdexp(SEXP q, SEXP location, SEXP scale, SEXP lower_tail, SEXP log_p) {
   if(n_q == 0) {
     return q;
   }
-    
-  PROTECT(ans = Rf_allocVector(REALSXP, n_q));  
+
+  int n_max = max(n_q, max(n_location, n_scale));
+  PROTECT(ans = Rf_allocVector(REALSXP, n_max));  
   double* c_q = REAL(q);
   double* c_location = REAL(location);
   double* c_scale = REAL(scale);
@@ -2022,7 +2023,6 @@ SEXP C_pdexp(SEXP q, SEXP location, SEXP scale, SEXP lower_tail, SEXP log_p) {
     int i_q = 0;
     int i_location = 0;
     int i_scale = 0;
-    int n_max = max(n_q, max(n_location, n_scale));
     for(int i = 0; i < n_max; i++) {
       REAL(ans)[i] = pdexp(c_q[i_q++], c_location[i_location++], c_scale[i_scale++], c_lower_tail, c_log_p);
       // implement recycling:
@@ -2049,8 +2049,9 @@ SEXP C_qdexp(SEXP p, SEXP location, SEXP scale, SEXP lower_tail, SEXP log_p) {
   if(n_p == 0) {
     return p;
   }
-    
-  PROTECT(ans = Rf_allocVector(REALSXP, n_p));  
+
+  int n_max = max(n_p, max(n_location, n_scale));
+  PROTECT(ans = Rf_allocVector(REALSXP, n_max));  
   double* c_p = REAL(p);
   double* c_location = REAL(location);
   double* c_scale = REAL(scale);
@@ -2064,7 +2065,6 @@ SEXP C_qdexp(SEXP p, SEXP location, SEXP scale, SEXP lower_tail, SEXP log_p) {
     int i_p = 0;
     int i_location = 0;
     int i_scale = 0;
-    int n_max = max(n_p, max(n_location, n_scale));
     for(int i = 0; i < n_max; i++) {
       REAL(ans)[i] = qdexp(c_p[i_p++], c_location[i_location++], c_scale[i_scale++], c_lower_tail, c_log_p);
       // implement recycling:
@@ -2112,8 +2112,9 @@ SEXP C_dsqrtinvgamma(SEXP x, SEXP shape, SEXP rate, SEXP return_log) {
   if(n_x == 0) {
     return x;
   }
-    
-  PROTECT(ans = Rf_allocVector(REALSXP, n_x));  
+
+  int n_max = max(n_x, max(n_shape, n_rate));
+  PROTECT(ans = Rf_allocVector(REALSXP, n_max));  
   double* c_x = REAL(x);
   double* c_shape = REAL(shape);
   double* c_rate = REAL(rate);
@@ -2127,7 +2128,6 @@ SEXP C_dsqrtinvgamma(SEXP x, SEXP shape, SEXP rate, SEXP return_log) {
     int i_x = 0;
     int i_shape = 0;
     int i_rate = 0;
-    int n_max = max(n_x, max(n_shape, n_rate));
     for(int i = 0; i < n_max; i++) {
       REAL(ans)[i] = dsqrtinvgamma(c_x[i_x++], c_shape[i_shape++], c_rate[i_rate++], give_log);
       // implement recycling:
@@ -2276,8 +2276,9 @@ SEXP C_dinvgamma(SEXP x, SEXP shape, SEXP rate, SEXP return_log) {
   if(n_x == 0) {
     return x;
   }
-    
-  PROTECT(ans = Rf_allocVector(REALSXP, n_x));  
+
+  int n_max = max(n_x, max(n_shape, n_rate));
+  PROTECT(ans = Rf_allocVector(REALSXP, n_max));  
   double* c_x = REAL(x);
   double* c_shape = REAL(shape);
   double* c_rate = REAL(rate);
@@ -2291,7 +2292,6 @@ SEXP C_dinvgamma(SEXP x, SEXP shape, SEXP rate, SEXP return_log) {
     int i_x = 0;
     int i_shape = 0;
     int i_rate = 0;
-    int n_max = max(n_x, max(n_shape, n_rate));
     for(int i = 0; i < n_max; i++) {
       REAL(ans)[i] = dinvgamma(c_x[i_x++], c_shape[i_shape++], c_rate[i_rate++], give_log);
       // implement recycling:
@@ -2360,8 +2360,9 @@ SEXP C_pinvgamma(SEXP q, SEXP shape, SEXP rate, SEXP lower_tail, SEXP log_p) {
   if(n_q == 0) {
     return q;
   }
-    
-  PROTECT(ans = Rf_allocVector(REALSXP, n_q));  
+
+  int n_max = max(n_q, max(n_shape, n_rate));
+  PROTECT(ans = Rf_allocVector(REALSXP, n_max));  
   double* c_q = REAL(q);
   double* c_shape = REAL(shape);
   double* c_rate = REAL(rate);
@@ -2375,7 +2376,6 @@ SEXP C_pinvgamma(SEXP q, SEXP shape, SEXP rate, SEXP lower_tail, SEXP log_p) {
     int i_q = 0;
     int i_shape = 0;
     int i_rate = 0;
-    int n_max = max(n_q, max(n_shape, n_rate));
     for(int i = 0; i < n_max; i++) {
       REAL(ans)[i] = pinvgamma(c_q[i_q++], c_shape[i_shape++], c_rate[i_rate++], c_lower_tail, c_log_p);
       // implement recycling:
@@ -2402,8 +2402,9 @@ SEXP C_qinvgamma(SEXP p, SEXP shape, SEXP rate, SEXP lower_tail, SEXP log_p) {
   if(n_p == 0) {
     return p;
   }
-    
-  PROTECT(ans = Rf_allocVector(REALSXP, n_p));  
+
+  int n_max = max(n_p, max(n_shape, n_rate));
+  PROTECT(ans = Rf_allocVector(REALSXP, n_max));  
   double* c_p = REAL(p);
   double* c_shape = REAL(shape);
   double* c_rate = REAL(rate);
@@ -2417,7 +2418,6 @@ SEXP C_qinvgamma(SEXP p, SEXP shape, SEXP rate, SEXP lower_tail, SEXP log_p) {
     int i_p = 0;
     int i_shape = 0;
     int i_rate = 0;
-    int n_max = max(n_p, max(n_shape, n_rate));
     for(int i = 0; i < n_max; i++) {
       REAL(ans)[i] = qinvgamma(c_p[i_p++], c_shape[i_shape++], c_rate[i_rate++], c_lower_tail, c_log_p);
       // implement recycling:

--- a/packages/nimble/inst/include/nimble/dists.h
+++ b/packages/nimble/inst/include/nimble/dists.h
@@ -24,6 +24,8 @@
 
 #include "Utils.h"
 
+using std::max;
+
 bool R_IsNA(double*, int);
 bool R_isnancpp(double*, int);
 bool R_FINITE_VEC(double*, int);

--- a/packages/nimble/inst/tests/test-distributions.R
+++ b/packages/nimble/inst/tests/test-distributions.R
@@ -547,6 +547,24 @@ test_that("ddexp usage", {
     cm$simulate('mu')
     expect_identical(smp[1], cm$mu, "incorrect compiled simulate for ddexp")
 })
+
+
+test_that("recycling behavior from R and within nimbleFunctions for non-R-native distributions", {
+    n <- 6
+    x <- rt_nonstandard(n, 3, 1:3, 2)
+    expect_equal(length(x), n)
+
+    d <- dt_nonstandard(x[1:3], 3, c(1:3,1:3), 2)
+
+    x <- 1:4
+    p <- pt_nonstandard(x, 3, 1, 2)
+    q <- qt_nonstandard(p, 3, 1, 2)
+    expect_equal(x, q)
+
+    p <- pt_nonstandard(1.5, 3, 1:3, 2)
+    qt_nonstandard(p, 3, 1:3, 2)
+    
+})
     
    
 sink(NULL)

--- a/packages/nimble/inst/tests/test-distributions.R
+++ b/packages/nimble/inst/tests/test-distributions.R
@@ -578,7 +578,7 @@ test_that("recycling behavior from R and within nimbleFunctions for non-R-native
         cf <- compileNimble(f)
         out <- cf(x[1:3], param) 
         expect_identical(out, c(d, p, q))
-    })
+    }
 
     ## dexp_nimble
     set.seed(1)

--- a/packages/nimble/inst/tests/test-distributions.R
+++ b/packages/nimble/inst/tests/test-distributions.R
@@ -550,20 +550,122 @@ test_that("ddexp usage", {
 
 
 test_that("recycling behavior from R and within nimbleFunctions for non-R-native distributions", {
-    n <- 6
-    x <- rt_nonstandard(n, 3, 1:3, 2)
-    expect_equal(length(x), n)
 
-    d <- dt_nonstandard(x[1:3], 3, c(1:3,1:3), 2)
+    ## dt_nonstandard
+    set.seed(1)
+    param <- runif(3)
+    x <- rt_nonstandard(6, 3, param, 2)
+    expect_equal(length(x), 6)
+    param <- rep(param, 2)
+    d <- dt_nonstandard(x[1:3], 3, param, 2)
+    expect_identical(d[1:3], d[4:6])
+    p <- pt_nonstandard(x[1:3], 3, param, 2)
+    q <- qt_nonstandard(p, 3, param, 2)
+    expect_equal(rep(x[1:3], 2), q)
+    expect_identical(p[1:3], p[4:6])
+    expect_identical(q[1:3], q[4:6])
 
-    x <- 1:4
-    p <- pt_nonstandard(x, 3, 1, 2)
-    q <- qt_nonstandard(p, 3, 1, 2)
-    expect_equal(x, q)
+    f <- nimbleFunction(
+        run = function(x = double(1), theta = double(1)) {
+            d <- dt_nonstandard(x, 3, theta, 2)
+            p <- pt_nonstandard(x, 3, theta, 2)
+            q <- qt_nonstandard(p, 3, theta, 2)
+            returnType(double(1))
+            return(c(d, p, q))
+        })
+    ## compilation error: issue #953
+    if(FALSE) {
+        cf <- compileNimble(f)
+        out <- cf(x[1:3], param) 
+        expect_identical(out, c(d, p, q))
+    })
 
-    p <- pt_nonstandard(1.5, 3, 1:3, 2)
-    qt_nonstandard(p, 3, 1:3, 2)
+    ## dexp_nimble
+    set.seed(1)
+    param <- runif(3)
+    x <- rexp_nimble(6, param)
+    expect_equal(length(x), 6)
+    param <- rep(param, 2)
+    d <- dexp_nimble(x[1:3], param)
+    expect_identical(d[1:3], d[4:6])
+    p <- pexp_nimble(x[1:3], param)
+    q <- qexp_nimble(p, param)
+    expect_equal(rep(x[1:3], 2), q)
+    expect_identical(p[1:3], p[4:6])
+    expect_identical(q[1:3], q[4:6])
+
+    f <- nimbleFunction(
+        run = function(x = double(1), theta = double(1)) {
+            d <- dexp_nimble(x, theta)
+            p <- pexp_nimble(x, theta)
+            q <- qexp_nimble(p, theta)
+            returnType(double(1))
+            return(c(d, p, q))
+        })
+    cf <- compileNimble(f)
+    out <- cf(x[1:3], param) 
+    expect_identical(out, c(d, p, q))
+
+    ## ddexp
+    set.seed(1)
+    param <- runif(3)
+    x <- rdexp(6, 0.5, param)
+    expect_equal(length(x), 6)
+    param <- rep(param, 2)
+    d <- ddexp(x[1:3], 0.5, param)
+    expect_identical(d[1:3], d[4:6])
+    p <- pdexp(x[1:3], 0.5, param)
+    q <- qdexp(p, 0.5, param)
+    expect_equal(rep(x[1:3], 2), q)
+    expect_identical(p[1:3], p[4:6])
+    expect_identical(q[1:3], q[4:6])
+
+    f <- nimbleFunction(
+        run = function(x = double(1), theta = double(1)) {
+            d <- ddexp(x, 0.5, theta)
+            p <- pdexp(x, 0.5, theta)
+            q <- qdexp(p, 0.5, theta)
+            returnType(double(1))
+            return(c(d, p, q))
+        })
+    cf <- compileNimble(f)
+    out <- cf(x[1:3], param) 
+    expect_identical(out, c(d, p, q))
+
+    ## dsqrt_invgamma (no p or q functions; not available in nimbleFunction)
+    set.seed(1)
+    param <- runif(3)
+    x <- rsqrtinvgamma(6, 0.5, param)
+    expect_equal(length(x), 6)
+    param <- rep(param, 2)
+    d <- dsqrtinvgamma(x[1:3], 0.5, param)
+    expect_identical(d[1:3], d[4:6])
     
+    ## dinvgamma
+    set.seed(1)
+    param <- runif(3)
+    x <- rinvgamma(6, 0.5, param)
+    expect_equal(length(x), 6)
+    param <- rep(param, 2)
+    d <- dinvgamma(x[1:3], 0.5, param)
+    expect_identical(d[1:3], d[4:6])
+    p <- pinvgamma(x[1:3], 0.5, param)
+    q <- qinvgamma(p, 0.5, param)
+    expect_equal(rep(x[1:3], 2), q)
+    expect_identical(p[1:3], p[4:6])
+    expect_identical(q[1:3], q[4:6])
+
+    f <- nimbleFunction(
+        run = function(x = double(1), theta = double(1)) {
+            d <- dinvgamma(x, 0.5, theta)
+            p <- pinvgamma(x, 0.5, theta)
+            q <- qinvgamma(p, 0.5, theta)
+            returnType(double(1))
+            return(c(d, p, q))
+        })
+    cf <- compileNimble(f)
+    out <- cf(x[1:3], param) 
+    expect_identical(out, c(d, p, q))
 })
     
    


### PR DESCRIPTION
This fixes a bug that we weren't recycling fully when a parameter vector was longer than the primary argument ('x', 'p', or 'q') for the 'd', 'q', and 'p' functions.

This is relevant for dt_nonstandard, ddexp, dinvgamma, dsqrtinvgamma, dexp_nimble.