### PR TITLE
Auto block warning

### DIFF
--- a/UserManual/src/chapter_MCMC.Rmd
+++ b/UserManual/src/chapter_MCMC.Rmd
@@ -204,6 +204,8 @@ The default MCMC configuration includes monitors on all top-level stochastic nod
 
 #### Automated parameter blocking
 
+\emph{The automated parameter blocking algorithm is no longer actively maintained.  In some cases, it may not operate correctly with more recent system features and/or distributions.}
+
 The default configuration may be replaced by one generated from an automated parameter blocking algorithm.  This algorithm determines groupings of model nodes that, when jointly sampled with a `RW_block` sampler, increase overall MCMC efficiency.  Overall efficiency is defined as the effective sample size of the slowest-mixing node divided by computation time.  This is done by:
 
 ```{r, mcmcconf5, eval=FALSE}

--- a/packages/nimble/R/MCMC_autoBlock.R
+++ b/packages/nimble/R/MCMC_autoBlock.R
@@ -1,5 +1,7 @@
 #' Automated parameter blocking procedure for efficient MCMC sampling
 #' 
+#' The automated parameter blocking algorithm is no longer actively maintained.  In some cases, it may not operate correctly with more recent system features and/or distributions.
+#' 
 #' Runs NIMBLE's automated blocking procedure for a given model object, to dynamically determine a blocking scheme of the continuous-valued model nodes.  This blocking scheme is designed to produce efficient MCMC sampling (defined as number of effective samples generated per second of algorithm runtime).  See Turek, et al (2015) for details of this algorithm.  This also (optionally) compares this blocked MCMC against several static MCMC algorithms, including all univariate sampling, blocking of all continuous-valued nodes, NIMBLE's default MCMC configuration, and custom-specified blockings of parameters.
 #' 
 #' This method allows for fine-tuned usage of the automated blocking procedure.  However, the main entry point to the automatic blocking procedure is intended to be through either buildMCMC(..., autoBlock = TRUE), or configureMCMC(..., autoBlock = TRUE).
@@ -41,6 +43,7 @@ autoBlock <- function(Rmodel,
                       verbose = FALSE,
                       makePlots = FALSE,
                       round = TRUE ) {
+    cat('The autoBlock option is no longer actively maintained.  In some cases, it may not operate correctly with more recent system features and/or distributions\n.')
     if(autoIt < 10000) stop('Minimum auto-blocking iterations is 10,000')
     control <- list(niter=autoIt, setSeed=setSeed, verbose=verbose, makePlots=makePlots)
     ab <- autoBlockClass(Rmodel, control)

--- a/packages/nimble/R/MCMC_autoBlock.R
+++ b/packages/nimble/R/MCMC_autoBlock.R
@@ -43,7 +43,7 @@ autoBlock <- function(Rmodel,
                       verbose = FALSE,
                       makePlots = FALSE,
                       round = TRUE ) {
-    cat('The autoBlock option is no longer actively maintained.  In some cases, it may not operate correctly with more recent system features and/or distributions\n.')
+    cat('\nThe autoBlock option is no longer actively maintained.  In some cases, it may not operate correctly with more recent system features and/or distributions.\n\n')
     if(autoIt < 10000) stop('Minimum auto-blocking iterations is 10,000')
     control <- list(niter=autoIt, setSeed=setSeed, verbose=verbose, makePlots=makePlots)
     ab <- autoBlockClass(Rmodel, control)


### PR DESCRIPTION
Using the `autoBlock` MCMC option gives the following output:

`The autoBlock option is no longer actively maintained.  In some cases, it may not operate correctly with more recent system features and/or distributions.`

In addition, this same information was added to the User Manual, and the Roxygen documentation for `autoBlock`.