### PR TITLE
fix dmvt args order so default unnamed params work

### DIFF
--- a/packages/nimble/R/distributions_inputList.R
+++ b/packages/nimble/R/distributions_inputList.R
@@ -216,7 +216,7 @@ distributionsInputList <- list(
                    discrete = TRUE,
                    alias    = 'dmultinom'),
     
-    dmvt  = list(BUGSdist = 'dmvt(mu, prec, scale, cholesky, df, prec_param)',
+    dmvt  = list(BUGSdist = 'dmvt(mu, prec, df, scale, cholesky, prec_param)',
                    Rdist    = c('dmvt_chol(mu, cholesky = chol(prec), df = df, prec_param = 1)',
                                 'dmvt_chol(mu, cholesky = chol(scale), df = df, prec_param = 0)',
                                 'dmvt_chol(mu, cholesky, df = df, prec_param)'),

--- a/packages/nimble/inst/tests/test-models.R
+++ b/packages/nimble/inst/tests/test-models.R
@@ -750,6 +750,17 @@ test_that("warning when RHS only nodes used as dynamic indexes", {
 
 })
 
+test_that("dmvt usage", {
+    code <- nimbleCode({
+    	 y1[1:n] ~ dmvt(z[1:n], pr[1:n, 1:n], 4)
+	 y2[1:n] ~ dmvt(z[1:n], scale = pr[1:n, 1:n], df = 4)
+    })
+    n <- 3
+    m <- nimbleModel(code, inits = list(pr = diag(rep(2,n))), constants = list(n = n))	 
+    expect_identical(m$getParam('y1[1:3]', 'prec'), diag(rep(2, n)))
+    expect_equal(m$getParam('y2[1:3]', 'prec'), diag(rep(0.5, n)))
+})
+
 sink(NULL)
 
 if(FALSE){  ## no warnings being generated in goldFile anymore (perhaps a change in testthat versions?)


### PR DESCRIPTION
Fixes issue #1014.  Adds basic testing of model with `dmvt`.