### PR TITLE
add as.list for a modelValues

### DIFF
--- a/UserManual/src/chapter_DataStructures.Rmd
+++ b/UserManual/src/chapter_DataStructures.Rmd
@@ -148,17 +148,30 @@ customMV$a
 
 
 Often it is useful to convert a modelValues object to a matrix for use
-in R.  For example, we may want to convert MCMC output into a matrix
-for use with the `coda` package for processing MCMC samples. This
-can be done with the `as.matrix` method for modelValues
-objects. This will generate column names from every scalar element of
-variables (e.g. "b[1, 1]" ,"b[2, 1]", etc.). The rows of
-the modelValues will be the rows of the matrix, with any matrices or
-arrays converted to a vector based on column-major ordering.
+in R.  For example, we may want to convert MCMC output into a matrix,
+for use with the `coda` package for processing MCMC samples, or into a
+list. This can be done with the `as.matrix` and `as.list` methods for
+modelValues objects, respectively. `as.matrix` will generate column
+names from every scalar element of variables (e.g. "b[1, 1]" ,"b[2,
+1]", etc.). The rows of the modelValues will be the rows of the
+matrix, with any matrices or arrays converted to a vector based on
+column-major ordering.
   
 ```{r, as.matrix-mv}
 as.matrix(customMV, 'a')   # convert 'a'
 as.matrix(customMV)        # convert all variables
+```
+
+`as.list` will return a list with an element for each variable.  Each
+element will be an array of the same size and shape as the variable
+with an additional index for the row (e.g., MCMC iteration when used for
+MCMC output).  By default row is the first index, but it
+can be the last if needed.
+
+```{r, as.list-mv}
+as.list(customMV, 'a')    # get only 'a'
+as.list(customMV)         # get all variables
+as.list(customMV, 'a', iterationAsFirstIndex = TRUE) # put row in last index
 ```
 
 If a variable is a scalar, using `unlist` in R to extract all rows as a vector can be useful.

--- a/UserManual/src/chapter_MCMC.Rmd
+++ b/UserManual/src/chapter_MCMC.Rmd
@@ -392,7 +392,7 @@ mcmcConf$printSamplers(executionOrder = TRUE)
 
 An MCMC configuration object contains two independent sets of variables to monitor, each with their own thinning interval: `thin` corresponding to `monitors`, and `thin2` corresponding to `monitors2`.  Monitors operate at the *variable* level.  Only entire model variables may be monitored.  Specifying a monitor on a *node*, e.g., `x[1]`, will result in the entire variable `x` being monitored.
 
-The variables specified in `monitors`  and `monitors2` will be recorded (with thinning interval `thin`) into objects called `mvSamples` and `mvSamples2`, contained within the MCMC object. These are both *modelValues* objects; modelValues are NIMBLE data structures used to store multiple sets of values of model variables^[See Section \@ref(sec:modelValues-struct) for general information on modelValues.].  These can be accessed as the member data `mvSamples` and `mvSamples2` of the MCMC object, and they can be converted to matrices using `as.matrix` (see Section \@ref(sec:extracting-samples)).
+The variables specified in `monitors`  and `monitors2` will be recorded (with thinning interval `thin`) into objects called `mvSamples` and `mvSamples2`, contained within the MCMC object. These are both *modelValues* objects; modelValues are NIMBLE data structures used to store multiple sets of values of model variables^[See Section \@ref(sec:modelValues-struct) for general information on modelValues.].  These can be accessed as the member data `mvSamples` and `mvSamples2` of the MCMC object, and they can be converted to matrices using `as.matrix` or lists using `as.list` (see Section \@ref(sec:extracting-samples)).
 
 Monitors may be added to the MCMC configuration either in the original call to `configureMCMC` or using the `addMonitors` method:
 ```{r, addMonitors, eval=FALSE}
@@ -598,11 +598,13 @@ mvSamples <- mcmc$mvSamples
 mvSamples2 <- mcmc$mvSamples2
 ```
 
-These *modelValues* objects can be converted into matrices using `as.matrix`:
+These *modelValues* objects can be converted into matrices using `as.matrix` or lists using `as.list`:
 
 ```{r, as.matrix-samples, eval=FALSE}
 samplesMatrix <- as.matrix(mvSamples)
+samplesList <- as.list(mvSamples)
 samplesMatrix2 <- as.matrix(mvSamples2)
+samplesList2 <- as.list(mvSamples2)
 ```
 
 The column names of the matrices will be the node names of nodes in the monitored variables.  Then, for example, the mean of the samples for node `x[2]` could be calculated as:
@@ -611,7 +613,9 @@ The column names of the matrices will be the node names of nodes in the monitore
 mean(samplesMatrix[, "x[2]"])
 ```
 
-Obtaining samples as matrices is most common, but see Section \@ref(sec:modelValues-struct) for more about programming with modelValues objects, especially if you want to write nimbleFunctions to use the samples.
+The list version will contain an element for each variable that will be the size and shape of the variable with an additional index for MCMC iteration.  By default MCMC iteration will be the first index, but including `iterationAsFirstIndex = FALSE` will make it the last index.
+
+Obtaining samples as matrices or lists is most common, but see Section \@ref(sec:modelValues-struct) for more about programming with modelValues objects, especially if you want to write nimbleFunctions to use the samples.
 
 ## Calculating WAIC {#sec:WAIC}
 
@@ -1007,7 +1011,7 @@ Cmcmc_CL <- compileNimble(mcmc_CL, project = Rmodel2)
 # run the default MCMC function,
 # and example the mean of mu[1]
 Cmcmc$run(1000)
-cSamplesMatrix <- as.matrix(Cmcmc$mvSamples)
+cSamplesMatrix <- as.matrix(Cmcmc$mvSamples) # alternative: as.list
 mean(cSamplesMatrix[, "mu[1]"])
 
 # run the crossLevel MCMC function,

--- a/UserManual/src/chapter_OtherAlgorithms.Rmd
+++ b/UserManual/src/chapter_OtherAlgorithms.Rmd
@@ -140,7 +140,7 @@ cENKF$run(parNum)
   
 ```{r, particle_Filter_Samples, eval=FALSE}
 # Equally-weighted samples (available from all filters)
-bootEWSamp <- as.matrix(cBootF$mvEWSamples)
+bootEWSamp <- as.matrix(cBootF$mvEWSamples) # alternative: as.list
 auxEWSamp <- as.matrix(cAuxF$mvEWSamples)
 LWFEWSamp <- as.matrix(cLWF$mvEWSamples)
 ENKFEWSamp <- as.matrix(cENKF$mvEWSamples)

--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -28,10 +28,12 @@
 #' \code{progressBar}: Boolean specifying whether to display a progress bar during MCMC execution (default = TRUE).  The progress bar can be permanently disabled by setting the system option \code{nimbleOptions(MCMCprogressBar = FALSE)}.
 #'
 #' Samples corresponding to the \code{monitors} and \code{monitors2} from the MCMCconf are stored into the interval variables \code{mvSamples} and \code{mvSamples2}, respectively.
-#' These may be accessed and converted into R matrix objects via:
+#' These may be accessed and converted into R matrix or list objects via:
 #' \code{as.matrix(mcmc$mvSamples)}
+#' \code{as.list(mcmc$mvSamples)}
 #' \code{as.matrix(mcmc$mvSamples2)}
-#'
+#' \code{as.list(mcmc$mvSamples2)}
+#' 
 #' The uncompiled MCMC function may be compiled to a compiled MCMC object, taking care to compile in the same project as the R model object, using:
 #' \code{Cmcmc <- compileNimble(Rmcmc, project = Rmodel)}
 #'
@@ -91,6 +93,7 @@
 #' Cmcmc <- compileNimble(Rmcmc, project=Rmodel)
 #' Cmcmc$run(10000)
 #' samples <- as.matrix(Cmcmc$mvSamples)
+#' samplesList <- as.list(Cmcmc$mvSamples)
 #' head(samples)
 #' WAIC <- Cmcmc$calculateWAIC(nburnin = 1000)
 #' }

--- a/packages/nimble/R/types_util.R
+++ b/packages/nimble/R/types_util.R
@@ -208,6 +208,24 @@ as.matrix.CmodelValues <- function(x, varNames, ...){
 	return(ans)
 }
 
+as.list.CmodelValues <- function(x, varNames, iterationAsFirstIndex = TRUE, ...) {
+  if(missing(varNames))
+    varNames <- x$varNames
+  nrows <- getsize(x)
+  results <- list()
+  for(v in varNames) {
+    samples <- x[[v]]
+    dims <- nimble:::dimOrLength(samples[[1]])
+    matrixVersion <- do.call("c", lapply(samples, as.numeric))
+    ansDims <- c(dims, nrows)
+    results[[v]] <- array(matrixVersion, dim = ansDims)
+    if(iterationAsFirstIndex) {
+      nDim <- length(ansDims)
+      results[[v]] <- aperm(results[[v]], c(nDim, 1:(nDim-1)))
+    }
+  }
+  results
+}
 
 modelValuesElement2Matrix <- function(mv, varName){
 	if(length(varName) != 1)

--- a/packages/nimble/R/types_util.R
+++ b/packages/nimble/R/types_util.R
@@ -208,6 +208,25 @@ as.matrix.CmodelValues <- function(x, varNames, ...){
 	return(ans)
 }
 
+as.list.modelValuesBaseClass <- function(x, varNames, iterationAsFirstIndex = TRUE, ...) {
+  if(missing(varNames))
+    varNames <- x$varNames
+  nrows <- getsize(x)
+  results <- list()
+  for(v in varNames) {
+    samples <- x[[v]]
+    dims <- nimble:::dimOrLength(samples[[1]])
+    matrixVersion <- do.call("c", lapply(samples, as.numeric))
+    ansDims <- c(dims, nrows)
+    results[[v]] <- array(matrixVersion, dim = ansDims)
+    if(iterationAsFirstIndex) {
+      nDim <- length(ansDims)
+      results[[v]] <- aperm(results[[v]], c(nDim, 1:(nDim-1)))
+    }
+  }
+  results
+}
+
 as.list.CmodelValues <- function(x, varNames, iterationAsFirstIndex = TRUE, ...) {
   if(missing(varNames))
     varNames <- x$varNames

--- a/packages/nimble/inst/tests/test-modelValuesInterface.R
+++ b/packages/nimble/inst/tests/test-modelValuesInterface.R
@@ -94,6 +94,30 @@ test_that("as.list works for CmodelValues",
     
     m <- nimbleModel(mc)
     mcmc <- buildMCMC(m)
+
+    ## uncompiled
+    mcmc$run(30)
+    samples <- as.matrix(mcmc$mvSamples)
+    
+    test <- as.list(mcmc$mvSamples)
+    
+    expect_identical(unname(samples[,1:3]), test$x)
+    expect_identical(unname(samples[,4:6]), test$y[,1:3,1])
+    expect_identical(unname(samples[,7:9]), test$y[,1:3,2])
+    expect_identical(unname(samples[,10:12]), test$z[,1:3,1,1])
+    expect_identical(unname(samples[,13:15]), test$z[,1:3,2,1])
+    expect_identical(unname(samples[,16:18]), test$z[,1:3,1,2])
+    expect_identical(unname(samples[,19:21]), test$z[,1:3,2,2])
+    expect_identical(unname(samples[,22:24]), test$z[,1:3,1,3])
+    expect_identical(unname(samples[,25:27]), test$z[,1:3,2,3])
+    
+    test <- as.list(mcmc$mvSamples, 'y')
+
+    expect_identical(names(test), 'y')
+    expect_identical(unname(samples[,4:6]), test$y[,1:3,1])
+    expect_identical(unname(samples[,7:9]), test$y[,1:3,2])
+
+    ## compiled
     cm <- compileNimble(m)
     cmcmc <- compileNimble(mcmc, project = m)
     

--- a/packages/nimble/inst/tests/test-modelValuesInterface.R
+++ b/packages/nimble/inst/tests/test-modelValuesInterface.R
@@ -80,5 +80,45 @@ test_that("as.matrix and matrix2mv work for modelValues",
 }
 )
 
+test_that("as.list works for CmodelValues",
+{
+    mc <- nimbleCode({
+        for(i in 1:3) x[i] ~ dnorm(0,1)
+        for(i in 1:3)
+            for(j in 1:2) y[i, j] ~ dnorm(0,1)
+        for(i in 1:3)
+            for(j in 1:2)
+                for(k in 1:4)
+                    z[i, j, k ] ~ dnorm(0,1)
+    })
+    
+    m <- nimbleModel(mc)
+    mcmc <- buildMCMC(m)
+    cm <- compileNimble(m)
+    cmcmc <- compileNimble(mcmc, project = m)
+    
+    cmcmc$run(30)
+    samples <- as.matrix(cmcmc$mvSamples)
+
+    test <- as.list(cmcmc$mvSamples)
+    
+    expect_identical(unname(samples[,1:3]), test$x)
+    expect_identical(unname(samples[,4:6]), test$y[,1:3,1])
+    expect_identical(unname(samples[,7:9]), test$y[,1:3,2])
+    expect_identical(unname(samples[,10:12]), test$z[,1:3,1,1])
+    expect_identical(unname(samples[,13:15]), test$z[,1:3,2,1])
+    expect_identical(unname(samples[,16:18]), test$z[,1:3,1,2])
+    expect_identical(unname(samples[,19:21]), test$z[,1:3,2,2])
+    expect_identical(unname(samples[,22:24]), test$z[,1:3,1,3])
+    expect_identical(unname(samples[,25:27]), test$z[,1:3,2,3])
+    
+    test <- as.list(cmcmc$mvSamples, 'y')
+
+    expect_identical(names(test), 'y')
+    expect_identical(unname(samples[,4:6]), test$y[,1:3,1])
+    expect_identical(unname(samples[,7:9]), test$y[,1:3,2])
+}
+)
+
 options(warn = RwarnLevel)
 nimbleOptions(verbose = nimbleVerboseSetting)


### PR DESCRIPTION
Back in January we drafted this `as.list` method for a `modelValuesBaseClass` and `CmodelValues`, i.e. uncompiled and compiled modelValues objects, for a specific purpose.  These allow `as.list(mcmc$mvSamples)` and `as.list(Cmcmc$mvSamples)` to work.  `as.list` returns a list with variable-named elements, each of which has the size and shape of the variable plus one dimension to index MCMC iteration.  MCMC iteration is by default the first index but ` iterationAsFirstIndex = FALSE` makes it the last index. We regularly hear of use cases where this would be helpful, so this PR opens discussion on adding it to the package.  There are arguments to control which variables are requested (default: all that are monitored) and whether to arrange the MCMC iteration as the first index (default: TRUE).

This PR would add `as.list.modelValuesBaseClass` and `as.list.CmodelValues` to the package but would not integrate them with functions like `nimbleMCMC` or `runMCMC`.  I'm thinking we could discuss that for a later release.

This PR includes a test and minor changes to documentation to draw attention to the `as.list` feature.
.