### PR TITLE
make nodeName2GraphIDs respect unique when nodeFunctionID = FALSE

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -2895,7 +2895,10 @@ modelDefClass$methods(nodeName2GraphIDs = function(nodeName, nodeFunctionID = TR
         else
             output2 <- unlist(lapply(parseEvalNumericManyList(nodeName, env = maps$vars2GraphID_functions_and_RHSonly, ignoreNotFound = ignoreNotFound), unique))
     } else {
-        output2 <- unique(parseEvalNumericMany(nodeName, env = maps$vars2ID_elements, ignoreNotFound = ignoreNotFound))
+        if(unique)
+            output2 <- unique(parseEvalNumericMany(nodeName, env = maps$vars2ID_elements))
+        else
+            output2 <- parseEvalNumericMany(nodeName, env = maps$vars2ID_elements)
     }
     output <- output2
     return(output[!is.na(output)])


### PR DESCRIPTION
Do not merge.

This is another minor fix that is useful for AD but not AD-specific, so I am running tests via this PR.