### PR TITLE
fix bug in dwish(S,df) and add test of dwish

### DIFF
--- a/packages/nimble/inst/CppCode/dists.cpp
+++ b/packages/nimble/inst/CppCode/dists.cpp
@@ -86,8 +86,10 @@ double dwish_chol(double* x, double* chol, double df, int p, double scale_param,
     xChol = x;
   else {
     xChol = new double[p*p];
-    for(i = 0; i < p*p; i++) 
-      xChol[i] = x[i];
+    // only need upper triangle for dpotrf chol calculation
+    for(j = 0; j < p; j++)
+      for(i = 0; i <= j; i++) 
+        xChol[j*p+i] = x[j*p+i];
   }
   F77_CALL(dpotrf)(&uplo, &p, xChol, &p, &info);
   for(i = 0; i < p*p; i += p + 1) 
@@ -100,6 +102,10 @@ double dwish_chol(double* x, double* chol, double df, int p, double scale_param,
   double tmp_dens = 0.0;
   if(scale_param) {
     // chol(x) %*% inverse(chol)
+    // need lower triangle of xChol to have zeros as dtrsm assumes it is full matrix
+    for(j = 0; j < p-1; j++)
+      for(i = j+1; i < p; i++)
+        xChol[j*p+i] = 0.0;
     F77_CALL(dtrsm)(&sideR, &uplo, &transN, &diag, &p, &p, &alpha, 
                     chol, &p, xChol, &p);
     // trace of crossproduct of result is sum of squares of elements

--- a/packages/nimble/inst/tests/test-distributions.R
+++ b/packages/nimble/inst/tests/test-distributions.R
@@ -284,7 +284,7 @@ test_that("Test that rinvwish_chol, dinvwish_chol, dwish_chol, and rwish_chol gi
     set.seed(1)
     df <- 20.3
     d <- 5
-    C <- crossprod(matrix(rnorm(d^2, 3), d))
+    C <- crossprod(matrix(rnorm(d^2, 0), d))
     pm <- C / (df - d - 1)
     
     n <- 100
@@ -303,11 +303,11 @@ test_that("Test that rinvwish_chol, dinvwish_chol, dwish_chol, and rwish_chol gi
     for(i in 1:n)
         draws3[,,i] <- rinvwish_chol(1, chol(solve(C)), df, scale_param = FALSE)
     pmean3 <- apply(draws3, c(1,2), mean)
-    expect_equal(max(abs(pmean1 - pm)), 0, tol = 0.06,
+    expect_equal(max(abs(pmean1 - pm)), 0, tol = 0.03,
                  info = "mean of inverse of rwish draws differs from truth")
-    expect_equal(max(abs(pmean2 - pm)), 0, tol = 0.06,
+    expect_equal(max(abs(pmean2 - pm)), 0, tol = 0.03,
                  info = "mean of rinvwish with scale draws differs from truth")
-    expect_equal(max(abs(pmean3 - pm)), 0, tol = 0.06,
+    expect_equal(max(abs(pmean3 - pm)), 0, tol = 0.03,
                  info = "mean of rinvwish with rate differs from truth")
 
     # draws1 is from rwish not rinvwish, but for comparing density values it doesn't matter their origin.

--- a/packages/nimble/inst/tests/test-distributions.R
+++ b/packages/nimble/inst/tests/test-distributions.R
@@ -280,10 +280,10 @@ test_that("dgamma-dinvgamma conjugacy with dependency using rate", {
 
 # dinvwish_chol
 
-test_that("Test that rinvwish_chol, dinvwish_chol, and rwish_chol give correct results", {
+test_that("Test that rinvwish_chol, dinvwish_chol, dwish_chol, and rwish_chol give correct results", {
     set.seed(1)
-    df <- 20
-    d <- 3
+    df <- 20.3
+    d <- 5
     C <- crossprod(matrix(rnorm(d^2, 3), d))
     pm <- C / (df - d - 1)
     
@@ -310,8 +310,9 @@ test_that("Test that rinvwish_chol, dinvwish_chol, and rwish_chol give correct r
     expect_equal(max(abs(pmean3 - pm)), 0, tol = 0.06,
                  info = "mean of rinvwish with rate differs from truth")
 
-    dens1 <- dinvwish_chol(draws1[,,1], chol(C), df, log = TRUE)
-    dens2 <- dinvwish_chol(draws1[,,1], chol(solve(C)), df, log = TRUE, scale_param = FALSE)
+    # draws1 is from rwish not rinvwish, but for comparing density values it doesn't matter their origin.
+    dens1 <- dinvwish_chol(draws1[,,1], chol(C), df, scale_param = TRUE, log = TRUE)
+    dens2 <- dinvwish_chol(draws1[,,1], chol(solve(C)), df, scale_param = FALSE, log = TRUE)
     
     dfun <- function(W, S, nu) {
         k <- nrow(W)
@@ -325,6 +326,23 @@ test_that("Test that rinvwish_chol, dinvwish_chol, and rwish_chol give correct r
                  info = "dinvwish with scale differs from truth")
     expect_equal(dens2-dens3, 0, tol = 0.000001,
                  info = "dinvwish with rate differs from truth")
+
+    dens1 <- dwish_chol(draws1[,,1], chol(C), df, scale_param = TRUE, log = TRUE)
+    dens2 <- dwish_chol(draws1[,,1], chol(solve(C)), df, scale_param = FALSE, log = TRUE)
+
+    dfun <- function(W, S, nu) {
+        k <- nrow(W)
+        U = chol(S)
+        return(-(log(2)*nu*k/2+(k*(k-1)/4)*log(pi) +sum(lgamma((nu + 1 - 1:k)/2))) - nu*sum(log(diag(U))) +
+               (nu-k-1)*sum(log(diag(chol(W)))) -0.5*sum(diag(solve(S, W))))               
+    }
+
+    dens3 <-  dfun(draws1[,,1], C, df)
+    expect_equal(dens1-dens3, 0, tol = 0.000001,
+                 info = "dinvwish with scale differs from truth")
+    expect_equal(dens2-dens3, 0, tol = 0.000001,
+                 info = "dinvwish with rate differs from truth")
+
 })
                                                                         
 set.seed(1)


### PR DESCRIPTION
WIP: This fixes a bug that the lower triangle of `xChol` in the call to `dtrsm` in `dwish_chol` was being assumed to be zero but the full matrix is used by `dtrsm`. This affects only the non-default `S` parameterization.  Also note that it would not affect conjugate MCMC sampling of the Wishart-distributed matrix.

Also adds a test of `dwish_chol`. 

Will need to cherry-pick this into `ADoak` to continue Wishart derivs testing there. 