### PR TITLE
Reduce copying

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -2905,38 +2905,15 @@ modelDefClass$methods(nodeName2GraphIDs = function(nodeName, nodeFunctionID = TR
 })
 
 ## next two functions work for properly formed nodeNames.
-modelDefClass$methods(nodeName2LogProbName = function(nodeName){ ## used in 3 places: MCMC_build, valuesAccessorVector, and cppInterfaces_models
-    ## This function needs better processing.
+modelDefClass$methods(nodeName2LogProbName = function(nodeName){
     if(length(nodeName) == 0)
-        return(NULL)
-    
-##     ## 1. so this needs to first get to a nodeFunctionID
-##     graphIDs <- unique(unlist(sapply(nodeName, parseEvalNumeric, env = maps$vars2GraphID_functions, USE.NAMES = FALSE)))
-##     ## 2. get node function names
-##     fullNodeNames <- maps$graphID_2_nodeName[graphIDs]
-##     ## 3 get corresponding logProbNames
-##     output <- unique(unlist(sapply(fullNodeNames, parseEvalCharacter, env = maps$vars2LogProbName, USE.NAMES = FALSE)))
+        return(character())
 
-##     ##graphIDs2 <- unique(parseEvalNumericMany(nodeName, env = maps$vars2GraphID_functions))
-##     ##fullNodeNames2 <- maps$graphID_2_nodeName[graphIDs2]
-##     ##output2 <- unique(parseEvalCharacterMany(fullNodeNames2, env = maps$vars2LogProbName))
-## ##    output2 <- unique(parseEvalCharacterMany(nodeName, env = maps$vars2LogProbName)) ## output2
-## ##    if(!identical(output[!is.na(output)], as.character(output2[!is.na(output2)]))) browser()
-##     output <- output[!is.na(output)]
+    graphIDs <- unique(parseEvalNumericMany(nodeName, env =  maps$vars2GraphID_functions))
+    output <- maps$graphID_2_logProbName[graphIDs]
+    output <- output[!is.na(output)]
 
-    graphIDs2 <- unique(parseEvalNumericMany(nodeName, env =  maps$vars2GraphID_functions))
-    output2 <- maps$graphID_2_logProbName[graphIDs2]
-    output2 <- output2[!is.na(output2)]
-
-    ## fullNodeNames2 <- maps$graphID_2_nodeName[graphIDs [maps$types[graphIDs] == "stoch"] ]
-    ## output2 <- gsub(":[0123456789]+", "", fullNodeNames2 )
-    ## output2 <- output2[!is.na(output2)]
-    ## output2 <- paste0("logProb_", output2)
-##    if(!identical(output, output2)) browser()
-
-##    output <- output2
-    return(output2)
-##    return(output[!is.na(output)])
+    return(output)
 })
 
 ## modelDefClass$methods(nodeName2LogProbID = function(nodeName){ ## used only in cppInterfaces_models

--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -102,7 +102,7 @@ sampler_categorical <- nimbleFunction(
     setup = function(model, mvSaved, target, control) {
         ## node list generation
         targetAsScalar <- model$expandNodeNames(target, returnScalarComponents = TRUE)
-        calcNodes  <- model$getDependencies(target)
+        calcNodes <- model$getDependencies(target)
         calcNodesNoSelf <- model$getDependencies(target, self = FALSE)
         isStochCalcNodesNoSelf <- model$isStoch(calcNodesNoSelf)   ## should be made faster
         calcNodesNoSelfDeterm <- calcNodesNoSelf[!isStochCalcNodesNoSelf]
@@ -741,7 +741,7 @@ sampler_AF_slice <- nimbleFunction(
         eps <- 1e-15
         ## node list generation
         targetAsScalar <- model$expandNodeNames(target, returnScalarComponents = TRUE)
-        calcNodes      <- model$getDependencies(target)
+        calcNodes <- model$getDependencies(target)
         finalTargetIndex <- max(match(model$expandNodeNames(target), calcNodes))
         if(!is.integer(finalTargetIndex) |
            length(finalTargetIndex) != 1 |
@@ -1633,7 +1633,7 @@ sampler_RW_dirichlet <- nimbleFunction(
         ## node list generation
         targetAsScalar <- model$expandNodeNames(target, returnScalarComponents = TRUE)
         calcNodes <- model$getDependencies(target)
-        depNodes  <- model$getDependencies(target, self = FALSE)
+        calcNodesNoSelf <- model$getDependencies(target, self = FALSE)
         isStochCalcNodesNoSelf <- model$isStoch(calcNodesNoSelf)   ## should be made faster
         calcNodesNoSelfDeterm <- calcNodesNoSelf[!isStochCalcNodesNoSelf]
         calcNodesNoSelfStoch <- calcNodesNoSelf[isStochCalcNodesNoSelf]
@@ -1661,7 +1661,7 @@ sampler_RW_dirichlet <- nimbleFunction(
                 thetaVecProp <- thetaVec
                 thetaVecProp[i] <- propValue
                 values(model, target) <<- thetaVecProp / sum(thetaVecProp)
-                logMHR <- alphaVec[i]*propLogScale + currentValue - propValue + calculateDiff(model, depNodes)
+                logMHR <- alphaVec[i]*propLogScale + currentValue - propValue + calculateDiff(model, calcNodesNoSelf)
                 jump <- decide(logMHR)
             } else jump <- FALSE
             if(adaptive & jump)   timesAcceptedVec[i] <<- timesAcceptedVec[i] + 1

--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -72,7 +72,7 @@ sampler_binary <- nimbleFunction(
             otherLogProb <- otherLogProbPrior + calculate(model, calcNodesNoSelf)
         }
         acceptanceProb <- 1/(exp(currentLogProb - otherLogProb) + 1)
-        jump <- (!is.nan(acceptanceProb)) && (runif(1,0,1) < acceptanceProb)
+        jump <- (!is.nan(acceptanceProb)) & (runif(1,0,1) < acceptanceProb)
         if(jump) {
             nimCopy(from = model, to = mvSaved, row = 1, nodes = target, logProb = TRUE)
             nimCopy(from = model, to = mvSaved, row = 1, nodes = calcNodesNoSelfDeterm, logProb = FALSE)
@@ -345,8 +345,8 @@ sampler_RW_block <- nimbleFunction(
         calcNodesDepStage <- calcNodes[-(1:finalTargetIndex)]
         ##calcNodesNoSelf <- model$getDependencies(target, self = FALSE)
         isStochCalcNodesDepStage <- model$isStoch(calcNodesDepStage)   ## should be made faster
-        calcNodesDepStageDeterm <- calcNodesNoSelf[!isStochCalcNodesDepStage]
-        calcNodesDepStageStoch <- calcNodesNoSelf[isStochCalcNodesDepStage]
+        calcNodesDepStageDeterm <- calcNodesDepStage[!isStochCalcNodesDepStage]
+        calcNodesDepStageStoch <- calcNodesDepStage[isStochCalcNodesDepStage]
         ## numeric value generation
         scaleOriginal <- scale
         timesRan      <- 0
@@ -751,8 +751,8 @@ sampler_AF_slice <- nimbleFunction(
         calcNodesDepStage <- calcNodes[-(1:finalTargetIndex)]
         ##calcNodesNoSelf <- model$getDependencies(target, self = FALSE)
         isStochCalcNodesDepStage <- model$isStoch(calcNodesDepStage)   ## should be made faster
-        calcNodesDepStageDeterm <- calcNodesNoSelf[!isStochCalcNodesDepStage]
-        calcNodesDepStageStoch <- calcNodesNoSelf[isStochCalcNodesDepStage]
+        calcNodesDepStageDeterm <- calcNodesDepStage[!isStochCalcNodesDepStage]
+        calcNodesDepStageStoch <- calcNodesDepStage[isStochCalcNodesDepStage]
         ## numeric value generation
         d                  <- length(targetAsScalar)
         discrete           <- sapply(targetAsScalar, function(x) model$isDiscrete(x))

--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -159,9 +159,9 @@ sampler_RW <- nimbleFunction(
         targetAsScalar <- model$expandNodeNames(target, returnScalarComponents = TRUE)
         calcNodes <- model$getDependencies(target)
         calcNodesNoSelf <- model$getDependencies(target, self = FALSE)
-        boolStoch <- model$isStoch(calcNodesNoSelf) ## This should be made faster
-        calcNodesDeterm <- calcNodes[!boolStoch]
-        calcNodesStoch <- calcNodes[boolStoch]
+        boolStochNoSelf <- model$isStoch(calcNodesNoSelf) ## This should be made faster
+        calcNodesDetermNoSelf <- calcNodesNoSelf[!boolStochNoSelf]
+        calcNodesStochNoSelf <- calcNodesNoSelf[boolStochNoSelf]
         ## numeric value generation
         scaleOriginal <- scale
         timesRan      <- 0
@@ -212,11 +212,13 @@ sampler_RW <- nimbleFunction(
             logMHR <- logMHR + calculateDiff(model, calcNodesNoSelf) + propLogScale
             jump <- decide(logMHR)
             if(jump) {
-                nimCopy(from = model, to = mvSaved, row = 1, nodes = calcNodesDeterm, logProb = FALSE)
-                nimCopy(from = model, to = mvSaved, row = 1, nodes = calcNodesStoch, logProbOnly = TRUE)
+                nimCopy(from = model, to = mvSaved, row = 1, nodes = target, logProb = TRUE)
+                nimCopy(from = model, to = mvSaved, row = 1, nodes = calcNodesDetermNoSelf, logProb = FALSE)
+                nimCopy(from = model, to = mvSaved, row = 1, nodes = calcNodesStochNoSelf, logProbOnly = TRUE)
             } else  {
-                nimCopy(from = mvSaved, to = model, row = 1, nodes = calcNodesDeterm, logProb = FALSE)
-                nimCopy(from = mvSaved, to = model, row = 1, nodes = calcNodesStoch, logProbOnly = TRUE)
+                nimCopy(from = mvSaved, to = model, row = 1, nodes = target, logProb = FALSE)
+                nimCopy(from = mvSaved, to = model, row = 1, nodes = calcNodesDetermNoSelf, logProb = FALSE)
+                nimCopy(from = mvSaved, to = model, row = 1, nodes = calcNodesStochNoSelf, logProbOnly = TRUE)
             }
         }
         if(adaptive)     adaptiveProcedure(jump)

--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -216,7 +216,7 @@ sampler_RW <- nimbleFunction(
                 nimCopy(from = model, to = mvSaved, row = 1, nodes = calcNodesDetermNoSelf, logProb = FALSE)
                 nimCopy(from = model, to = mvSaved, row = 1, nodes = calcNodesStochNoSelf, logProbOnly = TRUE)
             } else  {
-                nimCopy(from = mvSaved, to = model, row = 1, nodes = target, logProb = FALSE)
+                nimCopy(from = mvSaved, to = model, row = 1, nodes = target, logProb = TRUE)
                 nimCopy(from = mvSaved, to = model, row = 1, nodes = calcNodesDetermNoSelf, logProb = FALSE)
                 nimCopy(from = mvSaved, to = model, row = 1, nodes = calcNodesStochNoSelf, logProbOnly = TRUE)
             }

--- a/packages/nimble/R/MCMC_utils.R
+++ b/packages/nimble/R/MCMC_utils.R
@@ -49,12 +49,24 @@ decide <- function(logMetropolisRatio) {
 #' -- Return a logical value, indicating whether the proposal was accepted
 decideAndJump <- nimbleFunction(
     name = 'decideAndJump',
-    setup = function(model, mvSaved, calcNodes) { },
+    setup = function(model, mvSaved, target, calcNodes) {
+        calcNodesNoSelf <- model$getDependencies(target, self = FALSE)
+        isStochCalcNodesNoSelf <- model$isStoch(calcNodesNoSelf)   ## should be made faster
+        calcNodesNoSelfDeterm <- calcNodesNoSelf[!isStochCalcNodesNoSelf]
+        calcNodesNoSelfStoch <- calcNodesNoSelf[isStochCalcNodesNoSelf]
+    },
     run = function(modelLP1 = double(), modelLP0 = double(), propLP1 = double(), propLP0 = double()) {
         logMHR <- modelLP1 - modelLP0 - propLP1 + propLP0
         jump <- decide(logMHR)
-        if(jump) { nimCopy(from = model,   to = mvSaved, row = 1, nodes = calcNodes, logProb = TRUE)
-        } else   { nimCopy(from = mvSaved, to = model,   row = 1, nodes = calcNodes, logProb = TRUE) }
+        if(jump) {
+            nimCopy(from = model, to = mvSaved, row = 1, nodes = target, logProb = TRUE)
+            nimCopy(from = model, to = mvSaved, row = 1, nodes = calcNodesNoSelfDeterm, logProb = FALSE)
+            nimCopy(from = model, to = mvSaved, row = 1, nodes = calcNodesNoSelfStoch, logProbOnly = TRUE)
+        } else {
+            nimCopy(from = mvSaved, to = model, row = 1, nodes = target, logProb = TRUE)
+            nimCopy(from = mvSaved, to = model, row = 1, nodes = calcNodesNoSelfDeterm, logProb = FALSE)
+            nimCopy(from = mvSaved, to = model, row = 1, nodes = calcNodesNoSelfStoch, logProbOnly = TRUE)
+        }
         returnType(logical())
         return(jump)
     }

--- a/packages/nimble/R/nimbleFunction_Rexecution.R
+++ b/packages/nimble/R/nimbleFunction_Rexecution.R
@@ -730,14 +730,14 @@ values <- function(model, nodes, accessorIndex){
 #' 
 #' cCopy$run() ## execute the copy with the compiled function
 #' }
-nimCopy <- function(from, to, nodes = NULL, nodesTo = NULL, row = NA, rowTo = NA, logProb = FALSE){
+nimCopy <- function(from, to, nodes = NULL, nodesTo = NULL, row = NA, rowTo = NA, logProb = FALSE, logProbOnly = FALSE){
     if(is.null(nodes) )
         nodes = from$getVarNames(includeLogProb = logProb) ## allNodeNames(from)
     if( inherits(from, "modelBaseClass") ){
-        accessFrom = modelVariableAccessorVector(from, nodes, logProb = logProb)
+        accessFrom = modelVariableAccessorVector(from, nodes, logProb = logProb, logProbOnly = logProbOnly)
     } else
         if(inherits(from, "modelValuesBaseClass") || inherits(from, "CmodelValues")) {
-            accessFrom = modelValuesAccessorVector(from, nodes, logProb = logProb)
+            accessFrom = modelValuesAccessorVector(from, nodes, logProb = logProb, logProbOnly = logProbOnly)
             if(is.na(row))
                 stop("Error: need to supply 'row' for a modelValues copy")
             ##accessFrom$setRow(row) ## NEW ACCESSORS
@@ -746,15 +746,15 @@ nimCopy <- function(from, to, nodes = NULL, nodesTo = NULL, row = NA, rowTo = NA
 
     if( inherits(to, "modelBaseClass") ){
         if(is.null(nodesTo) ) 
-            accessTo = modelVariableAccessorVector(to, nodes, logProb = logProb)
+            accessTo = modelVariableAccessorVector(to, nodes, logProb = logProb, logProbOnly = logProbOnly)
         else
-            accessTo = modelVariableAccessorVector(to, nodesTo, logProb = logProb)
+            accessTo = modelVariableAccessorVector(to, nodesTo, logProb = logProb, logProbOnly = logProbOnly)
     } else
         if(inherits(to, "modelValuesBaseClass") || inherits(to, "CmodelValues")) {
             if(is.null(nodesTo) ) 
-                accessTo = modelValuesAccessorVector(to, nodes, logProb = logProb)
+                accessTo = modelValuesAccessorVector(to, nodes, logProb = logProb, logProbOnly = logProbOnly)
             else
-                accessTo = modelValuesAccessorVector(to, nodesTo, logProb = logProb)
+                accessTo = modelValuesAccessorVector(to, nodesTo, logProb = logProb, logProbOnly = logProbOnly)
             if(is.na(rowTo))
                 rowTo = row
             ##accessTo$setRow(rowTo) ## NEW ACCESSORS

--- a/packages/nimble/R/nimbleFunction_keywordProcessing.R
+++ b/packages/nimble/R/nimbleFunction_keywordProcessing.R
@@ -132,7 +132,7 @@ values_keywordInfo <- keywordInfoClass(
       if(isCodeArgBlank(code, 'model'))
       	stop('model argument missing from values call, with no accessor argument supplied')
       
-      accessArgList <- list(model = code$model, nodes = code$nodes, logProb = FALSE)
+      accessArgList <- list(model = code$model, nodes = code$nodes, logProb = FALSE, logProbOnly = FALSE)
 
       useAccessorVectorByIndex <- FALSE
       if(hasBracket(accessArgList$nodes)) { 
@@ -467,13 +467,13 @@ nimCopy_keywordInfo <- keywordInfoClass(
 				
 		if(from_ArgList$class == 'symbolModel'){
                     isMVfrom <- 0 
-                    accessFrom_ArgList <- list(model = code$from, nodes = from_ArgList$nodes, logProb = code$logProb)
+                    accessFrom_ArgList <- list(model = code$from, nodes = from_ArgList$nodes, logProb = code$logProb, logProbOnly = code$logProbOnly)
                     accessFrom_name <- modelVariableAccessorVector_setupCodeTemplate$makeName(accessFrom_ArgList)
                     addNecessarySetupCode(accessFrom_name, accessFrom_ArgList, modelVariableAccessorVector_setupCodeTemplate, nfProc)
 		}
 		else if(from_ArgList$class == 'symbolModelValues'){
                     isMVfrom <- 1
-                    accessFrom_ArgList <- list(modelValues = code$from, nodes = from_ArgList$nodes, logProb = code$logProb, row = from_ArgList$row)
+                    accessFrom_ArgList <- list(modelValues = code$from, nodes = from_ArgList$nodes, logProb = code$logProb, logProbOnly = code$logProbOnly, row = from_ArgList$row)
                     accessFrom_name <- modelValuesAccessorVector_setupCodeTemplate$makeName(accessFrom_ArgList)
                     addNecessarySetupCode(accessFrom_name, accessFrom_ArgList, modelValuesAccessorVector_setupCodeTemplate, nfProc)
 		}
@@ -484,13 +484,13 @@ nimCopy_keywordInfo <- keywordInfoClass(
         
 		if(to_ArgList$class == 'symbolModel'){
                     isMVto <- 0
-                    accessTo_ArgList <- list(model = code$to, nodes = to_ArgList$nodes, logProb = code$logProb)
+                    accessTo_ArgList <- list(model = code$to, nodes = to_ArgList$nodes, logProb = code$logProb, logProbOnly = code$logProbOnly)
                     accessTo_name <- modelVariableAccessorVector_setupCodeTemplate$makeName(accessTo_ArgList)
                     addNecessarySetupCode(accessTo_name, accessTo_ArgList, modelVariableAccessorVector_setupCodeTemplate, nfProc)
 		}
 		else if(to_ArgList$class == 'symbolModelValues'){
                     isMVto <- 1
-                    accessTo_ArgList <- list(modelValues = code$to, nodes = to_ArgList$nodes, logProb = code$logProb, row = to_ArgList$row)
+                    accessTo_ArgList <- list(modelValues = code$to, nodes = to_ArgList$nodes, logProb = code$logProb, logProbOnly = code$logProbOnly, row = to_ArgList$row)
                     accessTo_name <- modelValuesAccessorVector_setupCodeTemplate$makeName(accessTo_ArgList)
                     addNecessarySetupCode(accessTo_name, accessTo_ArgList, modelValuesAccessorVector_setupCodeTemplate, nfProc)
 		}
@@ -840,7 +840,7 @@ matchFunctions[['calculate']] <- calculate
 matchFunctions[['calculateDiff']] <- calculateDiff
 matchFunctions[['simulate']] <- simulate
 matchFunctions[['getLogProb']] <- getLogProb
-matchFunctions[['nimCopy']] <- function(from, to, nodes, nodesTo, row, rowTo, logProb = FALSE){}
+matchFunctions[['nimCopy']] <- function(from, to, nodes, nodesTo, row, rowTo, logProb = FALSE, logProbOnly = FALSE){}
 matchFunctions[['double']] <- function(nDim, dim, default, ...){}
 matchFunctions[['int']] <- function(nDim, dim, default, ...){}
 matchFunctions[['nimOptim']] <- nimOptim
@@ -1014,13 +1014,14 @@ length_char_SetupTemplate <- setupCodeTemplateClass(
 
 modelVariableAccessorVector_setupCodeTemplate <- setupCodeTemplateClass(
 	#Note to programmer: required fields of argList are model, nodes and logProb
-    makeName = function(argList) {Rname2CppName(paste(deparse(argList$model), deparse(argList$nodes), 'access_logProb', deparse(argList$logProb), sep = '_'))},
-    codeTemplate = quote( ACCESSNAME <- nimble:::modelVariableAccessorVector(MODEL, NODES, logProb = LOGPROB) ),
+    makeName = function(argList) {Rname2CppName(paste(deparse(argList$model), deparse(argList$nodes), 'access_logProb', deparse(argList$logProb),'LPO', deparse(argList$logProbOnly), sep = '_'))},
+    codeTemplate = quote( ACCESSNAME <- nimble:::modelVariableAccessorVector(MODEL, NODES, logProb = LOGPROB, logProbOnly = LOGPROBONLY) ),
     makeCodeSubList = function(resultName, argList) {
         list(ACCESSNAME = as.name(resultName),
              MODEL = argList$model,
              NODES = argList$nodes,
-             LOGPROB = argList$logProb)
+             LOGPROB = argList$logProb,
+             LOGPROBONLY = argList$logProbOnly)
     })
 
 copierVector_setupCodeTemplate <- setupCodeTemplateClass(
@@ -1038,13 +1039,14 @@ copierVector_setupCodeTemplate <- setupCodeTemplateClass(
 modelValuesAccessorVector_setupCodeTemplate <- setupCodeTemplateClass(
 	#Note to programmer: required fields of argList are model, nodes and logProb
 
-    makeName = function(argList) {Rname2CppName(paste(deparse(argList$model), deparse(argList$nodes), 'access_logProb', deparse(argList$logProb), deparse(argList$row), sep = '_'))},
-    codeTemplate = quote( ACCESSNAME <- nimble:::modelValuesAccessorVector(MODEL, NODES, logProb = LOGPROB) ),
+    makeName = function(argList) {Rname2CppName(paste(deparse(argList$model), deparse(argList$nodes), 'access_logProb', deparse(argList$logProb), 'LPO', deparse(argList$logProbOnly), deparse(argList$row), sep = '_'))},
+    codeTemplate = quote( ACCESSNAME <- nimble:::modelValuesAccessorVector(MODEL, NODES, logProb = LOGPROB, logProbOnly = LOGPROBONLY) ),
 	makeCodeSubList = function(resultName, argList) {
         list(ACCESSNAME = as.name(resultName),
              MODEL = argList$model,
              NODES = argList$nodes,
-             LOGPROB = argList$logProb)
+             LOGPROB = argList$logProb,
+             LOGPROBONLY = argList$logProbOnly)
     })
 
 nodeFunctionVector_SetupTemplate <- setupCodeTemplateClass(

--- a/packages/nimble/R/types_modelValuesAccessor.R
+++ b/packages/nimble/R/types_modelValuesAccessor.R
@@ -14,7 +14,7 @@ copierVector <- function(accessFrom_name, accessTo_name, isFromMV, isToMV) {
 }
 
 modelValuesAccessorVector <- function(mv, nodeNames, logProb = FALSE, logProbOnly = FALSE) {
-    ans <- list(mv, substitute(nodeNames), logProb, parent.frame(), logProbOnly)
+    ans <- list(mv, substitute(nodeNames), logProb | logProbOnly, parent.frame(), logProbOnly)
     class(ans) <- c('modelValuesAccessorVector', 'valuesAccessorVector')
     ans
 }

--- a/packages/nimble/R/types_modelValuesAccessor.R
+++ b/packages/nimble/R/types_modelValuesAccessor.R
@@ -13,8 +13,8 @@ copierVector <- function(accessFrom_name, accessTo_name, isFromMV, isToMV) {
     ans
 }
 
-modelValuesAccessorVector <- function(mv, nodeNames, logProb = FALSE) {
-    ans <- list(mv, substitute(nodeNames), logProb, parent.frame())
+modelValuesAccessorVector <- function(mv, nodeNames, logProb = FALSE, logProbOnly = FALSE) {
+    ans <- list(mv, substitute(nodeNames), logProb, parent.frame(), logProbOnly)
     class(ans) <- c('modelValuesAccessorVector', 'valuesAccessorVector')
     ans
 }
@@ -24,7 +24,10 @@ makeSetCodeFromAccessorVector <- function(accessorVector) {
     modelOrModelValues <- accessorVector[[1]]
     if(accessorVector[[3]]) {## logProb == TRUE
         isLogProbName <- grepl('logProb_', nodeNames)
-        nodeNames <- c(nodeNames, modelOrModelValues$modelDef$nodeName2LogProbName(nodeNames[!isLogProbName]))
+        if(accessorVector[[5]]) ## logProbOnly == TRUE
+            nodeNames <- c(modelOrModelValues$modelDef$nodeName2LogProbName(nodeNames[!isLogProbName]))
+        else
+            nodeNames <- c(nodeNames, modelOrModelValues$modelDef$nodeName2LogProbName(nodeNames[!isLogProbName]))
     }
     if(inherits(accessorVector, 'modelValuesAccessorVector'))
         setCode <- lapply(nodeNames, function(nn) {
@@ -48,7 +51,10 @@ makeGetCodeFromAccessorVector <- function(accessorVector) {
     modelOrModelValues <- accessorVector[[1]]
     if(accessorVector[[3]]) {## logProb == TRUE
         isLogProbName <- grepl('logProb_', nodeNames)
-        nodeNames <- c(nodeNames, modelOrModelValues$modelDef$nodeName2LogProbName(nodeNames[!isLogProbName]))
+        if(accessorVector[[5]]) ## logProbOnly == TRUE
+            nodeNames <- c(modelOrModelValues$modelDef$nodeName2LogProbName(nodeNames[!isLogProbName]))
+        else            
+            nodeNames <- c(nodeNames, modelOrModelValues$modelDef$nodeName2LogProbName(nodeNames[!isLogProbName]))
     }
     if(inherits(accessorVector, 'modelValuesAccessorVector'))
         getCode <- lapply(nodeNames, function(nn) {
@@ -78,7 +84,10 @@ makeMapInfoFromAccessorVectorFaster <- function(accessorVector ) {
         ## In this case, substr comparison is even more efficient
         ## isLogProbName <- grepl('logProb_', nodeNames)
         isLogProbName <- substr(nodeNames, 1, 8) == 'logProb_'
-        nodeNames <- c(nodeNames, sourceObject$modelDef$nodeName2LogProbName(nodeNames[!isLogProbName]))
+        if(accessorVector[[5]]) ## logProbOnly == TRUE
+            nodeNames <- c(sourceObject$modelDef$nodeName2LogProbName(nodeNames[!isLogProbName]))
+        else
+            nodeNames <- c(nodeNames, sourceObject$modelDef$nodeName2LogProbName(nodeNames[!isLogProbName]))
     }
     varNames <- .Call(parseVar, nodeNames)
     symTab <- sourceObject$getSymbolTable()
@@ -94,7 +103,10 @@ makeMapInfoFromAccessorVector <- function(accessorVector ) {
     
     if(accessorVector[[3]]) {## logProb == TRUE
         isLogProbName <- grepl('logProb_', nodeNames)
-        nodeNames <- c(nodeNames, sourceObject$modelDef$nodeName2LogProbName(nodeNames[!isLogProbName]))
+        if(accessorVector[[5]]) ## logProbOnly == TRUE
+            nodeNames <- c(sourceObject$modelDef$nodeName2LogProbName(nodeNames[!isLogProbName]))
+        else
+            nodeNames <- c(nodeNames, sourceObject$modelDef$nodeName2LogProbName(nodeNames[!isLogProbName]))
     }
     
     mapInfo <- lapply(nodeNames, function(z) {
@@ -111,9 +123,10 @@ makeMapInfoFromAccessorVector <- function(accessorVector ) {
         ans
     }) ## list elements will be offset, sizes, strides, varName, and singleton in that order.  Any changes must be propogated to C++
 
-    if(length(accessorVector) > 4) { ## set the length variable in the calling (setup) environment if needed
-        assign(accessorVector[[5]], length, envir = accessorVector[[4]]) 
-    }
+    ## Might need to go back and check if this was ever called.
+    ## if(length(accessorVector) > 4) { ## set the length variable in the calling (setup) environment if needed
+    ##     assign(accessorVector[[5]], length, envir = accessorVector[[4]]) 
+    ## }
     mapInfo
 }
 

--- a/packages/nimble/R/types_modelVariableAccessor.R
+++ b/packages/nimble/R/types_modelVariableAccessor.R
@@ -7,7 +7,7 @@
 
 
 modelVariableAccessorVector <- function(mv, nodeNames, logProb = FALSE, logProbOnly = FALSE) {
-    ans <- list(mv, substitute(nodeNames), logProb, parent.frame(), logProbOnly)
+    ans <- list(mv, substitute(nodeNames), logProb | logProbOnly, parent.frame(), logProbOnly)
     class(ans) <- c('modelVariableAccessorVector', 'valuesAccessorVector')
     ans
 }

--- a/packages/nimble/R/types_modelVariableAccessor.R
+++ b/packages/nimble/R/types_modelVariableAccessor.R
@@ -6,8 +6,8 @@
 ## model1_nodes_accessors$getAccessors() returns a list of the modelVariableAccessor objects
 
 
-modelVariableAccessorVector <- function(mv, nodeNames, logProb = FALSE) {
-    ans <- list(mv, substitute(nodeNames), logProb, parent.frame())
+modelVariableAccessorVector <- function(mv, nodeNames, logProb = FALSE, logProbOnly = FALSE) {
+    ans <- list(mv, substitute(nodeNames), logProb, parent.frame(), logProbOnly)
     class(ans) <- c('modelVariableAccessorVector', 'valuesAccessorVector')
     ans
 }


### PR DESCRIPTION
Do not merge.

This introduces a new argument, `logProbOnly`, to `nimCopy` and uses it in `sampler_RW` to reduce the copying upon acceptance or rejection of a Metropolis-Hastings proposal.  If this passes tests, then we can make use of this new feature in other samplers.