### PR TITLE
reduce memory needs of compiled getParam

### DIFF
--- a/packages/nimble/R/nimbleFunction_Rexecution.R
+++ b/packages/nimble/R/nimbleFunction_Rexecution.R
@@ -166,34 +166,44 @@ makeParamInfo <- function(model, nodes, param) {
     ## updating to allow nodes to be a vector. getParam only works for a scalar but in a case like nodes[i] the param info is set up for the entire vector.
 
     ## this allows for(i in seq_along(nodes)) a <- a + model$getParam(nodes[i], 'mean') through compilation even if some instances have nodes empty and so won't be called.
-    if(length(nodes) == 0) return(structure(c(list(paramID = integer()), type = NA, nDim = NA), class = 'getParam_info'))
+  if(length(nodes) == 0) return(structure(c(list(paramID = integer()), type = NA, nDim = NA), class = 'getParam_info'))
+  
+  if(length(param) != 1) stop(paste0(paste0('Problem with param(s) ', paste0(param, collapse = ','), ' while setting up getParam for node ', nodes,
+                                            '\nOnly one parameter is allowed.')))
+  
+  nodeIDs <- model$expandNodeNames(nodes, returnType = 'ids')
+  nodeDeclIDs <- model$modelDef$maps$graphID_2_declID[nodeIDs]
+  declID2nodeIDs <- split(nodeIDs, nodeDeclIDs)
+  numDeclIDs <- length(declID2nodeIDs)
+  paramIDs <- integer(numDeclIDs)
+  types <- character(numDeclIDs)
+  nDims <- integer(numDeclIDs)
+  for(i in seq_along(declID2nodeIDs)) {
+    nodeIDsFromOneDecl <- declID2nodeIDs[[i]]
+    firstNodeName <- model$modelDef$maps$graphID_2_nodeName[nodeIDsFromOneDecl[1]]
+    dist <- model$getDistribution(firstNodeName)
+    distInfo <- getDistributionInfo(dist)
+    paramIDs[i] <- distInfo$paramIDs[param]
+    if(is.na(paramIDs[i]))
+      stop(paste0("getParam: parameter '", param, "' not found in distribution ",
+                  dist, "."))
+    types[i] <- distInfo$types[[param]]$type
+    nDims[i] <- distInfo$types[[param]]$nDim
+  }
+  if(length(unique(types)) != 1 || length(unique(nDims)) != 1)
+    stop('cannot have an indexed vector of nodes used in getParam if they have different types or dimensions for the same parameter.')
 
-    distNames <- model$getDistribution(nodes)
-
-    if(length(param) != 1) stop(paste0(paste0('Problem with param(s) ', paste0(param, collapse = ','), ' while setting up getParam for node ', nodes,
-                                              '\nOnly one parameter is allowed.')))
-
-    distInfos <- lapply(distNames, getDistributionInfo)
-    paramIDvec <- unlist(lapply(distInfos, function(x) x$paramIDs[param]))
-
-    ## this check needed because getParamID no longer called
-    if(any(is.na(paramIDvec)))
-        stop(paste0("getParam: parameter '", param, "' not found in distribution ",
-                    paste0(unique(distNames), collapse = ','), "."))
+  ## on C++ side, we always work with double
+  if(types[1] %in% c('integer', 'logical')) types[1] <- 'double'
+  paramIDvec <- rep(1L, length(nodeIDs))
+  sourceIDs <- split(seq_along(nodeIDs), nodeDeclIDs)
+  for(i in seq_along(declID2nodeIDs)) { #unsplit() would be another approach to this step.
+    paramIDvec[sourceIDs[[i]] ] <- paramIDs[i]
+  }
     
-    typeVec <- unlist(lapply(distInfos, function(x) x$types[[param]]$type))
-    nDimVec <- unlist(lapply(distInfos, function(x) x$types[[param]]$nDim))
-    
-   ## paramIDvec <- sapply(distNames, getParamID, param)
-   ## typeVec <- sapply(distNames, getType, param)
-   ## nDimVec <- sapply(distNames, getDimension, param)
-    if(length(unique(typeVec)) != 1 || length(unique(nDimVec)) != 1) stop('cannot have an indexed vector of nodes used in getParam if they have different types or dimensions for the same parameter.')
-
-    ## on C++ side, we always work with double
-    if(typeVec[1] %in% c('integer', 'logical')) typeVec[1] <- 'double'
-    ans <- c(list(paramID = paramIDvec), type = typeVec[1], nDim = nDimVec[1])
-    class(ans) <- 'getParam_info'
-    ans
+  ans <- c(list(paramID = paramIDvec), type = types[1], nDim = nDims[1])
+  class(ans) <- 'getParam_info'
+  ans
 }
 
 defaultParamInfo <- function() {

--- a/packages/nimble/R/nimbleFunction_keywordProcessing.R
+++ b/packages/nimble/R/nimbleFunction_keywordProcessing.R
@@ -1069,6 +1069,7 @@ paramInfo_SetupTemplate <- setupCodeTemplateClass(
     codeTemplate = quote({
         PARAMINFONAME <- makeParamInfo(MODEL, NODE, PARAM)
         PARAMIDNAME <- PARAMINFONAME$paramID
+        rm(PARAMINFONAME)
        }),
     makeCodeSubList = function(resultName, argList){
         list(PARAMINFONAME = as.name(resultName),
@@ -1085,6 +1086,7 @@ boundInfo_SetupTemplate <- setupCodeTemplateClass(
     codeTemplate = quote({
         BOUNDINFONAME <- makeBoundInfo(MODEL, NODE, BOUND)
         BOUNDIDNAME <- BOUNDINFONAME$boundID
+        rm(BOUNDINFONAME)
        }),
     makeCodeSubList = function(resultName, argList){
         list(BOUNDINFONAME = as.name(resultName),

--- a/packages/nimble/R/nimbleFunction_keywordProcessing.R
+++ b/packages/nimble/R/nimbleFunction_keywordProcessing.R
@@ -1069,7 +1069,7 @@ paramInfo_SetupTemplate <- setupCodeTemplateClass(
     codeTemplate = quote({
         PARAMINFONAME <- makeParamInfo(MODEL, NODE, PARAM)
         PARAMIDNAME <- PARAMINFONAME$paramID
-        rm(PARAMINFONAME)
+        PARAMINFONAME$paramID <- NULL
        }),
     makeCodeSubList = function(resultName, argList){
         list(PARAMINFONAME = as.name(resultName),
@@ -1086,7 +1086,7 @@ boundInfo_SetupTemplate <- setupCodeTemplateClass(
     codeTemplate = quote({
         BOUNDINFONAME <- makeBoundInfo(MODEL, NODE, BOUND)
         BOUNDIDNAME <- BOUNDINFONAME$boundID
-        rm(BOUNDINFONAME)
+        BOUNDINFONAME$boundID <- NULL
        }),
     makeCodeSubList = function(resultName, argList){
         list(BOUNDINFONAME = as.name(resultName),

--- a/packages/nimble/inst/include/nimble/accessorClasses.h
+++ b/packages/nimble/inst/include/nimble/accessorClasses.h
@@ -97,6 +97,7 @@ inline double getParam_0D_double(int paramID, const NodeInstruction &useInfo, in
 }
 template<typename paramIDtype>
 inline double getParam_0D_double(const paramIDtype &paramID, const NodeInstruction &useInfo, int iNodeFunction) {
+  iNodeFunction = paramID[0] == -1 ? 1 : iNodeFunction;
 return(useInfo.nodeFunPtr->getParam_0D_double_block(paramID[iNodeFunction], useInfo.operand));
 }
 
@@ -105,6 +106,7 @@ NimArr<1, double> getParam_1D_double(int paramID, const NodeInstruction &useInfo
 
 template<class paramIDtype>
 NimArr<1, double> getParam_1D_double(const paramIDtype &paramID, const NodeInstruction &useInfo, int iNodeFunction) {
+  iNodeFunction = paramID[0] == -1 ? 1 : iNodeFunction;
   return(useInfo.nodeFunPtr->getParam_1D_double_block(paramID[iNodeFunction], useInfo.operand));
 }
 
@@ -112,6 +114,7 @@ NimArr<1, double> getParam_1D_double(const paramIDtype &paramID, const NodeInstr
 NimArr<2, double> getParam_2D_double(int paramID, const NodeInstruction &useInfo, int iNodeFunction = 0);
 template<class paramIDtype>
 NimArr<2, double> getParam_2D_double(const paramIDtype &paramID, const NodeInstruction &useInfo, int iNodeFunction) {
+  iNodeFunction = paramID[0] == -1 ? 1 : iNodeFunction;
   return(useInfo.nodeFunPtr->getParam_2D_double_block(paramID[iNodeFunction], useInfo.operand));
 }
 


### PR DESCRIPTION
This is ready to merge. It has three changes to the `getParam` implementation.

1. Modify keyword template for `getParam` (and getBound, since it is similar) to rm() an intermediate object that may be large, after it is no longer needed.
2. Modify `makeParamInfo` to operate by declaration, which should typically be faster for large vectors of nodes.
3.  In the case that the `paramID` for all nodes is the same, which will be common (for example when all nodes are from the same distribution), return a sparse representation encoded by `c(-1, paramID)` rather than the equivalent of `rep(paramID, <number of nodes>)`
