### PR TITLE
updated autoBlock for wishart and dirichlet nodes

### DIFF
--- a/packages/nimble/R/MCMC_autoBlock.R
+++ b/packages/nimble/R/MCMC_autoBlock.R
@@ -65,8 +65,8 @@ autoBlock <- function(Rmodel,
         }
     } else cat('\nAuto-Blocking converged on all scalar (univariate) sampling\n')
     cat('\n')
-## create a new MCMC conf with the autoBlock groupings:
-    conf <- configureMCMC(Rmodel, nodes = NULL)
+    ## create a new MCMC conf with the autoBlock groupings:
+    conf <- configureMCMC(Rmodel, nodes = NULL, print = FALSE)
     for(nodeGroup in lastAutoGrouping) addSamplerToConf(Rmodel, conf, nodeGroup)
     retList <- list(summary=dfmin, autoGroups=nonTrivialGroups, conf=conf)
     return(invisible(retList))
@@ -97,9 +97,11 @@ autoBlockModel <- setRefClass(
             ##nimCopy(from = Rmodel_orig, to = Rmodel, logProb = TRUE)
             ##for(var in ls(Rmodel_orig$isDataEnv)) Rmodel$isDataEnv[[var]] <<- Rmodel_orig$isDataEnv[[var]]  ## copies data flags to the new model
             scalarNodeVector <<- Rmodel$getNodeNames(stochOnly=TRUE, includeData=FALSE, returnScalarComponents=TRUE)
-            discreteInd <- sapply(scalarNodeVector, function(n) Rmodel$isDiscrete(n), USE.NAMES=FALSE)
-            scalarNodeVectorCont <<- scalarNodeVector[!discreteInd]   ## making work with discrete nodes
-            scalarNodeVectorDisc <<- scalarNodeVector[ discreteInd]   ## making work with discrete nodes
+            discreteInd <- as.logical(sapply(scalarNodeVector, function(n) Rmodel$isDiscrete(n), USE.NAMES=FALSE))
+            constrainedInd <- sapply(scalarNodeVector, function(n) Rmodel$getDistribution(n) %in% c('dwish', 'dinvwish', 'ddirch'), USE.NAMES=FALSE)
+            wholeNodeInd <- discreteInd | constrainedInd
+            scalarNodeVectorCont <<- scalarNodeVector[!wholeNodeInd]   ## making work with discrete nodes
+            scalarNodeVectorDisc <<- scalarNodeVector[ wholeNodeInd]   ## making work with discrete nodes, wishart inverse-wishart, and dirichlet
             if(length(scalarNodeVectorCont) == 0) stop('autoBlocking only works with one or more continuous-valued model nodes')   ## making work with discrete nodes
             nodeGroupScalars <<- c(unique(lapply(scalarNodeVectorDisc, Rmodel$expandNodeNames)), scalarNodeVectorCont)   ## making work with discrete nodes, and also with dmulti distributions
             ##nodeGroupAllBlocked <<- list(scalarNodeVector)   ## making work with discrete nodes
@@ -109,7 +111,7 @@ autoBlockModel <- setRefClass(
         },
         ## here is where the initial MCMC conf is created, for re-use -- for new version
         createInitialMCMCconf = function(runList) {
-            initialMCMCconf <<- configureMCMC(Rmodel)
+            initialMCMCconf <<- configureMCMC(Rmodel, print = FALSE)
             nInitialSamplers <- length(initialMCMCconf$samplerConfs)
             initialMCMCconf$addSampler(target = scalarNodeVectorCont[1], type = 'slice',    print=FALSE)  ## add one slice sampler
             initialMCMCconf$addSampler(target = scalarNodeVectorCont[1], type = 'RW',       print=FALSE)  ## add one RW sampler
@@ -390,7 +392,7 @@ autoBlockClass <- setRefClass(
         createConfFromGroups = function(groups) {
             groups <- sortGroups(groups)
             ##conf <- configureMCMC(Rmodel, nodes=NULL, monitors=character(0)) ## original version
-            conf <- configureMCMC(oldConf = abModel$initialMCMCconf)  ## new version
+            conf <- configureMCMC(oldConf = abModel$initialMCMCconf, print = FALSE)  ## new version
             conf$setSamplers()  ## new version -- removes all the samplers from initalMCMCconf
             for(nodeGroup in groups) addSamplerToConf(abModel$Rmodel, conf, nodeGroup)
             return(conf)

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -1346,7 +1346,7 @@ configureMCMC <- function(model, nodes, control = list(),
 # This is function which builds a new MCMCconf from an old MCMCconf
 # This is required to be able to a new C-based MCMC without recompiling
 makeNewConfFromOldConf <- function(oldMCMCconf){
-    newMCMCconf <- configureMCMC(oldMCMCconf$model, nodes = NULL)
+    newMCMCconf <- configureMCMC(oldMCMCconf$model, nodes = NULL, print = FALSE)
     newMCMCconf$monitors <- oldMCMCconf$monitors
     newMCMCconf$monitors2 <- oldMCMCconf$monitors2
     newMCMCconf$thin <- oldMCMCconf$thin


### PR DESCRIPTION
`autoBlock` routine will only group Wishart, Inverse-Wishart, and Dirichlet nodes with themselves.  It won't split them up, which would violate the constraints of those nodes.

Opening PR to trigger testing, then I'll merge this.