### PR TITLE
add tests for more general BNP

### DIFF
--- a/packages/nimble/R/BNP_samplers.R
+++ b/packages/nimble/R/BNP_samplers.R
@@ -1858,11 +1858,11 @@ findClusterNodes <- function(model, target) {
         if(length(loopIndexes) != 1)
             stop("findClusterNodes: found cluster membership parameters that use different indexing variables; NIMBLE's CRP sampling not designed for this case.")
         ## Note not clear when NULL would be the result...
-        loopIndex[[varIdx]] <- loopIndexes
+        loopIndex[varIdx] <- loopIndexes
 
         ## Determine potential cluster nodes by substituting all possible clusterID values into the indexing expression. 
         n <- nrow(unrolledIndices)
-        if(n > 0 && loopIndex %in% dimnames(unrolledIndices)[[2]]) {  # catch cases like use of xi[2] rather than xi[i]
+        if(n > 0 && loopIndex[varIdx] %in% dimnames(unrolledIndices)[[2]]) {  # catch cases like use of xi[2] rather than xi[i]
             ## Order so that loop over index of cluster ID in order of cluster ID so that
             ## clusterNodes will be grouped in chunks of unique cluster IDs for correct
             ## sampling of new clusters when have multiple obs per cluster.

--- a/packages/nimble/R/BNP_samplers.R
+++ b/packages/nimble/R/BNP_samplers.R
@@ -1370,6 +1370,12 @@ sampler_CRP <- nimbleFunction(
     
     nData <- length(dataNodes)
 
+    ## Check that no use of multiple clustering variables, such as 'thetaTilde[xi[i], eta[j]]'.
+    ## It's likely that if we set the non-conjugate sampler and turn off wrapping omits sampling of empty clusters
+    ## (which is not set up correctly for this case), that the existing code would give correct sampling.
+    if(any(clusterVarInfo$multipleStochIndexes))
+        stop("sampler_CRP: Detected use of multiple stochastic indexes of a variable: ", deparse(clusterVarInfo$indexExpr[[1]]), ". NIMBLE's CRP sampling is not yet set up to handle this case. Please contact the NIMBLE development team if you are interested in this functionality.")
+
     ## Check there is at least one or more "observation" per random index.
     ## Note that cases like mu[xi[i],xi[j]] are being trapped in findClusterNodes().
     if(n > nData)
@@ -1606,13 +1612,8 @@ sampler_CRP <- nimbleFunction(
             if(nIntermClusNodesPerClusID > 0) {
               model$calculate(intermNodes[((i-1)*nIntermClusNodesPerClusID+1):(i*nIntermClusNodesPerClusID)]) 
             }
-            model$calculate(dataNodes[((i-1)*nObsPerClusID+1):(i*nObsPerClusID)])       
-            curLogProb[iprob] <<- 0 # <<-
-            for(j1 in 1:nObsPerClusID) {
-                ## getLogProb can be done on a vector of nodes to avoid loop here.
-              curLogProb[iprob] <<- curLogProb[iprob] + model$getLogProb(dataNodes[(i-1)*nObsPerClusID+j1])  
-            }  
-            curLogProb[iprob] <<- log(xiCounts[xiUniques[j]]) + curLogProb[iprob] 
+            curLogProb[iprob] <<- log(xiCounts[xiUniques[j]]) +
+                model$calculate(dataNodes[((i-1)*nObsPerClusID+1):(i*nObsPerClusID)])
             reorderXiUniques[iprob] <- xiUniques[j]
             iprob <- iprob + 1
           }
@@ -1644,16 +1645,12 @@ sampler_CRP <- nimbleFunction(
       } else { # cluster is not a singleton.
         ## First, compute probability of sampling an existing label.
         for(j in 1:k) { 
-          model[[target]][i] <<- xiUniques[j]  # <<-
+          model[[target]][i] <<- xiUniques[j]  
           if(nIntermClusNodesPerClusID > 0) {
             model$calculate(intermNodes[((i-1)*nIntermClusNodesPerClusID+1):(i*nIntermClusNodesPerClusID)]) 
           }
-          model$calculate(dataNodes[((i-1)*nObsPerClusID+1):(i*nObsPerClusID)])       
-          curLogProb[j] <<- 0 # <<-
-          for(j1 in 1:nObsPerClusID) {
-            curLogProb[j] <<- curLogProb[j] + model$getLogProb(dataNodes[(i-1)*nObsPerClusID+j1])   
-          }  
-          curLogProb[j] <<- log(xiCounts[xiUniques[j]]) + curLogProb[j] 
+          curLogProb[j] <<- log(xiCounts[xiUniques[j]]) +
+              model$calculate(dataNodes[((i-1)*nObsPerClusID+1):(i*nObsPerClusID)])       
         }
         ## Second, compute probability of sampling a new cluster depending on the value of kNew.       
         if(kNew == 0) { # no new cluster can be created 

--- a/packages/nimble/inst/tests/test-bnp.R
+++ b/packages/nimble/inst/tests/test-bnp.R
@@ -3218,7 +3218,7 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
   n <- 5
   n2 <- 4
   J <- 3
-  constants <- list(n = n, J = J)
+  constants <- list(n = n, n2 = n2, J = J)
   data <- list(y = matrix(rnorm(n*J),n,J))
   inits <- list(alpha = 1, xi = rep(1, n),
                 thetaTilde = matrix(rnorm(J*n2), n2, J))

--- a/packages/nimble/inst/tests/test-bnp.R
+++ b/packages/nimble/inst/tests/test-bnp.R
@@ -3257,7 +3257,7 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
   n <- 5
   n2 <- 4
   J <- 3
-  constants <- list(n = n, J = J)
+  constants <- list(n = n, n2 = n2, J = J)
   data <- list(y = matrix(rnorm(n*J),n,J))
   inits <- list(alpha = 1, xi = rep(1, n),
                 thetaTilde = matrix(rnorm(J*n), n, J))
@@ -3520,7 +3520,7 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
   n <- 5
   n2 <- 4
   J <- 3
-  constants <- list(n = n, J = J)
+  constants <- list(n = n, n2 = n2, J = J)
   data <- list(y = rnorm(n))
   inits <- list(alpha = 1, xi = rep(1, n),
                 thetaTilde = rnorm(n2), s2tilde = runif(n))
@@ -4023,7 +4023,7 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
 
   n <- 5
   J <- 2
-  constants <- list(n = n)
+  constants <- list(n = n, J = J)
   data <- list(y = matrix(rnorm(n*J), n, J))
   inits <- list(alpha = 1, xi = rep(1, n),
                 thetaTilde = rnorm(n), sigmaTilde = matrix(rgamma(n*J, 1, 1), n, J))
@@ -4407,7 +4407,7 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
       for(i in 1:n)
           for(j in 1:J)
               beta[j, i] ~ dnorm(0,1)
-      xi[1:4] ~ dCRP(1, size=4)
+      xi[1:n] ~ dCRP(1, size = n)
   })
   n  <- 5
   J <- 2
@@ -5136,7 +5136,7 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
                 thetaTilde = rnorm(n))
   model <- nimbleModel(code, data = data, constants = constants, inits = inits)
   expect_silent(conf <- configureMCMC(model, print = FALSE))
-  expect_error(mcmc <- buildMCMC(conf), "sampler_CRP: Detected unusual indexing")
+  expect_error(mcmc <- buildMCMC(conf), "sampler_CRP: differing number of clusters")
 
   ## cases of multiple obs per group regarding priors on cluster parameters
 
@@ -5895,7 +5895,7 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
   n <- 5
   n2 <- 4
   J <- 3
-  constants <- list(n = n, J = J)
+  constants <- list(n = n, n2 = n2, J = J)
   data <- list(y = matrix(rnorm(n*J),n,J))
   inits <- list(alpha = 1, xi = rep(1, n+1),
                 thetaTilde = matrix(rnorm(J*n), n, J))
@@ -5919,7 +5919,7 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
   n <- 5
   n2 <- 4
   J <- 3
-  constants <- list(n = n, J = J)
+  constants <- list(n = n, n2 = n2, J = J)
   data <- list(y = matrix(rnorm(n*J),n,J))
   inits <- list(alpha = 1, xi = rep(1, n-1),
                 thetaTilde = matrix(rnorm(J*n), n, J))
@@ -5947,8 +5947,10 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
   y <- matrix(5, nrow=3, ncol=4)
   data <- list(y = y)
   model <- nimbleModel(code, data = data, inits = inits)
-  expect_error(conf <- configureMCMC(model),
+  expect_silent(conf <- configureMCMC(model, print = FALSE))
+  expect_error(mcmc <- buildMCMC(conf),
                "sampler_CRP: Detected use of multiple stochastic indexes of a variable")
+
 
   ## crossed clustering with truncation 
   code <- nimbleCode({
@@ -5970,9 +5972,10 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
   y <- matrix(5, nrow=3, ncol=4)
   data <- list(y = y)
   model <- nimbleModel(code, data = data, inits = inits)
-  conf <- configureMCMC(model)
-  expect_error(conf <- configureMCMC(model),
+  expect_silent(conf <- configureMCMC(model, print = FALSE))
+  expect_error(mcmc <- buildMCMC(conf),
                "sampler_CRP: Detected use of multiple stochastic indexes of a variable")
+
 
 })
 

--- a/packages/nimble/inst/tests/test-bnp.R
+++ b/packages/nimble/inst/tests/test-bnp.R
@@ -3569,7 +3569,7 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
                 thetaTilde = rnorm(n), tauTilde = rgamma(n, 1, 1))
   model <- nimbleModel(code, data = data, constants = constants, inits = inits)
   expect_silent(conf <- configureMCMC(model, print = FALSE))
-  expect_error(mcmc <- buildMCMC(conf), "sampler_CRP: detected that deterministic nodes are being clustered")
+  expect_error(mcmc <- buildMCMC(conf), "findClusterNodes: detected that deterministic nodes are being clustered")
 
   ## Model A: dnorm obs, dmnorm prior
   code <- nimbleCode({

--- a/packages/nimble/inst/tests/test-bnp.R
+++ b/packages/nimble/inst/tests/test-bnp.R
@@ -5947,8 +5947,8 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
   y <- matrix(5, nrow=3, ncol=4)
   data <- list(y = y)
   model <- nimbleModel(code, data = data, inits = inits)
-  conf <- configureMCMC(model)
-  mcmc <- buildMCMC(conf)
+  expect_error(conf <- configureMCMC(model),
+               "sampler_CRP: Detected use of multiple stochastic indexes of a variable")
 
   ## crossed clustering with truncation 
   code <- nimbleCode({
@@ -5971,7 +5971,8 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
   data <- list(y = y)
   model <- nimbleModel(code, data = data, inits = inits)
   conf <- configureMCMC(model)
-  mcmc <- buildMCMC(conf)
+  expect_error(conf <- configureMCMC(model),
+               "sampler_CRP: Detected use of multiple stochastic indexes of a variable")
 
 })
 


### PR DESCRIPTION
This adds a bunch of tests for our new BNP functionality. 

Also, it now errors out in 'crossed' clustering cases such as `thetaTilde[xi[i], eta[j]]`, which we don't fully handle (we could probably get this to work using the non-conjugate sampler if we avoid using the wrapping that stops sampling of parameters of empty clusters). 

Also, it simplifies logProb calculations in `sampler_CRP$run`.