### PR TITLE
allow multiplicative link in conjugacy system

### DIFF
--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -146,7 +146,7 @@ conjugacyRelationshipsInputList <- list(
          ## changing to only use link='identity' case, since the link='linear' case was not correct.
          ## -DT March 2017
          ## link = 'linear',
-         link = 'identity',
+         link = 'multiplicative',
          dependents = list(
              ## parentheses added to the contribution_R calculation:
              ## colVec * (rowVec * matrix)
@@ -155,16 +155,16 @@ conjugacyRelationshipsInputList <- list(
              ## changing to only use link='identity' case, since the link='linear' case was not correct
              ## -DT March 2017
              ## dmnorm = list(param = 'prec', contribution_R = 'asCol(value-mean) %*% (asRow(value-mean) %*% coeff)', contribution_df = '1')),
-             dmnorm = list(param = 'prec', contribution_R = 'asCol(value-mean) %*% asRow(value-mean)', contribution_df = '1')),
+             dmnorm = list(param = 'prec', contribution_R = 'coeff * asCol(value-mean) %*% asRow(value-mean)', contribution_df = '1')),
          posterior = 'dwish_chol(cholesky    = chol(prior_R + contribution_R),
                                  df          = prior_df + contribution_df,
                                  scale_param = 0)'),
 
     ## inverse wishart
     list(prior = 'dinvwish',
-         link = 'identity',
+         link = 'multiplicative',
          dependents = list(
-             dmnorm = list(param = 'cov', contribution_S = 'asCol(value-mean) %*% asRow(value-mean)', contribution_df = '1')),
+             dmnorm = list(param = 'cov', contribution_S = 'asCol(value-mean) %*% asRow(value-mean) / coeff', contribution_df = '1')),
          posterior = 'dinvwish_chol(cholesky    = chol(prior_S + contribution_S),
                                     df          = prior_df + contribution_df,
                                     scale_param = 1)')
@@ -566,10 +566,13 @@ conjugacyClass <- setRefClass(
             
             targetNdim <- getDimension(prior)
             targetCoeffNdim <- switch(as.character(targetNdim), `0`=0, `1`=2, `2`=2, stop())
+            targetCoeffNdimSave <- targetCoeffNdim 
             for(iDepCount in seq_along(dependentCounts)) {
                 distName <- names(dependentCounts)[iDepCount]
                 if(!is.null(dependents[[distName]]$link)) currentLink <- dependents[[distName]]$link else currentLink <- link
                 if(currentLink %in% c('multiplicative', 'linear', 'linear_plus_inprod') || (nimbleOptions()$allowDynamicIndexing && currentLink == 'identity' && doDependentScreen)) {
+                    if(currentLink == 'multiplicative')   ## There are no cases where we allow non-scalar 'coeff'.
+                        targetCoeffNdim <- 0
                     functionBody$addCode({
                         DEP_OFFSET_VAR2 <- array(0, dim = DECLARE_SIZE_OFFSET)                   ## the 2's here are *only* to prevent warnings about
                         DEP_COEFF_VAR2  <- array(0, dim = DECLARE_SIZE_COEFF)                    ## assigning into member variable names using
@@ -577,6 +580,7 @@ conjugacyClass <- setRefClass(
                             DEP_COEFF_VAR2      = as.name(paste0('dep_', distName, '_coeff')),   ## so it doesn't recognize the ref class field name
                             DECLARE_SIZE_OFFSET = makeDeclareSizeField(as.name(paste0('N_dep_', distName)), as.name(paste0('dep_', distName, '_nodeSizeMax')), as.name(paste0('dep_', distName, '_nodeSizeMax')), targetNdim),
                             DECLARE_SIZE_COEFF  = makeDeclareSizeField(as.name(paste0('N_dep_', distName)), as.name(paste0('dep_', distName, '_nodeSizeMax')), quote(d),                                          targetCoeffNdim)))
+                    targetCoeffNdim <- targetCoeffNdimSave
                 }
             }
 
@@ -729,11 +733,13 @@ conjugacyClass <- setRefClass(
             links <- rep(link, length(dependentCounts))
             for(iDepCount in seq_along(dependentCounts)) {
                 distName <- names(dependentCounts)[iDepCount]
-                if(!is.null(dependents[[distName]]$link)) links[iDepCount] <- dependents[[distName]]$link # clau: extra ) deleted.
+                if(!is.null(dependents[[distName]]$link)) links[iDepCount] <- dependents[[distName]]$link 
             }
             if(any(links %in% c('multiplicative', 'linear', 'linear_plus_inprod')) || (nimbleOptions()$allowDynamicIndexing && any(links == 'identity') && doDependentScreen)) {
                 targetNdim <- getDimension(prior)
                 targetCoeffNdim <- switch(as.character(targetNdim), `0`=0, `1`=2, `2`=2, stop())
+                if(all(links == 'multiplicative'))   ## There are no cases where we allow non-scalar 'coeff'.
+                    targetCoeffNdim <- 0
 
                 switch(as.character(targetNdim),
                        `0` = {
@@ -821,32 +827,33 @@ conjugacyClass <- setRefClass(
                                                 list(FORLOOPBODY = forLoopBody$getCode()))
                        },
                        `2` = {
+                           if(!all(links == 'multiplicative')) stop("Found non-multiplicative link for 2-d variable.")
+
                            functionBody$addCode({
-                               ## I <- model[[target]] * 0
-                               ## for(sizeIndex in 1:d)   { I[sizeIndex, sizeIndex] <- 1 }
-                               ## model[[target]] <<- I   ## initially, propogate through X = I
-                               I <- diag(d)
-                               model[[target]] <<- I   ## initially, propogate through X = I
+                               model[[target]] <<- diag(d)
                                calculate(model, calcNodesDeterm)
                            })
 
+                           ## Use _COEFF_VAR to store value; we need this for stoch indexing case
+                           ## where we determine that coeff = 0 because the potential dependency is not a dependency
+                           ## given current index values.
                            for(iDepCount in seq_along(dependentCounts)) {
                                distName <- names(dependentCounts)[iDepCount]
                                functionBody$addCode({
                                    for(iDep in 1:N_DEP) {
-                                       ##thisNodeSize <- DEP_NODESIZES[iDep]  ## not needed for targetDim=2 case ????
-                                       DEP_OFFSET_VAR[iDep, 1:d, 1:d] <<- model$getParam(DEP_NODENAMES[iDep], PARAM_NAME)  ## DEP_OFFSET_VAR = A+B(I) = A+B
+                                       DEP_COEFF_VAR[iDep] <<- model$getParam(DEP_NODENAMES[iDep], PARAM_NAME)[1, 1]   ## DEP_COEFF_VAR = (A+2B)-(A+B) = B
                                    }
                                },
                                                     list(N_DEP          = as.name(paste0('N_dep_', distName)),
-                                                         ##DEP_NODESIZES  = as.name(paste0('dep_', distName, '_nodeSizes')),  ## not needed for targetDim=2 case ????
-                                                         DEP_OFFSET_VAR = as.name(paste0('dep_', distName, '_offset')),
-                                                         DEP_NODENAMES  = as.name(paste0('dep_', distName,'_nodeNames')),
+                                                         DEP_COEFF_VAR  = as.name(paste0('dep_', distName, '_coeff')),
+                                                         DEP_NODENAMES  = as.name(paste0('dep_', distName, '_nodeNames')),
                                                          PARAM_NAME     = dependents[[distName]]$param))
                            }
 
                            functionBody$addCode({
-                               model[[target]] <<- I * 2   ## now, propogate through X = 2I
+                               ## Can't use zeros matrix as Cholesky fails; this is solely to determine if
+                               ## potential dependency is not a dependency of target (due to stochastic indexing).
+                               model[[target]] <<- 2*diag(d)  
                                calculate(model, calcNodesDeterm)
                            })
 
@@ -854,26 +861,13 @@ conjugacyClass <- setRefClass(
                                distName <- names(dependentCounts)[iDepCount]
                                functionBody$addCode({
                                    for(iDep in 1:N_DEP) {
-                                       ##thisNodeSize <- DEP_NODESIZES[iDep]  ## not needed for targetDim=2 case ????
-                                       DEP_COEFF_VAR[iDep, 1:d, 1:d] <<- model$getParam(DEP_NODENAMES[iDep], PARAM_NAME) - DEP_OFFSET_VAR[iDep, 1:d, 1:d]   ## DEP_COEFF_VAR = (A+2B)-(A+B) = B
+                                       DEP_COEFF_VAR[iDep] <<- model$getParam(DEP_NODENAMES[iDep], PARAM_NAME)[1, 1] - DEP_COEFF_VAR[iDep]
                                    }
                                },
                                                     list(N_DEP          = as.name(paste0('N_dep_', distName)),
-                                                         ##DEP_NODESIZES  = as.name(paste0('dep_', distName, '_nodeSizes')),  ## not needed for targetDim=2 case ????
                                                          DEP_COEFF_VAR  = as.name(paste0('dep_', distName, '_coeff')),
                                                          DEP_NODENAMES  = as.name(paste0('dep_', distName, '_nodeNames')),
-                                                         PARAM_NAME     = dependents[[distName]]$param,
-                                                         DEP_OFFSET_VAR = as.name(paste0('dep_', distName, '_offset'))))
-                               functionBody$addCode({
-                                   for(iDep in 1:N_DEP) {
-                                       ##thisNodeSize <- DEP_NODESIZES[iDep]  ## not needed for targetDim=2 case ????
-                                       DEP_OFFSET_VAR[iDep, 1:d, 1:d] <<- DEP_OFFSET_VAR[iDep, 1:d, 1:d] - DEP_COEFF_VAR[iDep, 1:d, 1:d]   ## now, DEP_OFFSET_VAR = (A+B)-(B) = A
-                                   }
-                               },
-                                                    list(N_DEP          = as.name(paste0('N_dep_', distName)),
-                                                         ##DEP_NODESIZES  = as.name(paste0('dep_', distName, '_nodeSizes')),  ## not needed for targetDim=2 case ????
-                                                         DEP_OFFSET_VAR = as.name(paste0('dep_', distName, '_offset')),
-                                                         DEP_COEFF_VAR  = as.name(paste0('dep_', distName, '_coeff'))))
+                                                         PARAM_NAME     = dependents[[distName]]$param))
                            }
 
                        },
@@ -884,6 +878,8 @@ conjugacyClass <- setRefClass(
 
             targetNdim <- getDimension(prior)
             targetCoeffNdim <- switch(as.character(targetNdim), `0`=0, `1`=2, `2`=2, stop())
+            if(all(links == 'multiplicative'))   ## There are no cases where we allow non-scalar 'coeff'.
+                targetCoeffNdim <- 0
             ## contribution terms have been moved to be setup function outputs,
             ## but we still need to *zero these variables out* before adding contribution terms into them
             for(contributionName in posteriorObject$neededContributionNames) {
@@ -928,7 +924,7 @@ conjugacyClass <- setRefClass(
                     if(!(contributionName %in% dependents[[distName]]$contributionNames))     next
                     contributionExpr <- eval(substitute(substitute(EXPR, subList), list(EXPR=dependents[[distName]]$contributionExprs[[contributionName]])))
                     if(nimbleOptions()$allowDynamicIndexing && doDependentScreen) { ## FIXME: would be nice to only have one if() here when we loop through multiple parameters
-                        if(targetNdim == 0)
+                        if(targetCoeffNdim == 0)
                             forLoopBody$addCode(if(COEFF_EXPR != 0) CONTRIB_NAME <<- CONTRIB_NAME + CONTRIB_EXPR,
                                                 list(COEFF_EXPR = subList$coeff, CONTRIB_NAME = as.name(contributionName), CONTRIB_EXPR = contributionExpr))
                         else forLoopBody$addCode(if(min(COEFF_EXPR) != 0 | max(COEFF_EXPR) != 0) CONTRIB_NAME <<- CONTRIB_NAME + CONTRIB_EXPR,
@@ -1149,12 +1145,26 @@ cc_linkCheck <- function(linearityCheck, link) {
     if(!(link %in% c('identity', 'multiplicative', 'linear', 'linear_plus_inprod', 'stick_breaking')))
         stop(paste0('unknown link: \'', link, '\''))
     if(is.null(linearityCheck))    return(FALSE)
-    offset <- linearityCheck$offset
-    scale  <- linearityCheck$scale
-    if(link == 'identity'       && offset == 0 && scale == 1)     return(TRUE)
-    if(link == 'multiplicative' && offset == 0)                   return(TRUE)
-    if(link == 'linear' || link == 'linear_plus_inprod')          return(TRUE)
+    offset      <- linearityCheck$offset
+    scale       <- linearityCheck$scale
+    if(link == 'identity'       && offset == 0 && scale == 1)                  return(TRUE)
+    ## We currently have no conjugacies where the scale can be a matrix, so check
+    ## that 'scale' is a scalar.
+    ## In particular we want to avoid that case when dealing with Wishart-related conjugacies.
+    if(link == 'multiplicative' && offset == 0 && cc_checkScalar(scale))       return(TRUE)
+    if(link == 'linear' || link == 'linear_plus_inprod')                       return(TRUE)
     return(FALSE)
+}
+
+cc_checkScalar <- function(expr) {
+    if(length(expr) == 1) return(TRUE)
+    if(expr[[1]] == ":") return(FALSE)
+    ## We don't know the output dims of all functions,
+    ## as there can be user-defined functions that produce non-scalar output from scalar inputs,
+    ## so only say it could be scalar (based on input args) in specific known cases we enumerate.
+    if(deparse(expr[[1]]) %in% c('(','[','*','+','-','/','exp','log','^','pow','sqrt')) {
+        return(all(sapply(expr[2:length(expr)], cc_checkScalar)))
+    } else return(FALSE)
 }
 
 ## checks the parameter expressions in the stochastic distribution of depNode

--- a/packages/nimble/inst/tests/mcmcTestLog_Correct.Rout
+++ b/packages/nimble/inst/tests/mcmcTestLog_Correct.Rout
@@ -2993,4 +2993,4 @@ sd      0.2099087   0.1621212   0.5846388
 ===== Finished MCMC test for conjugate Wishart, scaled. =====
 ===== Starting MCMC test for conjugate MVN with ragged dependencies. ========== Starting MCMC test for binary sampler. ========== Starting MCMC test for binary sampler handles out of bounds. ========== Starting MCMC test for RW_multinomial sampler. ========== Starting MCMC test RW_multinomial sampler on distribution of size 2. ========== Starting MCMC test if RW_dirichlet sampler consistent with conjugate multinomial sampler. ========== Starting MCMC test RW_dirichlet sampler more complicated. =====thin = 1: alpha, theta, p1, p2
 ===== Starting MCMC test dcar_normal sampling. ========== Starting test dcar_proper density evaluations. ========== Starting MCMC test dcar_proper sampling. =====thin = 1: tau, gamma, x
-===== Starting MCMC test of logProb variable monitoring ===== 
+===== Starting MCMC test of logProb variable monitoring =====

--- a/packages/nimble/inst/tests/mcmcTestLog_Correct.Rout
+++ b/packages/nimble/inst/tests/mcmcTestLog_Correct.Rout
@@ -2979,6 +2979,18 @@ sd      0.6607385   0.5216073    1.807713
 2.5%   -3.3270012   0.4077250    3.190403
 97.5%  -0.7673714   2.3647559   10.362390
 ===== Finished MCMC test for conjugate Wishart. =====
+===== Starting MCMC test for conjugate Wishart, scaled. =====
+      Omega[1, 1] Omega[2, 1] Omega[3, 1] Omega[1, 2] Omega[2, 2] Omega[3, 2]
+mean   0.35321660 -0.19514399  -0.6501530 -0.19514399   0.2376399   0.4332497
+sd     0.09429255  0.06497621   0.2099087  0.06497621   0.0677129   0.1621212
+2.5%   0.19117100 -0.34069029  -1.0797370 -0.34069029   0.1271453   0.1596554
+97.5%  0.55407639 -0.08167258  -0.2912551 -0.08167258   0.3907858   0.7630663
+      Omega[1, 3] Omega[2, 3] Omega[3, 3]
+mean   -0.6501530   0.4332497   2.0405923
+sd      0.2099087   0.1621212   0.5846388
+2.5%   -1.0797370   0.1596554   1.0318190
+97.5%  -0.2912551   0.7630663   3.3513359
+===== Finished MCMC test for conjugate Wishart, scaled. =====
 ===== Starting MCMC test for conjugate MVN with ragged dependencies. ========== Starting MCMC test for binary sampler. ========== Starting MCMC test for binary sampler handles out of bounds. ========== Starting MCMC test for RW_multinomial sampler. ========== Starting MCMC test RW_multinomial sampler on distribution of size 2. ========== Starting MCMC test if RW_dirichlet sampler consistent with conjugate multinomial sampler. ========== Starting MCMC test RW_dirichlet sampler more complicated. =====thin = 1: alpha, theta, p1, p2
 ===== Starting MCMC test dcar_normal sampling. ========== Starting test dcar_proper density evaluations. ========== Starting MCMC test dcar_proper sampling. =====thin = 1: tau, gamma, x
-===== Starting MCMC test of logProb variable monitoring =====
+===== Starting MCMC test of logProb variable monitoring ===== 

--- a/packages/nimble/inst/tests/test-bnp.R
+++ b/packages/nimble/inst/tests/test-bnp.R
@@ -3651,7 +3651,7 @@ data = list(y = matrix(rnorm(16), 4, 4))
 constants = list(mu0 = rep(0,4), Cov0 = diag(10, 4), Sigma0 = diag(1, 4))
 
 testBUGSmodel(example = 'test13', dir = "",
-              model = model, data = data, inits = inits, constants = constants,
+              model = model, data = c(data, constants), inits = inits, 
               useInits = TRUE)
 
 ## testing misspecification of dimension in a model

--- a/packages/nimble/inst/tests/test-bnp.R
+++ b/packages/nimble/inst/tests/test-bnp.R
@@ -1283,7 +1283,9 @@ test_that("testing multivariate normal mixture models with CRP", {
     lambda ~ dgamma(1, 1)
   })
   n <- 100
-  Consts <- list(n = n, S0 = diag(1, 2), mu0=c(0,0), R0 = diag(1, 2))
+  ## 2020-03-09: Modified prior because now with conjugate sampling, tight prior and
+  ## conjugate updates for Sigma cause slow burnin.
+  Consts <- list(n = n, S0 = diag(100, 2), mu0=c(0,0), R0 = diag(1, 2))
   Sigma <- array(0, c(2,2,n))
   for(i in 1:n)
     Sigma[, , i] <- matrix(c(1, 0, 0, 1), 2, 2)
@@ -1326,11 +1328,13 @@ test_that("testing multivariate normal mixture models with CRP", {
   
   
   ## 4-dimensional normal kernel with unknown mean and unknown variance
+
+  ## Chris changed S0 prior so not so informative and set df=6 instead of 4 (the latter implies no mean)
   code <- nimbleCode({
     xi[1:n] ~ dCRP(alpha, n)
     for(i in 1:n){
       mu[i, 1:4] ~ dmnorm(mu0[1:4], cov = S0[1:4, 1:4])
-      Sigma[1:4, 1:4, i] ~ dinvwish(S = R0[1:4, 1:4], df = 4)
+      Sigma[1:4, 1:4, i] ~ dinvwish(S = R0[1:4, 1:4], df = 6)
       SigmaAux[1:4, 1:4, i] <- Sigma[1:4, 1:4, xi[i]] / lambda  
       y[i, 1:4] ~ dmnorm(mu[xi[i], 1:4],  cov = SigmaAux[1:4, 1:4, i] )
     }
@@ -1338,7 +1342,7 @@ test_that("testing multivariate normal mixture models with CRP", {
     lambda ~ dgamma(1, 1)
   })
   n <- 100
-  Consts <- list(n = n, S0 = diag(1, 4), mu0=c(0,0,0,0), R0 = diag(1, 4))
+  Consts <- list(n = n, S0 = diag(100, 4), mu0=c(0,0,0,0), R0 = diag(1, 4))
   Sigma <- array(0, c(4,4,n))
   for(i in 1:n)
     Sigma[, , i] <- diag(1, 4)

--- a/packages/nimble/inst/tests/test-bnp.R
+++ b/packages/nimble/inst/tests/test-bnp.R
@@ -3655,7 +3655,7 @@ data = list(y = matrix(rnorm(16), 4, 4))
 constants = list(mu0 = rep(0,4), Cov0 = diag(10, 4), Sigma0 = diag(1, 4))
 
 testBUGSmodel(example = 'test13', dir = "",
-              model = model, data = data, inits = c(inits, constants), 
+              model = model, data = data, inits = c(inits, constants),
               useInits = TRUE)
 
 ## testing misspecification of dimension in a model

--- a/packages/nimble/inst/tests/test-bnp.R
+++ b/packages/nimble/inst/tests/test-bnp.R
@@ -3651,7 +3651,7 @@ data = list(y = matrix(rnorm(16), 4, 4))
 constants = list(mu0 = rep(0,4), Cov0 = diag(10, 4), Sigma0 = diag(1, 4))
 
 testBUGSmodel(example = 'test13', dir = "",
-              model = model, data = c(data, constants), inits = inits, 
+              model = model, data = data, inits = c(inits, constants), 
               useInits = TRUE)
 
 ## testing misspecification of dimension in a model

--- a/packages/nimble/inst/tests/test-mcmc.R
+++ b/packages/nimble/inst/tests/test-mcmc.R
@@ -764,6 +764,55 @@ test_that('conjugate Wishart setup', {
     
 })
 
+test_that('conjugate Wishart setup with scaling', {
+    set.seed(0)
+    
+    trueCor <- matrix(c(1, .3, .7, .3, 1, -0.2, .7, -0.2, 1), 3)
+    covs <- c(3, 2, .5)
+    tau <- 4
+    
+    trueCov = diag(sqrt(covs)) %*% trueCor %*% diag(sqrt(covs))
+    Omega = solve(trueCov) / tau
+    
+    n = 20
+    R = diag(rep(1,3))
+    mu = 1:3
+    Y = mu + t(chol(trueCov)) %*% matrix(rnorm(3*n), ncol = n)
+    M = 3
+    data <- list(Y = t(Y), n = n, M = M, mu = mu, R = R)
+    
+    code <- nimbleCode( {
+        for(i in 1:n) {
+            Y[i, 1:M] ~ dmnorm(mu[1:M], tmp[1:M,1:M])
+        }
+        tmp[1:M,1:M] <- tau * Omega[1:M,1:M]
+        Omega[1:M,1:M] ~ dwish(R[1:M,1:M], 4);
+    })
+    
+    newDf = 4 + n
+    newR = R + tcrossprod(Y - mu)*tau
+    OmegaTrueMean = newDf * solve(newR)
+    
+    wishRV <- array(0, c(M, M, 10000))
+    for(i in 1:10000) {
+        z <- t(chol(solve(newR))) %*% matrix(rnorm(3*newDf), ncol = newDf)
+        wishRV[ , , i] <- tcrossprod(z)
+    }
+    OmegaSimTrueSDs = apply(wishRV, c(1,2), sd)
+
+    m <- nimbleModel(code, data = data[1],constants=data[2:5],inits = list(Omega = OmegaTrueMean, tau = tau))
+    conf <- configureMCMC(m)
+    expect_equal(conf$getSamplers()[[1]]$name, "conjugate_dwish_dmnorm", info = "conjugate dmnorm-dwish with scaling not detected")
+    
+    test_mcmc(model = code, name = 'conjugate Wishart, scaled', data = data, seed = 0, numItsC = 1000, inits = list(Omega = OmegaTrueMean, tau = tau),
+              results = list(mean = list(Omega = OmegaTrueMean ),
+                             sd = list(Omega = OmegaSimTrueSDs)),
+              resultsTolerance = list(mean = list(Omega = matrix(.05, M,M)),
+                                      sd = list(Omega = matrix(0.06, M, M))), avoidNestedTest = TRUE)
+                                        # issue with Chol in R MCMC - probably same issue as in jaw-linear
+    
+})
+
 test_that('using RW_wishart sampler on non-conjugate Wishart node', {
     set.seed(0)
     trueCor <- matrix(c(1, .3, .7, .3, 1, -0.2, .7, -0.2, 1), 3)
@@ -867,6 +916,55 @@ test_that('using RW_wishart sampler on inverse-Wishart distribution', {
     expect_true(all(round(as.numeric(RWSD - conjSD), 9) == c(0.022803503, -0.010107015, 0.012342044, -0.010107015, 0.006191412, -0.000091101, 0.012342044, -0.000091101, 0.001340032)))
 })
 
+test_that('detect conjugacy when scaling Wishart, inverse Wishart cases', {
+    code <- nimbleCode({
+        mycov[1:p, 1:p]  <- lambda * Sigma[1:p,1:p] / eta
+        y[1:p] ~ dmnorm(z[1:p], cov = mycov[1:p, 1:p])
+        Sigma[1:p,1:p] ~ dinvwish(S[1:p,1:p], nu)
+    })
+    m  <- nimbleModel(code, constants = list(p = 3))
+    expect_identical(length(m$checkConjugacy('Sigma')), 1L, 'inverse-Wishart case')
+
+    code <- nimbleCode({
+        mycov[1:p, 1:p]  <- lambda * Sigma[1:p,1:p] / eta
+        y[1:p] ~ dmnorm(z[1:p], prec = mycov[1:p, 1:p])
+        Sigma[1:p,1:p] ~ dwish(S[1:p,1:p], nu)
+    })
+    m  <- nimbleModel(code, constants = list(p = 3))
+    expect_identical(length(m$checkConjugacy('Sigma')), 1L, 'Wishart case')
+
+    code <- nimbleCode({
+        mycov[1:p, 1:p]  <- lambda * Sigma[1:p,1:p] / eta
+        y[1:p] ~ dmnorm(z[1:p], cov = mycov[1:p, 1:p])
+        Sigma[1:p,1:p] ~ dwish(S[1:p,1:p], nu)
+    })
+    m  <- nimbleModel(code, constants = list(p = 3))
+    expect_identical(length(m$checkConjugacy('Sigma')), 0L, 'inverse-Wishart not-conj case')
+
+    code <- nimbleCode({
+        mycov[1:p, 1:p]  <- lambda * Sigma[1:p,1:p] / eta
+        y[1:p] ~ dmnorm(z[1:p], prec = mycov[1:p, 1:p])
+        Sigma[1:p,1:p] ~ dinvwish(S[1:p,1:p], nu)
+    })
+    m  <- nimbleModel(code, constants = list(p = 3))
+    expect_identical(length(m$checkConjugacy('Sigma')), 0L, 'Wishart not-conj case')
+
+    code <- nimbleCode({
+        mycov[1:p, 1:p]  <- lambda[1:p,1:p] * Sigma[1:p,1:p]
+        y[1:p] ~ dmnorm(z[1:p], cov = mycov[1:p, 1:p])
+        Sigma[1:p,1:p] ~ dinvwish(S[1:p,1:p], nu)
+    })
+    m  <- nimbleModel(code, constants = list(p = 3))
+    expect_identical(length(m$checkConjugacy('Sigma')), 0L, 'Wishart case')
+
+    code <- nimbleCode({
+        mycov[1:p, 1:p]  <- lambda[1:p,1:p] %*% Sigma[1:p,1:p]
+        y[1:p] ~ dmnorm(z[1:p], cov = mycov[1:p, 1:p])
+        Sigma[1:p,1:p] ~ dinvwish(S[1:p,1:p], nu)
+    })
+    m  <- nimbleModel(code, constants = list(p = 3))
+    expect_identical(length(m$checkConjugacy('Sigma')), 0L, 'Wishart case')
+})
 
 
 ## testing conjugate MVN updating with ragged dependencies;
@@ -938,9 +1036,8 @@ test_that('conjugate MVN with ragged dependencies', {
     
 
     expect_true(all(abs(pmean - obsmean) / pmean < 0.01), info = 'ragged dmnorm conjugate posterior mean')
-    expect_true(all(abs(pprec - obsprec) / pprec < 0.005), info = 'ragged dmnorm conjugate posterior precision')
-    
-    })
+    expect_true(all(abs(pprec - obsprec) / pprec < 0.005), info = 'ragged dmnorm conjugate posterior precision')    
+})
     
 ## testing binary sampler
 test_that('binary sampler setup', {
@@ -1757,6 +1854,29 @@ test_that('checkConjugacy corner case when linear scale is identically zero', {
                           scale = 0))
 })
 
+test_that('cc_checkScalar operates correctly', {
+    expect_true(cc_checkScalar(quote(lambda)))
+    expect_true(cc_checkScalar(quote(lambda*eta)))
+    expect_true(cc_checkScalar(quote(exp(lambda))))
+    expect_true(cc_checkScalar(quote(5+exp(lambda[2]))))
+
+    expect_false(cc_checkScalar(quote(exp(lambda[2:3]))))
+    expect_false(cc_checkScalar(quote(lambda[1:2,1:2])))
+    expect_false(cc_checkScalar(quote(lambda[1:2,1:2]/eta)))
+    expect_false(cc_checkScalar(quote(eta*(theta*lambda[1:2,1:2]))))
+    expect_false(cc_checkScalar(quote(lambda[1:2,1:2,1:5])))
+
+    expect_true(cc_checkScalar(quote(lambda[xi[i]])))
+    expect_true(cc_checkScalar(quote(lambda[xi[i],xi[j]])))
+    expect_false(cc_checkScalar(quote(lambda[xi[i]:3])))
+    expect_false(cc_checkScalar(quote(lambda[xi[i]:3,2])))
+
+    ## Ideally this case would evaluate to TRUE, but we would
+    ## have to handle knowing output dims of user-defined fxns.
+    expect_false(cc_checkScalar(quote(sum(lambda[1:5]))))
+    expect_false(cc_checkScalar(quote(foo(lambda))))
+
+})
 
 sink(NULL)
 


### PR DESCRIPTION
FTO - DNM.

@danielturek would be great if you could look over this. 

This adds a multiplicative link capability, in particular for wish, invwish distributions;
note that this causes additional computations because computation of
scale involves matrix manipulations.

We need this functionality for some conjugacies in BNP.

Next steps will be to modify our conjugacy link processing to
identify if offset and scale need to be calculated in cases
where they are possible.