### PR TITLE
add method getWidthHistory for slice sampler

### DIFF
--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -624,6 +624,9 @@ sampler_slice <- nimbleFunction(
             timesRan     <<- 0
             timesAdapted <<- 0
             sumJumps     <<- 0
+            if(saveMCMChistory) {
+                widthHistory  <<- c(0, 0)    ## widthHistory
+            }
         }
     )
 )

--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -534,6 +534,10 @@ sampler_slice <- nimbleFunction(
         timesRan      <- 0
         timesAdapted  <- 0
         sumJumps      <- 0
+        widthHistory  <- c(0, 0)   ## widthHistory
+        if(nimbleOptions('MCMCsaveHistory')) {
+            saveMCMChistory <- TRUE
+        } else saveMCMChistory <- FALSE
         discrete      <- model$isDiscrete(target)
         ## checks
         if(length(targetAsScalar) > 1)     stop('cannot use slice sampler on more than one target node')
@@ -598,10 +602,23 @@ sampler_slice <- nimbleFunction(
                 meanJump <- sumJumps / timesRan
                 width <<- width + (2*meanJump - width) * adaptFactor   # exponentially decaying adaptation of 'width' -> 2 * (avg. jump distance)
                 timesAdapted <<- timesAdapted + 1
+                if(saveMCMChistory) {
+                    setSize(widthHistory, timesAdapted)                 ## widthHistory
+                    widthHistory[timesAdapted] <<- width                ## widthHistory
+                }
                 timesRan <<- 0
                 sumJumps <<- 0
             }
         },
+        getWidthHistory = function() {       ## widthHistory
+            returnType(double(1))
+            if(saveMCMChistory) {
+                return(widthHistory)
+            } else {
+                print("Please set 'nimbleOptions(MCMCsaveHistory = TRUE)' before building the MCMC")
+                return(numeric(1, 0))
+            }
+       },
         reset = function() {
             width        <<- widthOriginal
             timesRan     <<- 0


### PR DESCRIPTION
Hi all,
Here is the pull-request you suggested to be able to follow the adaptive phase of the slice sampler with a `getWidthHistory ` method similar to `getScaleHistory` of the RW samplers. I briefly tested it and it seemed to work. 
In summary:
- I added an option in `setup()` to activate the save  following the `MCMCsaveHistory` argument 
- I changed `adaptiveProcedure()` to save width history
- I added the method `getWidthHistory()` to retrieve the width history
I hope you'll have all information needed, else feel free to ask.
Best,
Rémi