### PR TITLE
fix  UNPROTECT count for nimbleRcall when returnType is void()

### DIFF
--- a/packages/nimble/R/externalCalls.R
+++ b/packages/nimble/R/externalCalls.R
@@ -221,7 +221,7 @@ nimbleRcall <- function(prototype, returnType, Rfun, where = getNimbleFunctionEn
                             substitute(returnType(RT), list(RT = returnType))
                             )
     } else {
-        resultLines <- list(quote(UNPROTECT(1)),
+        resultLines <- list(substitute(nimVerbatim(UNPROTECT(2 + NARGS)), list(NARGS = length(args))),
                             substitute(returnType(RT), list(RT = returnType))
                             )
     }


### PR DESCRIPTION
This fixes a bug in the generated C++ that results in run-time warnings from R that the PROTECT and UNPROTECT calls are not matched.  It only occurred for returnType void.  It is a single-line fix.