### PR TITLE
default MCMC configuration will not monitor top-level data nodes

### DIFF
--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -797,7 +797,7 @@ Details: See the initialize() function
                 if(getNimbleOption('MCMCmonitorAllSampledNodes')) {
                     vars <- model$getNodeNames(stochOnly = TRUE, includeData = FALSE)
                 } else {
-                    vars <- model$getNodeNames(stochOnly = TRUE, topOnly = TRUE)
+                    vars <- model$getNodeNames(stochOnly = TRUE, includeData = FALSE, topOnly = TRUE)
                 }
             } else {
                 vars <- unlist(vars)


### PR DESCRIPTION
Opening PR to begin testing.