### PR TITLE
check whether the GID_map in modelValues is fully deprecated

### DIFF
--- a/packages/nimble/R/cppInterfaces_modelValues.R
+++ b/packages/nimble/R/cppInterfaces_modelValues.R
@@ -57,6 +57,7 @@ CmodelValues <- setRefClass(
             return(varNames[!grepl('logProb_', varNames)])
         },
         expandNodeNames = function (nodeNames, returnType = "names", flatIndices = TRUE)  {
+            stop("Call to CmodelValues$expandNodeNames")
             return(GID_map$expandNodeNames(nodeNames = nodeNames, returnType = returnType, 
                                            flatIndices = flatIndices))
         },

--- a/packages/nimble/R/cppInterfaces_modelValues.R
+++ b/packages/nimble/R/cppInterfaces_modelValues.R
@@ -57,9 +57,9 @@ CmodelValues <- setRefClass(
             return(varNames[!grepl('logProb_', varNames)])
         },
         expandNodeNames = function (nodeNames, returnType = "names", flatIndices = TRUE)  {
-            stop("Call to CmodelValues$expandNodeNames")
-            return(GID_map$expandNodeNames(nodeNames = nodeNames, returnType = returnType, 
-                                           flatIndices = flatIndices))
+            stop('There was a call to expandNodeNames for a compiled modelValues object.\n  This is deprecated and should not have occurred.\n  Please contact nimble developers at the nimble-users google group or at nimble.stats@gmail.com to let them know this happened.  \n Thank you.')
+##            return(GID_map$expandNodeNames(nodeNames = nodeNames, returnType = returnType, 
+##                                           flatIndices = flatIndices))
         },
         finalizeInternal = function() {
             finalize()

--- a/packages/nimble/R/types_modelValues.R
+++ b/packages/nimble/R/types_modelValues.R
@@ -97,7 +97,7 @@ modelValuesBaseClass <- setRefClass('modelValuesBaseClass',
                                                     }
                                                 assign(vN, rep(list(array( data = as.numeric(NA), dim = sizes[[vN]])), nrow), inherits = TRUE)
                                             }
-                                            GID_map <<- nimble:::makeMV_GID_Map(.self)
+                                           ## GID_map <<- nimble:::makeMV_GID_Map(.self)
                                         },
                                         getSymbolTable = function() {
                                             return(symTab)
@@ -108,7 +108,8 @@ modelValuesBaseClass <- setRefClass('modelValuesBaseClass',
                                             return(varNames[!grepl('logProb_', varNames)])
                                         },
                                         expandNodeNames = function(nodeNames, returnType = "names", flatIndices = TRUE) 
-                                            {
+                                        {
+                                            stop('Call to modelValuesBaseClass$expandNodeNames')
                                                 return(GID_map$expandNodeNames(nodeNames = nodeNames, returnType = returnType, flatIndices = flatIndices))
                                             }                          
                                     )

--- a/packages/nimble/R/types_modelValues.R
+++ b/packages/nimble/R/types_modelValues.R
@@ -109,9 +109,9 @@ modelValuesBaseClass <- setRefClass('modelValuesBaseClass',
                                         },
                                         expandNodeNames = function(nodeNames, returnType = "names", flatIndices = TRUE) 
                                         {
-                                            stop('Call to modelValuesBaseClass$expandNodeNames')
-                                                return(GID_map$expandNodeNames(nodeNames = nodeNames, returnType = returnType, flatIndices = flatIndices))
-                                            }                          
+                                            stop('There was a call to expandNodeNames for a modelValues object.\n  This is deprecated and should not have occurred.\n  Please contact nimble developers at the nimble-users google group or at nimble.stats@gmail.com to let them know this happened.  \n Thank you.')
+                                            ##return(GID_map$expandNodeNames(nodeNames = nodeNames, returnType = returnType, flatIndices = flatIndices))
+                                        }                          
                                     )
                                     )
 
@@ -294,58 +294,4 @@ pointAt <- function(model, to, vars = NULL, toVars = NULL, index = NA,  logProb 
       model[[makeNameName(vars[i])]] <- toVars[i]
       model[[makeRowName(vars[i])]] <- as.integer(index)
   }
-}
-
-
-
-makeMV_GID_Map <- function(mv){
-	sizeList = mv$sizes
-    varNames = sort(mv$varNames, FALSE)
-    nodeNames = NA
-    nodeIndex = 0
-    nodeNames2GID_maps <- new.env()
-    all.names <- character()
-    all.flatIndexNames <- character()
-    for (i in seq_along(varNames)) {
-        baseName = varNames[i]
-        dims = sizeList[[baseName]]
-        if (length(dims) == 1 & dims[1] == 1) {
-            nodeNames[nodeIndex + 1] = baseName
-            nodeIndex <- nodeIndex + 1
-            nodeNames2GID_maps[[baseName]] <- nodeIndex
-            all.names <- c(all.names, baseName)
-            all.flatIndexNames <- c(all.flatIndexNames, baseName)
-        }
-        else {
-            mins <- rep(1, length(dims))
-            indexStuff <- paste(mins, dims, sep = ":", collapse = ", ")
-            compactNodeNames <- paste0(baseName, "[", indexStuff, 
-                "]")
-            expandedNodeNames <- nl_expandNodeIndex(compactNodeNames)
-            nodeNames[nodeIndex + 1:length(expandedNodeNames)] <- expandedNodeNames
-            
-            nodeNames2GID_maps[[baseName]] <- array(dim = dims)
-            nodeNames2GID_maps[[baseName]][1:length(expandedNodeNames)] <- nodeIndex + 1:length(expandedNodeNames)
-            nodeIndex = nodeIndex + length(expandedNodeNames)
-        	all.names <- c(all.names, expandedNodeNames)
-        	all.flatIndexNames <- c(all.flatIndexNames, paste0(baseName, '[', 1:length(expandedNodeNames) ,']' ))
-        }
-    	
-    }
-    GID_Map <- new.env()
-    GID_Map[['nodeNames2GID_maps']] <- nodeNames2GID_maps
-    GID_Map[['graphID_2_nodeName']] <- all.names
-    GID_Map[['graphID_2_flatIndexNames']] <- all.flatIndexNames
-    GID_Map[['expandNodeNames']] <- function(nodeNames, returnType = 'names', flatIndices = TRUE){
-    	if(length(nodeNames) == 0)	return(NULL)
-    	gIDs <- unlist(sapply(nodeNames, parseEvalNumeric, env = GID_Map$nodeNames2GID_maps, USE.NAMES = FALSE) )
-    	gIDs <- gIDs[!is.na(gIDs)]
-    	if(returnType == 'names'){
-    		if(flatIndices == TRUE)
-    			return(GID_Map$graphID_2_flatIndexNames[gIDs])
-    		return(GID_Map$graphID_2_nodeName[gIDs])
-    		}
-    	return(gIDs)
-    }
-    return(GID_Map)
 }


### PR DESCRIPTION
Do not merge.

This PR turns off the `GID_map` internal to modelValues class definitions to see if it is fully deprecated.