### PR TITLE
Fixes Issue #918 by catching "::" in deparsed default model name

### DIFF
--- a/packages/nimble/R/BUGS_readBUGS.R
+++ b/packages/nimble/R/BUGS_readBUGS.R
@@ -81,6 +81,7 @@ nimbleModel <- function(code,
     if(is.null(name)) name <- paste0(gsub(" ", "_", substr(deparse(substitute(code))[1], 1, 10)),
                                      '_',
                                      nimbleModelID())
+    name <- gsub("::", "_cc_", name) ## :: can arise from a call via do.call, for example, giving name with "base::quote_"...
     if(length(constants) && sum(names(constants) == ""))
       stop("BUGSmodel: 'constants' must be a named list")
     if(length(dimensions) && sum(names(dimensions) == ""))


### PR DESCRIPTION
Fixed #918 

(The issue occurs when compileNimble is called)