### PR TITLE
deal with overly-long names

### DIFF
--- a/packages/nimble/R/BUGS_utils.R
+++ b/packages/nimble/R/BUGS_utils.R
@@ -197,6 +197,9 @@ parseTreeSubstitute <- function(pt, pattern, replacement) {
     return(pt)
 }
 
+
+CppNameLabelMaker <- labelFunctionCreator('UID')
+
 # no longer documented in Rd
 # Generates a valid C++ name from an R Name
 # 
@@ -210,12 +213,13 @@ parseTreeSubstitute <- function(pt, pattern, replacement) {
 # @export
 # @examples
 #  genName('theta[1]')
-Rname2CppName <- function(rName, colonsOK = TRUE) {
+Rname2CppName <- function(rName, colonsOK = TRUE, maxLength = 250) {
     ## This will serve to replace and combine our former Rname2CppName and nameMashupFromExpr
     ## which were largely redundant
-    if (!is.character(rName))
+    if (!is.character(rName)) {
+        browser()
         rName <- deparse(rName)
-
+        }
     if( colonsOK) {
         # Substitute single colons but preserve double colons.
         rName <- gsub('::', '_DOUBLE_COLON_', rName)
@@ -258,6 +262,12 @@ Rname2CppName <- function(rName, colonsOK = TRUE) {
     rName <- gsub('\\^', '_tothe_', rName)
     rName <- gsub('^_+', '', rName) # remove leading underscores.  can arise from (a+b), for example
     rName <- gsub('^([[:digit:]])', 'd\\1', rName)    # if begins with a digit, add 'd' in front
+    rName <- sapply(rName,
+                    function(x) {
+                        if(nchar(x) > maxLength)  # cut off 50 extra to ensure result is less than maxLength so not subsequently modified 
+                            x <- paste0(substring(x, 1, maxLength), '_', CppNameLabelMaker())
+                        return(x)
+                    })
     rName
     
 }

--- a/packages/nimble/R/BUGS_utils.R
+++ b/packages/nimble/R/BUGS_utils.R
@@ -263,7 +263,7 @@ Rname2CppName <- function(rName, colonsOK = TRUE, maxLength = 250) {
     rName <- gsub('^([[:digit:]])', 'd\\1', rName)    # if begins with a digit, add 'd' in front
     rName <- sapply(rName,
                     function(x) {
-                        if(nchar(x) > maxLength && !grep("___TRUNC___", x)) 
+                        if(nchar(x) > maxLength && !length(grep("___TRUNC___", x))) 
                             x <- paste0(substring(x, 1, maxLength), CppNameLabelMaker())
                         return(x)
                     })

--- a/packages/nimble/R/BUGS_utils.R
+++ b/packages/nimble/R/BUGS_utils.R
@@ -198,7 +198,7 @@ parseTreeSubstitute <- function(pt, pattern, replacement) {
 }
 
 
-CppNameLabelMaker <- labelFunctionCreator('UID')
+CppNameLabelMaker <- labelFunctionCreator('___TRUNC___')
 
 # no longer documented in Rd
 # Generates a valid C++ name from an R Name
@@ -216,10 +216,9 @@ CppNameLabelMaker <- labelFunctionCreator('UID')
 Rname2CppName <- function(rName, colonsOK = TRUE, maxLength = 250) {
     ## This will serve to replace and combine our former Rname2CppName and nameMashupFromExpr
     ## which were largely redundant
-    if (!is.character(rName)) {
-        browser()
+    if (!is.character(rName)) 
         rName <- deparse(rName)
-        }
+
     if( colonsOK) {
         # Substitute single colons but preserve double colons.
         rName <- gsub('::', '_DOUBLE_COLON_', rName)
@@ -264,8 +263,8 @@ Rname2CppName <- function(rName, colonsOK = TRUE, maxLength = 250) {
     rName <- gsub('^([[:digit:]])', 'd\\1', rName)    # if begins with a digit, add 'd' in front
     rName <- sapply(rName,
                     function(x) {
-                        if(nchar(x) > maxLength)  # cut off 50 extra to ensure result is less than maxLength so not subsequently modified 
-                            x <- paste0(substring(x, 1, maxLength), '_', CppNameLabelMaker())
+                        if(nchar(x) > maxLength && !grep("___TRUNC___", x)) 
+                            x <- paste0(substring(x, 1, maxLength), CppNameLabelMaker())
                         return(x)
                     })
     rName

--- a/packages/nimble/R/nimbleFunction_core.R
+++ b/packages/nimble/R/nimbleFunction_core.R
@@ -90,7 +90,6 @@ nimbleFunction <- function(setup         = NULL,
     }
 
     virtual <- FALSE
-
     # we now include the namespace in the name of the RefClass to avoid two nfs having RefClass of same name but existing in different namespaces
     if(is.na(name)) name <- nf_refClassLabelMaker(envName = environmentName(where))
     className <- name


### PR DESCRIPTION
This truncates long names in Rname2CppName.

Fixes issue #1039 