### PR TITLE
allow nimNumeric, nimMatrix and nimArray into models

### DIFF
--- a/packages/nimble/R/BUGS_BUGSdecl.R
+++ b/packages/nimble/R/BUGS_BUGSdecl.R
@@ -92,9 +92,11 @@ nimbleOrRfunctionNames <- c('[',
                             paste0(c('d','r','q','p'), 't'),
                             paste0(c('d','r','q','p'), 'exp'),
                             'nimC', 'nimRep', 'nimSeq', 'diag',
+                            'nimNumeric','nimMatrix','nimArray',
                             'length')
 
-functionsThatShouldNeverBeReplacedInBUGScode <- c(':','nimC','nimRep','nimSeq', 'diag')
+functionsThatShouldNeverBeReplacedInBUGScode <- c(':','nimC','nimRep','nimSeq', 'diag',
+                                                  'nimNumeric', 'nimMatrix', 'nimArray')
 
 #' BUGSdeclClass contains the information extracted from one BUGS declaration
 BUGSdeclClass <- setRefClass(


### PR DESCRIPTION
Not sure whey these were being error-trapped out of model code.  It appears they can work if they are let through error-trapping and also on the "never replace" (i.e. never make into a lifted node) list.

Am I forgetting any reason not to support these?  We might want to add some tests before merging.