### PR TITLE
fix checkDistributionFunctions to respect default nDim=0 when extracting first argument

### DIFF
--- a/packages/nimble/R/distributions_processInputList.R
+++ b/packages/nimble/R/distributions_processInputList.R
@@ -277,7 +277,9 @@ checkDistributionFunctions <- function(distributionInput, userEnv) {
                     " is not available. NIMBLE is generating a placeholder function that will invoke an error if an algorithm needs to simulate from this distribution. Some algorithms (such as random-walk Metropolis MCMC sampling) will work without the ability to simulate from the distribution.  If simulation is needed, provide a nimbleFunction (with no setup code) to do it.\n"))
         rargInfo <- environment(get(densityName, pos = userEnv))$nfMethodRCobject$argInfo
         returnType <- deparse(unlist(rargInfo[[1]]))
-        returnDim <- rargInfo[[1]][[2]]
+        returnDim <- 0
+        if(length(rargInfo[[1]]) > 1)
+            returnDim <- rargInfo[[1]][[2]]
         rargInfo <- rargInfo[-length(rargInfo)]  # remove 'log' argument
         rargInfo[[1]] <- quote(integer(0))
         names(rargInfo)[1] <- 'n'


### PR DESCRIPTION
checkDistributionFunctions determines if an "r" function exists to match the "d" function.  If not, it constructs a dummy function with return type set from the type of the first argument to the "d" function.  This PR updates how that works so that if the number of dimensions is missing from that type declaration, the expected default of 0 will be used.