### PR TITLE
fix access to member data of >2D in a nested nimbleFunction

### DIFF
--- a/packages/nimble/R/genCpp_eigenization.R
+++ b/packages/nimble/R/genCpp_eigenization.R
@@ -835,7 +835,7 @@ eigenizeName <- function(code, symTab, typeEnv, workEnv) {
     
     if(needStrides) {
         newArgs <- list()
-        newArgs[[1]] <- code$name
+        newArgs[[1]] <- as.name(code$name)
         newArgs[[2]] <- code$nDim ## not used but for completeness
         newArgs[[3]] <- quote(0) ## eigenizeNameStrided will insert getOffset(ptr)
         newArgs[[4]] <- code$sizeExprs

--- a/packages/nimble/R/genCpp_eigenization.R
+++ b/packages/nimble/R/genCpp_eigenization.R
@@ -835,7 +835,7 @@ eigenizeName <- function(code, symTab, typeEnv, workEnv) {
     
     if(needStrides) {
         newArgs <- list()
-        newArgs[[1]] <- as.name(code$name)
+       newArgs[[1]] <- as.name(code$name)
         newArgs[[2]] <- code$nDim ## not used but for completeness
         newArgs[[3]] <- quote(0) ## eigenizeNameStrided will insert getOffset(ptr)
         newArgs[[4]] <- code$sizeExprs

--- a/packages/nimble/R/genCpp_maps.R
+++ b/packages/nimble/R/genCpp_maps.R
@@ -229,7 +229,7 @@ makeMapExprFromBrackets <- function(code, drop = TRUE) {
 ## This is used to build the setMap expression for a NimArr
 nimArrMapExpr <- function(code, symTab, typeEnv, newName) {
     mapName <- newName
-    varRexpr <- code$args[[1]] ## This should already be an R parse tree, not a nimExpr
+    varRexpr <- code$args[[1]] 
     possibleVarName <- deparse(varRexpr)
     needStartOffset <- !is.null(typeEnv$passedArgumentNames[[possibleVarName]])
     targetSym <- symTab$getSymbolObject(possibleVarName, TRUE)
@@ -257,7 +257,7 @@ nimArrMapExpr <- function(code, symTab, typeEnv, newName) {
     else offsetRexpr <- substitute( chainedCall(template(static_cast, int), OE), list(OE = code$args[[3]]) )
     
     ## Need to build up this expression
-    ans <- list(as.name('setMap'), as.name(newName), varRexpr, offsetRexpr) ## varName used to be targetSym$name. Should be identical
+    ans <- list(as.name('setMap'), as.name(newName), as.name(varRexpr), offsetRexpr) ## varName used to be targetSym$name. Should be identical
     ans <- c(ans, strides, sizeExprs)
     ans <- as.call(ans)
     return(ans)


### PR DESCRIPTION
This PR fixes cases like the following, which are not working:

```
nf1 <- nimbleFunction(
  setup = function() {
    A <- array(0, dim = c(2, 3, 4))
    setupOutputs(A)
  },
  run = function() {}
)

nf2 <- nimbleFunction(
  setup = function() {
    mynf1 <- nf1()
  },
  run = function() {
    ans <- mynf1$A[,,1]
    returnType(double(2))
    return(ans)
  }
)
mynf2 <- nf2()
cmynf2 <- compileNimble(mynf2)  
```

The problem only occurs if `A` has dimension > 2.