### PR TITLE
prevent use of WAIC when not monitoring all direct stochastic parents (direct parameters) of data nodes

### DIFF
--- a/UserManual/src/UserManualRefs.bib
+++ b/UserManual/src/UserManualRefs.bib
@@ -193,4 +193,16 @@ url = {http://www.stat.berkeley.edu/~paciorek/research/techVignettes/techVignett
   publisher={Taylor \& Francis}
 }
 
-
+@article{Ariyo_etal_2019,
+author = {Oludare Ariyo and Adrian Quintero and Johanna Muñoz and Geert Verbeke and Emmanuel Lesaffre},
+title = {Bayesian model selection in linear mixed models for longitudinal data},
+journal = {Journal of Applied Statistics},
+volume = {47},
+number = {5},
+pages = {890-913},
+year  = {2020},
+publisher = {Taylor & Francis},
+doi = {10.1080/02664763.2019.1657814},
+URL = {https://doi.org/10.1080/02664763.2019.1657814},
+eprint = {https://doi.org/10.1080/02664763.2019.1657814}
+}

--- a/UserManual/src/chapter_MCMC.Rmd
+++ b/UserManual/src/chapter_MCMC.Rmd
@@ -634,11 +634,12 @@ Cmcmc$calculateWAIC(nburnin = 100)
 ```
 
 Note that there is not a unique value of WAIC for a model. WAIC is calculated from
-Equations 5, 12, and 13 in [@Gelman_etal_2014] (i.e. using \emph{p}WAIC2). In NIMBLE, the set
-of all stochastic nodes monitored by the MCMC object will be treated as
-$\theta$ for the purposes of Equation 5 from [@Gelman_etal_2014].
+Equations 5, 12, and 13 in [@Gelman_etal_2014] (i.e., using \emph{p}WAIC2). The current version of NIMBLE only provides the conditional WAIC, namely the version of WAIC where all parameters directly involved in the likelihood are treated as
+$\theta$ for the purposes of Equation 5 from [@Gelman_etal_2014]. As a result, the user *must* set the MCMC monitors (via the `monitors` argument) to include all stochastic nodes that are parents of any data nodes; by default the MCMC monitors are only the top-level nodes of the model.
 
-In many cases one would want $\theta$ to be the set of all stochastic nodes in the model, in which case the user *must* set the MCMC monitors to include all stochastic nodes; by default the MCMC monitors are only the top-level nodes of the model.
+In some cases, one would want to calculate the marginal version of WAIC, integrating over latent variables, e.g., [@Ariyo_etal_2019]. NIMBLE does not currently provide this version of WAIC (although you could monitor the relevant nodes and carry out the calculations yourself based on the MCMC output).
+
+Also note that WAIC relies on a partition of the observations, i.e., 'pointwise' prediction. In NIMBLE the sum over log pointwise predictive density values treats each data node as contributing a single value to the sum. When a data node is multivariate, that data node contributes a single value to the sum based on the joint density of the elements in the node. Note that if one wants the WAIC calculation to be based on the joint likelihood for each group of observations (e.g., grouping the observations from each person or unit in a longitudinal data context), one would need to use a multivariate distribution for the observations in each group (potentially by writing a user-defined distribution).
 
 ## k-fold cross-validation
 

--- a/packages/nimble/R/BNP_samplers.R
+++ b/packages/nimble/R/BNP_samplers.R
@@ -1,31 +1,5 @@
 ## Used when syntax xi[1:N] ~ dCRP(conc) is used in BUGS.
 
-## FIXME: this is temporary function until we bring this into the full model API
-getParentNodes <- function(nodes, model, returnType = 'names', stochOnly = FALSE) {
-    ## adapted from BUGS_modelDef creation of edgesFrom2To
-    getParentNodesCore <- function(nodes, model, returnType = 'names', stochOnly = FALSE) {
-        nodeIDs <- model$expandNodeNames(nodes, returnType = "ids")
-        fromIDs <- sort(unique(unlist(edgesTo2From[nodeIDs])))
-        fromNodes <- maps$graphID_2_nodeName[fromIDs]
-        if(!length(fromNodes))
-            return(character(0))
-        fromNodesDet <- fromNodes[model$modelDef$maps$types[fromIDs] == 'determ']
-        ## Recurse through parents of deterministic nodes.
-        fromNodes <- c(if(stochOnly) fromNodes[model$modelDef$maps$types[fromIDs] == 'stoch'] else fromNodes, 
-                       if(length(fromNodesDet)) getParentNodesCore(fromNodesDet, model, returnType, stochOnly) else character(0))
-        fromNodes
-    }
-    
-    maps <- model$modelDef$maps
-    maxNodeID <- length(maps$vertexID_2_nodeID) ## should be same as length(maps$nodeNames)
-    ## Only determine edgesTo2From once and then obtain in getParentNodesCore via scoping.
-    edgesLevels <- if(maxNodeID > 0) 1:maxNodeID else numeric(0)
-    fedgesTo <- factor(maps$edgesTo, levels = edgesLevels) ## setting levels ensures blanks inserted into the splits correctly
-    edgesTo2From <- split(maps$edgesFrom, fedgesTo)
-
-    getParentNodesCore(nodes, model, returnType, stochOnly)
-}
-
 getNsave <- nimbleFunction(
   setup = function(mvSaved){
     niter <- 0

--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -56,28 +56,26 @@
 #' 
 #' The \code{calculateWAIC} method calculates the WAIC of the model that the
 #' MCMC was performed on. The WAIC (Watanabe, 2010) is calculated from
-#' Equations 5, 12, and 13 in Gelman et al. (2014) (i.e. using \emph{p}WAIC2).  The set
-#' of all stochastic nodes monitored by the MCMC object will be treated as
-#' \eqn{theta} for the purposes of Equation 5 from Gelman et al. (2014). 
-#' All non-monitored nodes downstream of the monitored nodes that are necessary
-#' to calculate \eqn{p(y|theta)} will be simulated from the posterior samples of 
-#' \eqn{theta}.  This allows customization of exactly what predictive 
-#' distribution \eqn{p(y|theta)} to use for calculations.  For more detail
-#' on the use of different predictive distributions, see Section 2.5 from Gelman et al.
-#' (2014). Note that by default only top-level stochastic nodes are monitored, but
-#' in many situations one would want to set monitors on all stochastic nodes so that
-#' all stochastic nodes are treated as \eqn{theta} for the WAIC calculation.
-#' 
-#' Note that there exist sets of monitored parameters that do not lead to valid
-#' WAIC calculations.  Specifically, for a valid WAIC calculation, every 
-#' node that a data node depends on must be either monitored, or be
-#' downstream from monitored nodes.  An easy way to ensure this is satisfied
-#' is to monitor all top-level parameters in a model (NIMBLE's default).  
-#' Another way to guarantee correctness is to monitor all nodes
-#' directly upstream from a data node. However, other combinations of monitored
-#' nodes are also valid.  If \code{enableWAIC = TRUE}, NIMBLE checks to see if
-#' the set of monitored nodes is valid, and returns an error if not.
-#' 
+#' Equations 5, 12, and 13 in Gelman et al. (2014) (i.e., using \emph{p}WAIC2).
+#'
+#' Note that there is not a unique value of WAIC for a model. The current version of
+#' NIMBLE only provides the conditional WAIC, namely the version of WAIC where all
+#' parameters directly involved in the likelihood are treated as \eqn{theta}
+#' for the purposes of Equation 5 from Gelman et al. (2014). As a result, the user
+#' must set the MCMC monitors (via the \code{monitors} argument) to include all stochastic
+#' nodes that are parents of any data nodes; by default the MCMC monitors are only
+#' the top-level nodes of the model. For more detail on the use of different predictive
+#' distributions, see Section 2.5 from Gelman et al. (2014) or Ariyo et al. (2019).
+
+#' Also note that WAIC relies on a partition of the observations, i.e., 'pointwise'
+#' prediction. In NIMBLE the sum over log pointwise predictive density values treats
+#' each data node as contributing a single value to the sum. When a data node is
+#' multivariate, that data node contributes a single value to the sum based on the
+#' joint density of the elements in the node. Note that if one wants the WAIC
+#' calculation to be based on the joint predictive density for each group of observations
+#' (e.g., grouping the observations from each person or unit in a longitudinal
+#' data context), one would need to use a multivariate distribution for the
+#' observations in each group (potentially by writing a user-defined distribution).
 #' 
 #' @examples
 #' \dontrun{
@@ -87,7 +85,7 @@
 #'     y ~ dnorm(x, 1)
 #' })
 #' Rmodel <- nimbleModel(code, data = list(y = 0))
-#' conf <- configureMCMC(Rmodel)
+#' conf <- configureMCMC(Rmodel, monitors = c('mu', 'x'))
 #' Rmcmc <- buildMCMC(conf, enableWAIC = TRUE)
 #' Cmodel <- compileNimble(Rmodel)
 #' Cmcmc <- compileNimble(Rmcmc, project=Rmodel)
@@ -106,6 +104,8 @@
 #' Watanabe, S. (2010). Asymptotic equivalence of Bayes cross validation and widely applicable information criterion in singular learning theory. \emph{Journal of Machine Learning Research} 11: 3571-3594.
 #' 
 #' Gelman, A., Hwang, J. and Vehtari, A. (2014). Understanding predictive information criteria for Bayesian models. \emph{Statistics and Computing} 24(6): 997-1016.
+#'
+#' Ariyo, O., Quintero, A., Munoz, J., Verbeke, G. and Lesaffre, E. (2019). Bayesian model selection in linear mixed models for longitudinal data. \emph{Journal of Applied Statistics} 47: 890-913.
 #' @export
 buildMCMC <- nimbleFunction(
     name = 'MCMC',

--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -142,7 +142,7 @@ buildMCMC <- nimbleFunction(
         enableWAIC <- enableWAICargument || conf$enableWAIC   ## enableWAIC comes from MCMC configuration, or from argument to buildMCMC
         if(enableWAIC) {
             if(dataNodeLength == 0)   stop('WAIC cannot be calculated, as no data nodes were detected in the model.')
-            mcmc_checkWAICmonitors(model = model, monitors = sampledNodes, dataNodes = dataNodes)
+            mcmc_checkWAICmonitors_conditional(model = model, monitors = sampledNodes, dataNodes = dataNodes)
         }
     },
 

--- a/packages/nimble/R/MCMC_utils.R
+++ b/packages/nimble/R/MCMC_utils.R
@@ -388,6 +388,7 @@ mcmc_processMonitorNames <- function(model, nodes) {
     return(c(expandedNodeNames, expandedLogProbNames))
 }
 
+## As of 0.10.1 stop WAIC if not monitoring all parameters of data nodes
 mcmc_checkWAICmonitors_conditional <- function(model, monitors, dataNodes) {
     parentNodes <- getParentNodes(dataNodes, model, stochOnly = TRUE)
     parentVars <- model$getVarNames(nodes = parentNodes)

--- a/packages/nimble/R/MCMC_utils.R
+++ b/packages/nimble/R/MCMC_utils.R
@@ -388,38 +388,22 @@ mcmc_processMonitorNames <- function(model, nodes) {
     return(c(expandedNodeNames, expandedLogProbNames))
 }
 
-
 mcmc_checkWAICmonitors_conditional <- function(model, monitors, dataNodes) {
-    monitoredDetermNodes <- model$expandNodeNames(monitors)[model$isDeterm(model$expandNodeNames(monitors))]
-    if(length(monitoredDetermNodes) > 0) {
-        monitors <- monitors[- which(monitors %in% model$getVarNames(nodes = monitoredDetermNodes))]
-    }
-    
-    thisNodes <- model$getNodeNames(stochOnly = TRUE, includeData = FALSE)
-    thisVars <- model$getVarNames(nodes = thisNodes)
-    thisVars <- thisVars[!(thisVars %in% monitors)]
-
-    ## No unmonitored nodes should have direct data dependencies.
-    badVars <- sapply(thisVars, function(oneVar) {
-        nextNodes <- model$getDependencies(oneVar, stochOnly = TRUE, omit = monitoredDetermNodes,
-                                           self = FALSE, includeData = TRUE)
-        if(any(dataNodes %in% nextNodes))
-            return(oneVar) else return(as.character(NA))
-    })
-    badVars <- badVars[!is.na(badVars)]
-
-    if(length(badVars) > 10) {
-        badVars <- c(badVars[1:10], "...")
-    }
-    if(length(badVars)) 
+    parentNodes <- getParentNodes(dataNodes, model, stochOnly = TRUE)
+    parentVars <- model$getVarNames(nodes = parentNodes)
+    wh <- which(!parentVars %in% monitors)
+    if(length(wh)) {
+        if(length(wh) > 10)
+            badVars <- c(parentVars[wh[1:10]], "...") else badVars <- parentVars[wh]
         stop(paste0("In calculate WAIC in NIMBLE, all parameters of",
                     " data nodes in the model must be monitored.", "\n", 
                     "  Currently, the following parameters are not monitored: ",
                     paste0(badVars, collapse = ", ")))
+    }
     message('Monitored nodes are valid for WAIC.')
 }
 
-
+## Used through version 0.10.0 and likely to be used in some form once we re-introduce mWAIC
 mcmc_checkWAICmonitors <- function(model, monitors, dataNodes) {
     monitoredDetermNodes <- model$expandNodeNames(monitors)[model$isDeterm(model$expandNodeNames(monitors))]
     if(length(monitoredDetermNodes) > 0) {

--- a/packages/nimble/R/MCMC_utils.R
+++ b/packages/nimble/R/MCMC_utils.R
@@ -395,7 +395,7 @@ mcmc_checkWAICmonitors_conditional <- function(model, monitors, dataNodes) {
     if(length(wh)) {
         if(length(wh) > 10)
             badVars <- c(parentVars[wh[1:10]], "...") else badVars <- parentVars[wh]
-        stop(paste0("In calculate WAIC in NIMBLE, all parameters of",
+        stop(paste0("To calculate WAIC in NIMBLE, all parameters of",
                     " data nodes in the model must be monitored.", "\n", 
                     "  Currently, the following parameters are not monitored: ",
                     paste0(badVars, collapse = ", ")))

--- a/packages/nimble/inst/tests/test-getDependencies.R
+++ b/packages/nimble/inst/tests/test-getDependencies.R
@@ -101,5 +101,38 @@ test_that("getDependencies in second model with some criss-crossing dependencies
     expect_identical(m2$getDependencies(c('c2','h1','c3')), ans4)
 })
 
+test_that("getParentNodes works", {
+    code=nimbleCode({
+        for(j in 1:J) {
+            for(i in 1:I)
+                y[j,i] ~ dnorm(theta[j], sigma)
+            theta[j] ~ dnorm(mu, sd = tau)
+        }
+        mu ~ dnorm(mu0,1)
+        mu0 <- mu00
+        sigma ~ dunif(sigma0,1)
+        sigma1 ~ dunif(0,1)
+        tau ~ dunif(0,1)
+    })
+    I <- 4
+    J <- 3
+    constants <- list(I = I, J = J)
+    m <- nimbleModel(code,
+                     data = list(y = matrix(rnorm(I*J), J, I)),
+                     constants = constants)
+    expect_identical(getParentNodes('mu', m, stochOnly =  TRUE), character(0))
+    expect_identical(getParentNodes('mu', m), c('mu0', 'mu00'))
+    expect_identical(getParentNodes('y', m, stochOnly = TRUE),
+                     c('theta[1]','theta[2]','theta[3]', 'sigma'))
+    expect_identical(getParentNodes('y', m),
+                     c('lifted_d1_over_sqrt_oPsigma_cP', 'theta[1]','theta[2]','theta[3]', 'sigma'))
+    expect_identical(getParentNodes('y[2, 1:3]', m, stochOnly = TRUE),
+                     c('theta[2]', 'sigma'))
+    expect_identical(getParentNodes('theta', m),
+                     c('tau', 'mu'))
+    
+})
+
+
 options(warn = RwarnLevel)
 nimbleOptions(verbose = nimbleVerboseSetting)

--- a/packages/nimble/inst/tests/test-waic.R
+++ b/packages/nimble/inst/tests/test-waic.R
@@ -38,15 +38,16 @@ test_that("school model WAIC is accurate", {
   CschoolSATmcmc <- compileNimble(schoolSATmcmc, project = schoolSATmodel)
   CschoolSATmcmc$run(50000)
   expect_equal(CschoolSATmcmc$calculateWAIC(), 61.8, tolerance = 2.0)
+
   schoolSATmcmcConf <- configureMCMC(schoolSATmodel, monitors = c('mu', 'itau'))
-  expect_message(buildMCMC(schoolSATmcmcConf, enableWAIC = TRUE), 
-  "Monitored nodes are valid for WAIC",
-  all = FALSE, fixed = TRUE)
-  schoolSATmcmcConf <- configureMCMC(schoolSATmodel, monitors = c('mu'))
-  expect_error(buildMCMC(schoolSATmcmcConf, enableWAIC = TRUE))
+  expect_error(buildMCMC(schoolSATmcmcConf, enableWAIC = TRUE), 
+               "To calculate WAIC in NIMBLE, all parameters")
+  ## mWAIC not enabled as of 0.10.1
+  ## schoolSATmcmcConf <- configureMCMC(schoolSATmodel, monitors = c('mu'))
+  ## expect_error(buildMCMC(schoolSATmcmcConf, enableWAIC = TRUE))
   ## different set of monitors than above, so different waic value expected
-  expect_equal(nimbleMCMC(model = schoolSATmodel, WAIC = TRUE)$WAIC, 67, 
-               tolerance = 8) 
+  ## expect_equal(nimbleMCMC(model = schoolSATmodel, WAIC = TRUE)$WAIC, 67, tolerance = 8) 
+
   schoolSATmcmcConf <- configureMCMC(schoolSATmodel, monitors = c('schoolmean'))
   schoolSATmcmc <- buildMCMC(schoolSATmcmcConf, enableWAIC = TRUE)
   CschoolSATmcmc <- compileNimble(schoolSATmcmc, project = schoolSATmodel, 
@@ -107,41 +108,36 @@ test_that("voter model WAIC is accurate", {
                            constants = constList,
                            inits = list(beta_1 = 44, beta_2 = 3.75, 
                                         sigma = 4.4))
+
   votermcmcConf <- configureMCMC(voterModel, monitors = c('beta_1',
                                                           'beta_2',
-                                                          'sigma'))
+                                                          'sigma_2'))
   expect_message(buildMCMC(votermcmcConf, enableWAIC = TRUE), 
                  "Monitored nodes are valid for WAIC",
                  all = FALSE, fixed = TRUE)
+
+  votermcmcConf <- configureMCMC(voterModel, monitors = c('beta_12',
+                                                          'beta_2',
+                                                          'sigma'))
+  expect_error(buildMCMC(votermcmcConf, enableWAIC = TRUE), 
+                 "To calculate WAIC in NIMBLE, all parameters")
   
-  votermcmcConf <- configureMCMC(voterModel, monitors = c('beta_1',
-                                                          'beta_2',
-                                                          'sigma_2'))
-  expect_message(buildMCMC(votermcmcConf, enableWAIC = TRUE), 
-                 "Monitored nodes are valid for WAIC",
-                 all = FALSE, fixed = TRUE)
-  votermcmcConf <- configureMCMC(voterModel, monitors = c('beta_1',
-                                                          'beta_2',
-                                                          'sigma',
-                                                          'sigma_2'))
-  expect_message(buildMCMC(votermcmcConf, enableWAIC = TRUE), 
-                 "Monitored nodes are valid for WAIC",
-                 all = FALSE, fixed = TRUE)
   votermcmcConf <- configureMCMC(voterModel, monitors = c('beta_12',
                                                           'beta_2',
                                                           'sigma_2'))
-  expect_message(buildMCMC(votermcmcConf, enableWAIC = TRUE), 
-                 "Monitored nodes are valid for WAIC",
-                 all = FALSE, fixed = TRUE)
+  expect_error(buildMCMC(votermcmcConf, enableWAIC = TRUE),
+                 "To calculate WAIC in NIMBLE, all parameters")
+
   votermcmcConf <- configureMCMC(voterModel, monitors = c('beta_12',
                                                           'beta_2',
                                                           'sigma'))
-  expect_message(buildMCMC(votermcmcConf, enableWAIC = TRUE), 
-                 "Monitored nodes are valid for WAIC",
-                 all = FALSE, fixed = TRUE)
+  expect_error(buildMCMC(votermcmcConf, enableWAIC = TRUE), 
+                 "To calculate WAIC in NIMBLE, all parameters")
+
   votermcmcConf <- configureMCMC(voterModel, monitors = c('beta_1',
                                                           'beta_2'))
-  expect_error(buildMCMC(votermcmcConf, enableWAIC = TRUE))
+  expect_error(buildMCMC(votermcmcConf, enableWAIC = TRUE),
+               "To calculate WAIC in NIMBLE, all parameters")
 })
 
 


### PR DESCRIPTION
Previously, any use of WAIC that did not monitor all direct stochastic parents would use a single draw of the missing stochastic parents. This is not a good Monte Carlo estimate of the expected marginal likelihood and therefore gave incorrect WAIC results. We now check for this case and error out if detected.

In a forthcoming release, we plan to greatly enhance WAIC functionality to include marginal WAIC, online calculation of WAIC, and options for how to group observations for the 'pointwise' calculation of the log predictive density. 