### PR TITLE
Support NA in compiler

### DIFF
--- a/UserManual/src/chapter_RCfunctions.Rmd
+++ b/UserManual/src/chapter_RCfunctions.Rmd
@@ -393,6 +393,16 @@ for(i in 1:10)
    x[i] <- foo(y[i]) 
 ```
 
+#### How NIMBLE handles `NA`
+
+NIMBLE supports use of `NA` with some caveats.  In the compiled version of a nimbleFunction:
+
+  - `NA` values in a logical scalar or vector will not work;
+  - Assigning `NA` to a new variable will make that variable have type double (in R, this would be a logical!);
+  - Non-trivial use of `NA` in integer variables may fail by having the value become a large (negative) number;
+  - Use of `NA` in doubles should generally work.
+
+These issues arise because NIMBLE uses R's encoding of NA values in C(++) but uses native compiled math and type-casting in C++, which do not always preserve R's NA encodings.  In summary, NA should generally work for doubles and should be used cautiously (i.e. after you test that what you need to work actually works) for integers.  For some needs, NaN is a suitable alternative to NA.
 
 
 #### Changing the sizes of existing objects: *setSize* {#sec:chang-sizes-exist}

--- a/packages/nimble/R/genCpp_generateCpp.R
+++ b/packages/nimble/R/genCpp_generateCpp.R
@@ -96,10 +96,17 @@ nimCppKeywordsThatFillSemicolon <- c(
 
 ## Main function for generating C++ output
 nimGenerateCpp <- function(code, symTab = NULL, indent = '', showBracket = TRUE, asArg = FALSE) {
-    if(is.numeric(code)) return(if(is.nan(code)) "(nimble_NaN())" else code)
-    if(is.character(code)) return(paste0('\"', gsub("\\n","\\\\n", code), '\"'))
+    ## The literal token NA should not appear in code as numeric or character, since it is logical in R.
+    ## Hence the checking of is.na cases for is.numeric and is.character are defensive only and not expected to be necessary.
+    if(is.numeric(code)) return(if(is.nan(code)) "(nimble_NaN())" else if(is.na(code)) 'NA_REAL' else code)
+    if(is.character(code)) {if(is.na(code)) stop("Character NA is not supported for compilation."); return(paste0('\"', gsub("\\n","\\\\n", code), '\"'))}
     if(is.null(code)) return('R_NilValue')
-    if(is.logical(code) ) return(if(code) 'true' else 'false')
+    ## In R's internals (Arith.h), there are R_NaReal and R_NaInt.  Then in Rmath, NA_REAL is defined to what is ultimately R_NaReal
+    ## It would be tempting to us R_NaReal for doubles and R_NaInt for ints, but R_NaReal (NA_REAL) seems to provide desired behavior
+    ## for arithmetic for both double and int.  E.g. 1 + NA_REAL will result in NA_REAL for either double or int,
+    ## but 1 + R_NaInt will not result in R_NaInt for int.  Hence, we use NA_REAL for every case of NA.
+    ## Note that NA will not work for bools in compiled code -- a meaningful mismatch from R, where NA defaults to logical.
+    if(is.logical(code) ) return(if(is.na(code)) 'NA_REAL' else if(code) 'true' else 'false')
     if(is.list(code) ) stop("Error generating C++ code, there is a list where there shouldn't be one.  It is probably inside map information.", call. = FALSE)
 
     if(length(code$isName) == 0) stop("Error generating C++ code, length(code$isName) == 0.", call. = FALSE)

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -1,7 +1,7 @@
 sizeProc_storage_mode <- function(x) {
     if(is.na(x))
         if(storage.mode(x) == 'logical')
-            return('integer') ## promote logical NA to integer for compiled code.
+            return('double') ## promote logical NA to double for compiled code.
     storage.mode(x)
 }
     

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -1,3 +1,10 @@
+sizeProc_storage_mode <- function(x) {
+    if(is.na(x))
+        if(storage.mode(x) == 'logical')
+            return('integer') ## promote logical NA to integer for compiled code.
+    storage.mode(x)
+}
+    
 assignmentAsFirstArgFuns <- c('nimArr_rmnorm_chol',
                               'nimArr_rmvt_chol',
                               'nimArr_rwish_chol',
@@ -562,7 +569,7 @@ sizeConcatenate <- function(code, symTab, typeEnv) { ## This is two argument ver
                         asserts <- c(asserts, sizeInsertIntermediate(code, thisArgIndex, symTab, typeEnv))
                     thisType <- arithmeticOutputType(thisType, code$args[[thisArgIndex]]$type)
                 } else {
-                    thisType <- storage.mode(code$args[[thisArgIndex]]) ##'double'
+                    thisType <- sizeProc_storage_mode(code$args[[thisArgIndex]]) ##'double'
                 }
                 ## Putting a map, or a values access, through parse(nimDeparse) won't work
                 ## So we lift any expression element above.
@@ -1753,7 +1760,7 @@ sizeAssignAfterRecursing <- function(code, symTab, typeEnv, NoEigenizeMap = FALS
         if(is.numeric(RHS) | is.logical(RHS)) {
             RHSname = ''
             RHSnDim <- 0
-            RHStype <- storage.mode(RHS)
+            RHStype <- sizeProc_storage_mode(RHS)
             RHSsizeExprs <- list() 
         }
         else if(is.character(RHS)){
@@ -2652,7 +2659,7 @@ getArgumentType <- function(expr) {
     if(inherits(expr, 'exprClass')) {
         expr$type
     } else
-        storage.mode(expr)
+        sizeProc_storage_mode(expr)
 }
 
 setReturnType <- function(keyword, argType) {
@@ -3089,7 +3096,7 @@ sizeBinaryCwise <- function(code, symTab, typeEnv) {
         a1DropNdim <- 0
         a1nDim <- 0
         a1sizeExprs <- list()
-        a1type <- storage.mode(a1)
+        a1type <- sizeProc_storage_mode(a1)
         if(!nimbleOptions('experimentalNewSizeProcessing') ) a1toEigenize <- 'maybe'
     }
     if(inherits(a2, 'exprClass')) {
@@ -3109,7 +3116,7 @@ sizeBinaryCwise <- function(code, symTab, typeEnv) {
         a2DropNdim <- 0
         a2nDim <- 0
         a2sizeExprs <- list()
-        a2type <- storage.mode(a2)
+        a2type <- sizeProc_storage_mode(a2)
         if(!nimbleOptions('experimentalNewSizeProcessing') )  a2toEigenize <- 'maybe'
     }
     

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -1837,7 +1837,7 @@ sizeAssignAfterRecursing <- function(code, symTab, typeEnv, NoEigenizeMap = FALS
             }
             ## and warn if type issue e.g. int <- double
             if(assignmentTypeWarn(LHS$type, RHStype)) {
-                message(paste0('Warning, RHS numeric type is losing information in assignment to LHS.', nimDeparse(code)))
+                message(paste0('Warning, RHS numeric type is losing information in assignment to LHS in line:\n', nimDeparse(code)))
             }
         }
     }


### PR DESCRIPTION
Several user issues recently have requested support for NA in compiled code.

It is not always clear that one should "want" to use NA in a model context, but supporting it for nimbleFunctions is a more general need.

Doing so is not entirely straightforward.  We can support NA for integer and double types, but not for logicals, in compiled code.  In compiled code, logicals are implemented at C++ bools, and there is no way to extent beyond `true` and `false` values for those.  That does not mesh naturally with R, in which "NA" *defaults* to logical.  In this PR, NA defaults to integer in compiled code.

Some ancillary aspects of compiler support for flexible numeric operations were noticed in exploring the NA issue but will be dealt with separately.  In particular, it would be nice to issue a warning if NA is assigned to a logical.  This looks like it fits into a larger need to issue warnings for "information loss" assignments, like "int <- double".  We currently issue such warnings for these if the LHS is a name but not an indexed expression.  It would also be nice to special-case the warning if there is NA on the RHS in order to provide more helpful information.

There is still a need to make default = NA work.  That is not part of this PR.
