### PR TITLE
Clean up commented-out code from no-longer-experimental changes

### DIFF
--- a/packages/nimble/R/BUGS_getDependencies.R
+++ b/packages/nimble/R/BUGS_getDependencies.R
@@ -1,12 +1,7 @@
-
-
-
 ## returns a list of all deterministic dependents up to the first stochastic dependent,
 ## omitting any nodes in 'omit', or down the path of 'omit' nodes
 ## works only in terms of vertex IDs, as in the igraph object.
 gd_getDependencies_IDs <- function(graph, maps, nodes, omit, downstream) {
-  # nonStochNodes <- which(maps$types != 'stoch') 		We should be able to speed things up by looking up by graphID instead of intersecting...
-
     nodes <- setdiff(nodes, omit)
     newNodes <- if(length(nodes) > 0)    unlist(maps$edgesFrom2To[nodes]) else integer(0)  ## first set of dependencies, including from LHSinferred
     newNodes <- setdiff(newNodes, omit)
@@ -23,8 +18,6 @@ gd_getDependencies_IDs <- function(graph, maps, nodes, omit, downstream) {
         nodes <- c(nodes, fullNodes)           ## add to nodes
 
         fullNodesForRecursion <- fullNodes
-      ##  fullNodesForRecursion <- if(downstream)   fullNodes   else  fullNodes[maps$types[fullNodes] != 'stoch'] ## find recursion nodes
-
         fullNodesDeps <- if(length(fullNodesForRecursion) > 0) unlist(maps$edgesFrom2To[fullNodesForRecursion]) else integer(0) ## get dependencies of x[1:10]
         
         fullNodesDepsLHSinferred <- maps$types[fullNodesDeps] == 'LHSinferred' ## filter out LHSinferred dependencies, e.g. x[2]
@@ -43,21 +36,6 @@ gd_getDependencies_IDs <- function(graph, maps, nodes, omit, downstream) {
     nodes <- unique(nodes)
     nodes <- sort(nodes)    # topological sort
     return(nodes)
-
-    ## old
-    ## nodes <- setdiff(nodes, omit)
-    ## newNodes <- if(length(nodes) > 0)    unlist(maps$edgesFrom2To[nodes]) else integer(0) 
-    ## newNodes <- setdiff(newNodes, omit)
-    ## while(length(newNodes) > 0) {
-    ##     nodes <- c(nodes, newNodes)
-    ##     newNodesForRecursion <- if(downstream)   newNodes   else  newNodes[maps$types[newNodes] != 'stoch'] 
-    ##     newNodes <- if(length(newNodesForRecursion) > 0)  unlist(maps$edgesFrom2To[newNodesForRecursion]) else integer(0) 
-    ##     newNodes <- setdiff(newNodes, omit)
-    ## }
-    ## nodes <- unique(nodes)
-    ## nodes <- sort(nodes)    # topological sort
-    ## return(nodes)
-
 }
 
 

--- a/packages/nimble/R/BUGS_graphNodeMaps.R
+++ b/packages/nimble/R/BUGS_graphNodeMaps.R
@@ -10,7 +10,6 @@ mapsClass <- setRefClass(
         notStoch = 'ANY',
         
         ## vectors of nodeNames, representing different subsets of 'types'
-
         nodeNamesLHSall = 'ANY',                 ## names of all nodes with node functions, i.e. all node names *except* RHSonly nodes
         nodeNamesRHSonly = 'ANY',                ## names of all nodes appearing on RHS only
         elementNames = 'ANY',
@@ -37,7 +36,6 @@ mapsClass <- setRefClass(
         vars2LogProbName =			'ANY',
 ##        vars2LogProbID = 			'ANY',
         
-        ##logProbIDs_2_LogProbName =	'ANY',
         ## positions vectors of nodeNames (top, latent, end)
         isEndNode_byGID = 'ANY',
 
@@ -72,13 +70,11 @@ assignLogProbName <- function(nodeInfo, nodeName2LogProbMap){
 
 mapsClass$methods(setPositions3 = function(graph) { ## graph not actually used any more!
     ## new version to work with XXX3 system from modelDefClass
-
     ## determine who has any stochastic dependents (descendents)
 
     boolAnyStochDep <- nimbleGraph$anyStochDependencies()
-
     boolAnyStochParent <- nimbleGraph$anyStochParents()
-        
+
     ## end nodes have no stochastic dependents
     ## top nodes have no stochastic ancestor
     ## latent nodes have a stochastic descendent and ancestor
@@ -91,7 +87,6 @@ mapsClass$methods(setPositions3 = function(graph) { ## graph not actually used a
     isEndNode_byGID[end_IDs] <<- TRUE
 
     NULL
-    
 })
 
 

--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -365,11 +365,6 @@ nodes: An optional character vector supplying a subset of nodes for which to ext
                                       }
                                       ## "includeData" argument to getVarNames (with default = TRUE)
                                       ## was removed by consensus, March 2017.
-                                      ## no uses of it anywhere in codebase, plus it errors out.
-                                      ##if(!includeData) {
-                                      ##    allData <- unlist(lapply(mget(ans, envir = tm$isDataEnv, inherits = FALSE, ifnotfound = TRUE), all))
-                                      ##    ans <- ans[!allData]
-                                      ##}
     	                              return(ans)
                                   },
 
@@ -497,19 +492,6 @@ unique: should names be the unique names or should original ordering of nodes (a
                                       if(length(nodes) == 0) return(if(returnType=='names') character() else numeric())
                                       graphID <- modelDef$nodeName2GraphIDs(nodes, !returnScalarComponents, unique = unique, ignoreNotFound = TRUE)
                                       expandNodeNamesFromGraphIDs(graphID, returnScalarComponents, returnType, sort)
-                                      ## if(sort)
-                                      ##     graphID <- sort(graphID)
-                                      ## if(returnType == 'names'){
-                                      ##     if(returnScalarComponents) nodeNames <- modelDef$maps$elementNames[graphID] ## these are really elementIDs
-                                      ##     else nodeNames <- modelDef$maps$graphID_2_nodeName[graphID]
-                                      ##     return(nodeNames)
-                                      ## }
-                                      ## if(returnType == 'ids'){
-                                      ##     if(returnScalarComponents) print("NIMBLE development warning: returning IDs of scalar components may not be meaningful.  Checking to see if we ever see this message.")
-                                      ##     return(graphID)
-                                      ## }
-                                      ## if(!(returnType %in% c('ids','names')))
-                                      ## 	stop('instead expandNodeNames, imporper returnType chosen')
                                   },
 
                                   topologicallySortNodes = function(nodes, returnType = 'names') {
@@ -524,7 +506,7 @@ returnType: character vector indicating return type. Choices are "names" or "ids
 
 Details: This function merely reorders its input argument.  This may be inportany prior to calls such as simulate(model, nodes) or calculate(model, nodes), to enforce that the operation is performed in topological order.
 '
-                                      nodeIDs <- expandNodeNames(nodes, returnType = 'ids')			#modelDef$maps$nodeName_2_graphID[nodes]
+                                      nodeIDs <- expandNodeNames(nodes, returnType = 'ids')
                                       nodeIDs <- sort(nodeIDs)
                                       nodeNames <- expandNodeNames(nodeIDs, returnType = returnType)
                                       return(nodeNames)
@@ -757,17 +739,7 @@ returnScalar Componenets: Logical argument specifying whether multivariate nodes
 Details: The downward search for dependent nodes propagates through deterministic nodes, but by default will halt at the first level of stochastic nodes encountered.
 '
                                       if(inherits(nodes, 'character')) {
-                                          ## elementIDs <- modelDef$nodeName2GraphIDs(nodes, !returnScalarComponents)
-                                          ## if(returnScalarComponents)
-                                          ##    # nodeIDs <- .Internal(unique(modelDef$maps$elementID_2_vertexID[elementIDs],     ## turn into IDs in the graph
-                                          ##     nodeIDs <- unique(modelDef$maps$elementID_2_vertexID[elementIDs],     ## turn into IDs in the graph
-                                          ##                          FALSE,
-                                          ##                          FALSE,
-                                          ##                          NA)
-                                          ## else
-                                          ##     nodeIDs <- elementIDs
-
-                                          ## experimental: always start from scalar components
+                                          ## always start from scalar components
                                           elementIDs <- modelDef$nodeName2GraphIDs(nodes, FALSE)
                                           nodeIDs <- unique(modelDef$maps$elementID_2_vertexID[elementIDs],     ## turn into IDs in the graph
                                                             FALSE,
@@ -777,15 +749,7 @@ Details: The downward search for dependent nodes propagates through deterministi
                                       else if(inherits(nodes, 'numeric'))
                                           nodeIDs <- nodes
 
-                                      if(inherits(omit, 'character')) { ## mimic above if it works
-                                      ##     elementIDs <- modelDef$nodeName2GraphIDs(omit, !returnScalarComponents)
-                                      ##     if(returnScalarComponents)
-                                      ##         omitIDs <- unique(modelDef$maps$elementID_2_vertexID[elementIDs],
-                                      ##                              FALSE,
-                                      ##                              FALSE,
-                                      ##                              NA)
-                                      ##     else
-                                      ##         omitIDs <- elementIDs
+                                      if(inherits(omit, 'character')) { ## mimic above
                                           elementIDs <- modelDef$nodeName2GraphIDs(omit, FALSE)
                                           omitIDs <- unique(modelDef$maps$elementID_2_vertexID[elementIDs],     ## turn into IDs in the graph
                                                             FALSE,
@@ -794,17 +758,14 @@ Details: The downward search for dependent nodes propagates through deterministi
                                       }
                                       else if(inherits(omit, 'numeric'))
                                           omitIDs <- omit
-
-## new C++ version
+## Go into C++
  depIDs <- modelDef$maps$nimbleGraph$getDependencies(nodes = nodeIDs, omit = if(is.null(omitIDs)) integer() else omitIDs, downstream = downstream)
-
-## ## Uncomment these lines to catch discrepancies between the old and new systems.
+## ## Uncomment these lines to catch discrepancies between the C++ and R systems.
 ## depIDs <- nimble:::gd_getDependencies_IDs(graph = getGraph(), maps = getMaps(all = TRUE), nodes = nodeIDs, omit = omitIDs, downstream = downstream)
 ## if(!identical(as.numeric(depIDsOld), as.numeric(depIDs))) {
 ##     cat('caught a discrepancy for depIDs')
 ##     browser()
 ## }
-
                                       if(!includeRHSonly) depIDs <- depIDs[modelDef$maps$types[depIDs] != 'RHSonly']
                                       if(determOnly)	depIDs <- depIDs[modelDef$maps$types[depIDs] == 'determ']
                                       if(stochOnly)	depIDs <- depIDs[modelDef$maps$types[depIDs] == 'stoch']
@@ -873,16 +834,6 @@ inits: A named list.  The names of list elements must correspond to model variab
                                           } else  .self[[names(inits)[i]]] <- inits[[i]]
                                       }
                                   },
-
-
-                                  ## original (older) version of checkConjugacy(), deprecated
-                                  ## DT, Nov. 2016
-                                  ##checkConjugacy = function(nodeVector) {
-                                  ##    if(missing(nodeVector))
-                                  ##        nodeVector <- getNodeNames(stochOnly=TRUE, includeData=FALSE)
-                                  ##    nodeVector <- expandNodeNames(nodeVector)
-                                  ##    nimble:::conjugacyRelationshipsObject$checkConjugacy(.self, nodeVector)
-                                  ##},
                                   checkConjugacy = function(nodeVector, restrictLink = NULL) {
                                       '
 Determines whether or not the input nodes appear in conjugate relationships
@@ -907,9 +858,7 @@ Checks for size/dimension mismatches and for presence of NAs in model variables 
                                               declInfo <- .self$modelDef$declInfo[[j]]
                                               nn <- length(declInfo$nodeFunctionNames)
                                               nfn <- declInfo$nodeFunctionNames[nn]
-                                              ## NEWNODEFXNS
                                               nf <- .self$nodeFunctions[[j]]
-                                              #context <- as.list(declInfo$unrolledIndicesMatrix[nrow(declInfo$unrolledIndicesMatrix), ])
 
                                               if(declInfo$type == 'determ') {
                                                   # check LHS and RHS are same size/dim
@@ -1049,7 +998,6 @@ Checks for errors in model specification and for missing values that prevent use
                                               if(!nimble:::isValid(.self[[v]]) || !nimble:::isValid(getLogProb(setdiff(expandNodeNames(v), modelDef$maps$nodeNamesRHSonly))))
                                                   varsToCheck <- c(varsToCheck, v)
                                           badVars <- list(na=character(), nan=character(), inf=character())
-                                      ##nns <- getNodeNames(includeRHSonly = TRUE)
                                           nns <- expandNodeNames(varsToCheck)
                                           nns <- topologicallySortNodes(nns)   ## should be unnecessary; just in case
                                           for(nn in nns) {
@@ -1308,8 +1256,6 @@ RMakeCustomModelClass <- function(vars, className, isDataVars, modelDef, where =
                 callSuper(modelDef = inputList$modelDef, ...)
                 setupDefaultMV()
                 init_isDataEnv()
-                # setData(modelDef$constantsList, warnAboutMissingNames = FALSE)
-                # removed given new handling of lumped data and constants
             }
         ), where = where),
                     list(FIELDS = makeBUGSclassFields(varnames, vars)

--- a/packages/nimble/R/BUGS_readBUGS.R
+++ b/packages/nimble/R/BUGS_readBUGS.R
@@ -92,13 +92,6 @@ nimbleModel <- function(code,
         is.numeric(x) || is.logical(x) ||
             (is.data.frame(x) && all(sapply(x, 'is.numeric'))) })))
         stop("BUGSmodel: elements of 'data' must be numeric")
-    ## constantLengths <- unlist(lapply(constants, length))
-    ## if(any(constantLengths > 1)) {
-    ##     iLong <- which(constantLengths > 1)
-    ##     message(paste0('Constant(s) ', paste0(names(constants)[iLong], sep=" ", collapse = " "), ' are non-scalar and will be handled as inits.'))
-    ##     inits <- c(inits, constants[iLong])
-    ##     constants[iLong] <- NULL
-    ## }
     md <- modelDefClass$new(name = name)
     if(nimbleOptions('verbose')) message("defining model...")
     md$setupModel(code=code, constants=constants, dimensions=dimensions, inits = inits, data = data, userEnv = userEnv, debug=debug)
@@ -393,14 +386,9 @@ readBUGSmodel <- function(model, data = NULL, inits = NULL, dir = NULL, useInits
   }
   if(is.null(data)) {
       possibleNames <- paste0(modelName, c("-data.R", "-data.txt", "data"))
-          ## c(
-          ##              file.path(dir, paste0(modelName, "-data.R")),
-          ##              file.path(dir, paste0(modelName, "-data.txt")),
-          ##              file.path(dir, paste0(modelName, "-data")))
     if(!Sys.info()['sysname'] %in% c("Darwin", "Windows")) # UNIX-like is case-sensitive
         possibleNames <- c(possibleNames,
                            paste0(modelName, "-data.r"))
-##                         file.path(dir, paste0(modelName, "-data.r")))
       if(!skip.file.path) possibleNames <- normalizePath(file.path(dir, possibleNames), winslash = "\\", mustWork=FALSE)
       fileExistence <- file.exists(possibleNames)
       if(sum(fileExistence) > 1)

--- a/packages/nimble/R/BUGS_utils.R
+++ b/packages/nimble/R/BUGS_utils.R
@@ -331,8 +331,4 @@ is.Cmodel <- function(obj, inputIsName = FALSE) {
     return(inherits(obj, 'CmodelBaseClass'))
 }
 
-# extracts dimension from character vec of form such as c("double(0)", "integer(1)")
-## getDimFromType <- function(text) {
-##     sapply(parse(text = text), '[[', 2)
-## }
 

--- a/packages/nimble/R/MCEM_build.R
+++ b/packages/nimble/R/MCEM_build.R
@@ -7,7 +7,6 @@ calc_asympVar = nimbleFunction(
     calc_E_llk <- calc_E_llk_gen(model, fixedNodes = fixedNodes, sampledNodes = sampledNodes, burnIn = 0, mvSample = mvBlock)
   },
   run = function(nsamps = integer(0), theta = double(1), oldTheta = double(1)){
-    ##declare(svals, double(1, numReps))
     svals <- numeric(numReps, init=FALSE)
     l <- ceiling(min(1000, (nsamps - burnIn)/20)) #length of each block, ensures it's not too big
     q <- (nsamps - burnIn) - l + 1 #total number of blocks available to sample from

--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -316,13 +316,7 @@ sampler_RW <- nimbleFunction(
                 print("Please set 'nimbleOptions(MCMCsaveHistory = TRUE)' before building the MCMC")
                 return(numeric(1, 0))
             }
-        },          
-        ##getScaleHistoryExpanded = function() {                                                 ## scaleHistory
-        ##    scaleHistoryExpanded <- numeric(timesAdapted*adaptInterval, init=FALSE)            ## scaleHistory
-        ##    for(iTA in 1:timesAdapted)                                                         ## scaleHistory
-        ##        for(j in 1:adaptInterval)                                                      ## scaleHistory
-        ##            scaleHistoryExpanded[(iTA-1)*adaptInterval+j] <- scaleHistory[iTA]         ## scaleHistory
-        ##    returnType(double(1)); return(scaleHistoryExpanded) },                             ## scaleHistory
+        },
         reset = function() {
             scale <<- scaleOriginal
             timesRan      <<- 0
@@ -488,18 +482,6 @@ sampler_RW_block <- nimbleFunction(
             returnType(double(3))
             return(propCovHistory)
         },
-        ##getScaleHistoryExpanded = function() {                                                              ## scaleHistory
-        ##    scaleHistoryExpanded <- numeric(timesAdapted*adaptInterval, init=FALSE)                         ## scaleHistory
-        ##    for(iTA in 1:timesAdapted)                                                                      ## scaleHistory
-        ##        for(j in 1:adaptInterval)                                                                   ## scaleHistory
-        ##            scaleHistoryExpanded[(iTA-1)*adaptInterval+j] <- scaleHistory[iTA]                      ## scaleHistory
-        ##    returnType(double(1)); return(scaleHistoryExpanded) },                                          ## scaleHistory
-        ##getPropCovHistoryExpanded = function() {                                                            ## scaleHistory
-        ##    propCovHistoryExpanded <- array(dim=c(timesAdapted*adaptInterval,d,d), init=FALSE)              ## scaleHistory
-        ##    for(iTA in 1:timesAdapted)                                                                      ## scaleHistory
-        ##        for(j in 1:adaptInterval)                                                                   ## scaleHistory
-        ##            propCovHistoryExpanded[(iTA-1)*adaptInterval+j,1:d,1:d] <- propCovHistory[iTA,1:d,1:d]  ## scaleHistory
-        ##    returnType(double(3)); return(propCovHistoryExpanded) },                                        ## scaleHistory
         reset = function() {
             scale   <<- scaleOriginal
             propCov <<- propCovOriginal

--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -317,6 +317,12 @@ sampler_RW <- nimbleFunction(
                 return(numeric(1, 0))
             }
         },
+        ##getScaleHistoryExpanded = function() {                                                 ## scaleHistory
+        ##    scaleHistoryExpanded <- numeric(timesAdapted*adaptInterval, init=FALSE)            ## scaleHistory
+        ##    for(iTA in 1:timesAdapted)                                                         ## scaleHistory
+        ##        for(j in 1:adaptInterval)                                                      ## scaleHistory
+        ##            scaleHistoryExpanded[(iTA-1)*adaptInterval+j] <- scaleHistory[iTA]         ## scaleHistory
+        ##    returnType(double(1)); return(scaleHistoryExpanded) },                             ## scaleHistory
         reset = function() {
             scale <<- scaleOriginal
             timesRan      <<- 0
@@ -482,6 +488,18 @@ sampler_RW_block <- nimbleFunction(
             returnType(double(3))
             return(propCovHistory)
         },
+        ##getScaleHistoryExpanded = function() {                                                              ## scaleHistory
+        ##    scaleHistoryExpanded <- numeric(timesAdapted*adaptInterval, init=FALSE)                         ## scaleHistory
+        ##    for(iTA in 1:timesAdapted)                                                                      ## scaleHistory
+        ##        for(j in 1:adaptInterval)                                                                   ## scaleHistory
+        ##            scaleHistoryExpanded[(iTA-1)*adaptInterval+j] <- scaleHistory[iTA]                      ## scaleHistory
+        ##    returnType(double(1)); return(scaleHistoryExpanded) },                                          ## scaleHistory
+        ##getPropCovHistoryExpanded = function() {                                                            ## scaleHistory
+        ##    propCovHistoryExpanded <- array(dim=c(timesAdapted*adaptInterval,d,d), init=FALSE)              ## scaleHistory
+        ##    for(iTA in 1:timesAdapted)                                                                      ## scaleHistory
+        ##        for(j in 1:adaptInterval)                                                                   ## scaleHistory
+        ##            propCovHistoryExpanded[(iTA-1)*adaptInterval+j,1:d,1:d] <- propCovHistory[iTA,1:d,1:d]  ## scaleHistory
+        ##    returnType(double(3)); return(propCovHistoryExpanded) },                                        ## scaleHistory
         reset = function() {
             scale   <<- scaleOriginal
             propCov <<- propCovOriginal

--- a/packages/nimble/R/MCMC_utils.R
+++ b/packages/nimble/R/MCMC_utils.R
@@ -206,10 +206,6 @@ calcAdaptationFactor <- nimbleFunction(
     )
 )
 
-
-
-
-
 # for now export this as R<3.1.2 give warnings if don't
 
 #' Class \code{codeBlockClass}
@@ -317,32 +313,6 @@ extractControlElement <- function(controlList, elementName, defaultValue, error)
     }
 }
 
-
-## obselete, since control defaults were moved to sampler function setup code
-## -DT July 2017
-##mcmc_findControlListNamesInCode <- function(code) {
-##    if(is.function(code))     return(mcmc_findControlListNamesInCode(body(code)))
-##    if(is.name(code) || is.numeric(code) || is.logical(code) || is.character(code) || is.pairlist(code))     return(character())
-##    if(is.call(code)) {
-##        if(code[[1]] == '$' && code[[2]] == 'control') {
-##            if(is.name(code[[3]])) { return(as.character(code[[3]]))
-##            } else                 { warning(paste0('having trouble processing control list elements: ', deparse(code)))
-##                                     return(character()) }
-##        }
-##        if(code[[1]] == '[[' && code[[2]] == 'control') {
-##            if(is.character(code[[3]])) { return(as.character(code[[3]]))
-##            } else                 { warning(paste0('having trouble processing control list elements: ', deparse(code)))
-##                                     return(character()) }
-##        }
-##        ## code is some call, other than $ or [[
-##        return(unique(unlist(lapply(code, mcmc_findControlListNamesInCode))))
-##    }
-##    browser()
-##    stop('not sure how to handle this code expression')
-##}
-
-
-
 #' @export
 samplesSummary <- function(samples, round) {
     summary <- try(cbind(
@@ -434,42 +404,6 @@ mcmc_checkWAICmonitors <- function(model, monitors, dataNodes) {
     }
     message('Monitored nodes are valid for WAIC')
 }
-
-
-## formerly used in conf$printSamplers(byType = TRUE)
-## to compress scalar index ranges of variables.
-## deprecated Nov 2019.
-##mcmc_compressIndexRanges <- function(nums) {
-##    nums <- sort(unique(nums))
-##    rangeStartInd <- c(1, which(diff(nums) != 1) + 1)
-##    ranges <- vector('list', length(rangeStartInd))
-##    for(i in seq_along(rangeStartInd)) {
-##        startInd <- rangeStartInd[i]
-##        if(i == length(rangeStartInd)) {
-##            if(rangeStartInd[i] == length(nums)) {
-##                ranges[[i]] <- nums[startInd]
-##            } else {
-##                ranges[[i]] <- substitute(START:END, list(START = as.numeric(nums[startInd]),
-##                                                          END = as.numeric(nums[length(nums)])))
-##            }
-##        } else {
-##            if(startInd+1 < rangeStartInd[i+1]) {
-##                ranges[[i]] <- substitute(START:END, list(START = as.numeric(nums[startInd]),
-##                                                          END = as.numeric(nums[rangeStartInd[i+1]-1])))
-##            } else ranges[[i]] <- nums[startInd]
-##        }
-##    }
-##    return(ranges)
-##}
-##
-##
-##mcmc_getIndexNumberFromNodeNames <- function(nodeNames, indNumber) {
-##    (nodeInsideBrackets <- gsub('^[[:alpha:]]+\\[(.+)\\]$', '\\1', nodeNames))
-##    splitList <- strsplit(nodeInsideBrackets, ',')
-##    if(length(splitList[[1]]) < indNumber) stop('in mcmc_getIndexNumberFromNodeNames: indNumber exceeds node dimension', call. = FALSE)
-##    indices <- as.numeric(sapply(splitList, function(el) el[indNumber]))
-##    return(indices)
-##}
 
 
 

--- a/packages/nimble/R/NF_utils.R
+++ b/packages/nimble/R/NF_utils.R
@@ -208,7 +208,3 @@ identityMatrix <- nimbleFunction(
         returnType(double(2))
         return(arr)
     })
-
-
-
-

--- a/packages/nimble/R/cppDefs_core.R
+++ b/packages/nimble/R/cppDefs_core.R
@@ -227,7 +227,7 @@ cppClassDef <- setRefClass('cppClassDef',
 ## The parse tree can be either an R parse tree or one of our exprClass objects
 cppCodeBlock <- setRefClass('cppCodeBlock',
                             fields = list(typeDefs = 'ANY', objectDefs = 'ANY', code = 'ANY', skipBrackets = 'ANY',
-                                          cppADCode = 'ANY', generatorSymTab = 'ANY'),			#'logical'),
+                                          cppADCode = 'ANY', generatorSymTab = 'ANY'),
                             methods = list(
                                 generate = function(indent = '', ...) {
                                     if(inherits(typeDefs, 'uninitializedField')) typeDefs <<- list()
@@ -239,7 +239,7 @@ cppCodeBlock <- setRefClass('cppCodeBlock',
                                     objectDefsToUse <- if(inherits(objectDefs, 'symbolTable')) objectDefs$symbols else objectDefs
                                     if(length(objectDefsToUse) > 0) {
                                         outputCppCode <- c(outputCppCode, paste0(indent, generateObjectDefs(objectDefsToUse),';'))
-                                    } ##else outputCppCode <- list()
+                                    } 
 
                                     if(inherits(code, 'exprClass')) {
                                         if(inherits(generatorSymTab, 'symbolTable')) useSymTab <- generatorSymTab

--- a/packages/nimble/R/cppDefs_nimbleFunction.R
+++ b/packages/nimble/R/cppDefs_nimbleFunction.R
@@ -156,7 +156,6 @@ cppNimbleClassClass <- setRefClass('cppNimbleClassClass',
                                            cppCopyTypes <- makeNimbleFxnCppCopyTypes(nimCompProc$getSymbolTable(), objectDefs$getSymbolNames())
                                            copyFromRobjectDefs <- makeCopyFromRobjectDef(className = nfProc$name, cppCopyTypes)
                                            functionDefs[['copyFromRobject']] <<- copyFromRobjectDefs$copyFromRobjectDef
-                                          ## SEXPmemberInterfaceFuns[['copyFromRobject']] <<- copyFromRobjectDefs$copyFromRobjectInterfaceDef
                                        },
                                        buildAll = function(where = where) {
                                            makeCppNames()

--- a/packages/nimble/R/cppDefs_outputCppFromRparseTree.R
+++ b/packages/nimble/R/cppDefs_outputCppFromRparseTree.R
@@ -31,7 +31,6 @@ ModifiedRmmParseKeywords2 <- c( structure( as.list(rep('outputCppBinaryOperation
                                    '(' = 'outputCppOpenParentheses2',
                                    'cppOpenParentheses' = 'outputCppOpenParentheses2', 'if' = 'outputCppIfElse2', '{' = 'outputCppOpenBracketInvisible',
                                    scopeBlock = 'outputCppOpenBracket2',
-                                   ##'[[' = 'outputCppArrayIndex2',
                                    '[' = 'outputCppArrayIndex2', 'cppFor' = 'outputCppFor2', 'cppDereference' = 'outputCppDereference2',
                                    'cppReference' = 'outputCppReference2', 'cppCommentBlock' = 'outputCppCommentBlock2', 'cppCout' = 'outputCppCout2',
                                    'c' = 'outputCppTempArray2', 'cppExit' = 'outputCppExit2', 'cppWhile' = 'outputCppWhile2', 'cppScopeResolution' = 'outputCppScopeResolution2',

--- a/packages/nimble/R/cppInterfaces_modelValues.R
+++ b/packages/nimble/R/cppInterfaces_modelValues.R
@@ -34,7 +34,6 @@ CmodelValues <- setRefClass(
         varNames = 'ANY',
         componentExtptrs = 'ANY',
         blankAns = 'ANY',
-        ##.nodePtrs_byGID = 'ANY',
         GID_map = 'ANY',
         symTab = 'ANY',
         initialized = 'ANY',
@@ -58,8 +57,6 @@ CmodelValues <- setRefClass(
         },
         expandNodeNames = function (nodeNames, returnType = "names", flatIndices = TRUE)  {
             stop('There was a call to expandNodeNames for a compiled modelValues object.\n  This is deprecated and should not have occurred.\n  Please contact nimble developers at the nimble-users google group or at nimble.stats@gmail.com to let them know this happened.  \n Thank you.')
-##            return(GID_map$expandNodeNames(nodeNames = nodeNames, returnType = returnType, 
-##                                           flatIndices = flatIndices))
         },
         finalizeInternal = function() {
             finalize()
@@ -82,7 +79,6 @@ CmodelValues <- setRefClass(
                 extptr <<- extptrlist[[1]]
                 namedObjectsPtr <<- extptrlist[[3]] ## order should come from the cppDef, but cheating here to get it right
                 eval(call('.Call',nimbleUserNamespace$sessionSpecificDll$register_namedObjects_Finalizer, namedObjectsPtr, dll[['handle']], 'modelValues'))
-#                extptr <<- .Call(buildCall)
             }
             else{
                 extptr <<- existingPtr

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -2060,16 +2060,12 @@ sizeScalar <- function(code, symTab, typeEnv) {
     if(code$args[[1]]$toEigenize == 'yes') {
         asserts <- c(asserts, sizeInsertIntermediate(code, 1, symTab, typeEnv))
     }
-    ## else {
-    ##     asserts <- NULL
-    ## }
     code$nDim <- 0
     outputType <- scalarOutputTypes[[code$name]]
     if(is.null(outputType)) code$type <- 'double'
     else code$type <- outputType
     code$sizeExprs <- list()
     code$toEigenize <- 'maybe' ## a scalar can be eigenized or not
-    ##invisible(NULL)
     asserts
 }
 
@@ -3350,67 +3346,6 @@ sizePassByMap <- function(code, symTab, typeEnv) {
     typeEnv$.ensureNimbleBlocks <- ensureNimbleBlocks
     asserts
 }
-
-###
-## This function would be called with arguments from an RCfunction or nimbleFunction
-## the functions dim and length would be taken over to work on the sizeExprs.
-## but for now it can just return NAs for size expressions, and then the new returned value will have default size expressions (dim(name)[1], etc)
-##
-## generalFunSizeHandler <- function(code, symTab, typeEnv, returnType, args, chainedCall = FALSE) {
-##     useArgs <- unlist(lapply(args, function(x) as.character(x[[1]]) %in% c('double', 'integer', 'logical')))
-    
-##     if(chainedCall) useArgs <- c(FALSE, useArgs)
-##     if(length(code$args) != length(useArgs)) {
-##         stop(exprClassProcessingErrorMsg(code, 'In generalFunSizeHandler: Wrong number of arguments.'), call. = FALSE)
-##     }
-##     ## Note this is NOT checking the dimensions of each arg. useArgs just means it will recurse on that and lift or do as needed
-    
-##     asserts <- recurseSetSizes(code, symTab, typeEnv, useArgs)
-
-##     ## lift any argument that is an expression
-##     for(i in seq_along(code$args)) {
-##         if(useArgs[i]) {
-##             if(inherits(code$args[[i]], 'exprClass')) {
-##                 if(!code$args[[i]]$isName) {
-##                     asserts <- c(asserts, sizeInsertIntermediate(code, i, symTab, typeEnv) )
-##                 }
-##             }
-##         }
-##     }
-##     if(inherits(returnType, 'symbolNimbleList')) {
-##         code$type <- 'nimbleList'
-##         code$sizeExprs <- returnType
-##         code$toEigenize <- 'maybe'
-##         code$nDim <- 0
-##         liftIfAmidExpression <- TRUE
-##     } else {
-##         returnSymbolBasic <- inherits(returnType, 'symbolBasic')
-##         returnTypeLabel <- if(returnSymbolBasic) returnType$type else as.character(returnType[[1]])
-        
-##         if(returnTypeLabel == 'void') {
-##             code$type <- returnTypeLabel
-##             code$toEigenize <- 'unknown'
-##             return(asserts)
-##         }
-##         returnNDim <- if(returnSymbolBasic) returnType$nDim
-##                       else if(length(returnType) > 1) as.numeric(returnType[[2]]) else 0
-                                                                
-##         returnSizeExprs <- vector('list', returnNDim) ## This stays blank (NULLs), so if assigned as a RHS, the LHS will get default sizes
-##         code$type <- returnTypeLabel
-##         code$nDim <- returnNDim
-##         code$sizeExprs <- returnSizeExprs
-##         code$toEigenize <- if(code$nDim == 0) 'maybe' else 'no'
-##         liftIfAmidExpression <- code$nDim > 0
-##     }
-    
-##     if(liftIfAmidExpression) {
-##         if(!(code$caller$name %in% c('{','<-','<<-','='))) {
-##             asserts <- c(asserts, sizeInsertIntermediate(code$caller, code$callerArgID, symTab, typeEnv))
-##         } else
-##             typeEnv$.ensureNimbleBlocks <- TRUE
-##     }
-##     return(asserts)
-## }
 
 generalFunSizeHandlerFromSymbols <- function(code, symTab, typeEnv, returnSymbol, argSymTab, chainedCall = FALSE) {
     ## symbols should be in order

--- a/packages/nimble/R/initializeModel.R
+++ b/packages/nimble/R/initializeModel.R
@@ -64,8 +64,6 @@ initializeModel <- nimbleFunction(
         graphIDs <- graphIDs[!bool]
         rm(allNodes)
         rm(allTypes)
-#        LHSnodes <- model$getNodeNames()
-#        nodeTypes <- model$getNodeType(LHSnodes)
         bool <- nodeTypes == "stoch"
         typeCode <- c(ifelse(nodeTypes == "determ", 1,
                       ifelse(bool, 2,
@@ -95,8 +93,6 @@ initializeModel <- nimbleFunction(
                 }
             }
         }
-        ## removed trailing full model$calculate() -DT Feb. 2019
-        ##model$calculate(LHSnodes)
     },
     methods = list(
         initialize_deterministic = function(i = integer()) {
@@ -154,56 +150,4 @@ checkRHSonlyInit <- nimbleFunction(
         if(any_na(vals) | any_nan(vals)) print('warning: value in right-hand-side-only variable is NA or NaN, in variable: ', variable)
     }
 )
-
-## determNodeInit <- nimbleFunction(
-##     name = 'determNodeInit',
-##     contains = nodeInit_virtual,
-##     setup = function(model, node, silent) {},
-##     run = function() {
-##         nodeValue <- values(model, node)
-##         if(is.na.vec(nodeValue) | is.nan.vec(nodeValue)) calculate(model, node)
-##         nodeValue <- values(model, node)
-##         if(is.na.vec(nodeValue) | is.nan.vec(nodeValue)) print('warning: value of deterministic node ',node,': value is NA or NaN even after trying to calculate.')
-##     }
-## )
-
-## stochDataNodeInit <- nimbleFunction(
-##     name = 'stochDataNodeInit',
-##     contains = nodeInit_virtual,
-##     setup = function(model, node, silent) {},
-##     run = function() {
-##         nodeValue <- values(model, node)
-##         if(is.na.vec(nodeValue) | is.nan.vec(nodeValue)) print('warning: value of data node ',node,': value is NA or NaN.')
-##         lp <- calculate(model, node)
-##         if(is.na(lp) | is.nan(lp)) print('warning: logProb of data node ', node, ': logProb is NA or NaN.')
-##         if(!(is.na(lp) | is.nan(lp))) {
-##             if(lp == -Inf) {
-##                 if(!silent) print('warning: logProb of data node ', node, ': logProb is -Inf.')
-##             } else if(lp < -1e12) {
-##                 if(!silent) print('warning: logProb of data node ', node, ': logProb less than -1e12.')
-##             }
-##         }
-##     }
-## )
-
-## stochNonDataNodeInit <- nimbleFunction(
-##     name = 'stochNonDataNodeInit',
-##     contains = nodeInit_virtual,
-##     setup = function(model, node, silent) {},
-##     run = function() {
-##         nodeValue <- values(model, node)
-##         if(is.na.vec(nodeValue) | is.nan.vec(nodeValue)) simulate(model, node)
-##         nodeValue <- values(model, node)
-##         if(is.na.vec(nodeValue) | is.nan.vec(nodeValue)) print('warning: value of stochastic node ',node,': value is NA or NaN even after trying to simulate.')
-##         lp <- calculate(model, node)
-##         if(is.na(lp) | is.nan(lp)) print('warning: problem initializing stochastic node ', node, ': logProb is NA or NaN.')
-##         if(!(is.na(lp) | is.nan(lp))) {
-##             if(lp == -Inf) {
-##                 if(!silent) print('warning: problem initializing stochastic node ', node, ': logProb is -Inf.')
-##             } else if(lp < -1e12) {
-##                 if(!silent) print('warning: problem initializing stochastic node ', node, ': logProb less than -1e12.')
-##             }
-##         }
-##     }
-## )
 

--- a/packages/nimble/R/makevars.R
+++ b/packages/nimble/R/makevars.R
@@ -68,7 +68,6 @@ function(pkgFlags, pkgLibs, ..., dir = getwd(),
 genLocalMakevars =
 function(target, vars = character(), .useLib = UseLibraryMakevars)
 {
-##    cat("creating local makeVars in", target, "\n")
     inc.make = system.file("make", if(.useLib) 
                                      "Makevars_lib" 
                                    else if(.Platform$OS.type == "windows")

--- a/packages/nimble/R/nimbleFunction_keywordProcessing.R
+++ b/packages/nimble/R/nimbleFunction_keywordProcessing.R
@@ -28,23 +28,6 @@ setupCodeTemplateClass <- setRefClass('setupCodeTemplateClass',
 
 
 ### KEYWORD INFO OBJECTS
-
-#		Current objects:
-#		d_gamma_keywordInfo
-#		pq_gamma_keywordInfo
-#		rgamma_keywordInfo
-#		d_dist_keywordInfo
-#		qp_dist_keywordInfo
-#		values_keywordInfo
-#		calculate_keywordInfo
-#		simulate_keywordInfo
-#		getLogProb_keywordInfo
-#		nimCopy_keywordInfo
-#		doubleBracket_keywordInfo
-#		dollarSign_keywordInfo
-#		singleBracket_keywordInfo
-		
-		
 		
 d_gamma_keywordInfo <- keywordInfoClass(
     keyword = 'dgamma',

--- a/packages/nimble/R/nimbleProject.R
+++ b/packages/nimble/R/nimbleProject.R
@@ -194,8 +194,6 @@ nimbleProjectClass <- setRefClass('nimbleProjectClass',
                         }
                         assign('nimbleProject', NULL, envir = RCfunInfos[[i]]$nfMethodRCobj)
                         thisName <- RCfunInfos[[i]]$nfMethodRCobj$uniqueName
-                        ##if(!is.null(cppProjects[[thisName]])) cppProjects[[thisName]] <<- NULL
-                        ##RCfunInfos[[i]] <<- NULL
                         rm(list = i, envir = RCfunInfos)
                     }
                 }
@@ -209,7 +207,6 @@ nimbleProjectClass <- setRefClass('nimbleProjectClass',
                             if(exists('name', envir = thisRCO, inherits = FALSE)) {
                                 thisname <- thisRCO$name
                                 rm(list = thisname, envir = nimbleFunctions)
-                                ##nimbleFunctions[[ thisname ]] <<- NULL
                                 rm('name', envir = thisRCO)
                             }
                             thisRCO[['nimbleProject']] <- NULL
@@ -225,7 +222,6 @@ nimbleProjectClass <- setRefClass('nimbleProjectClass',
                             }
                         }
                         nfCompInfos[[i]] <<- NULL
-                        ## cppProjects[[i]] <<- NULL
                     }
                 }
             }
@@ -266,7 +262,6 @@ nimbleProjectClass <- setRefClass('nimbleProjectClass',
                 } 
                 model$nimbleProject <- .self
                 models[[ model$name ]] <<- model
-                ##modelCppInterfaces[[ model$name ]] <<- new.env()	#list(NULL)
             }
         },
         addNimbleFunctionMulti = function(funList, fromModel = FALSE, generatorFunNames = NULL) {
@@ -280,7 +275,7 @@ nimbleProjectClass <- setRefClass('nimbleProjectClass',
                                      unlist(lapply(funList, function(x) environment(x$.generatorFunction)$name), use.names = FALSE)
                                  else
                                      generatorFunNames
-            generatorName2Indices <- split(seq_along(funList), allGeneratorNames) ##uniqueGeneratorNamesIndices <- which(!duplicated(allGeneratorNames))
+            generatorName2Indices <- split(seq_along(funList), allGeneratorNames)
             for(i in seq_along(generatorName2Indices)) { ##genID in uniqueGeneratorNameIndices) {
                 genID <- generatorName2Indices[[i]][1]
                 generatorName <- names(generatorName2Indices)[i] ##allGeneratorNames[genID]
@@ -385,8 +380,7 @@ nimbleProjectClass <- setRefClass('nimbleProjectClass',
             }
           }
           if(!nestedList)   nimbleLists[[ nl$name ]] <<- nl
-          # nlCompInfos[[generatorName]]$addRinstance(nl)
-          
+                   
           if(!exists('Cname', envir = nl, inherits = FALSE)) {
             assign('Cname', Rname2CppName(nl$name), envir = nl)
           }
@@ -537,11 +531,9 @@ nimbleProjectClass <- setRefClass('nimbleProjectClass',
             cppProjects[[ modelDefName ]] <<- cppProj
             ## genModelValuesCppClass will back to the project to add its mv class
             mvc <- modelCpp$genModelValuesCppClass()
-            ##if(is.null(filename)) filename <- paste0(projectName, '_', modelDefName)
             cppProj$addClass(mvc, filename = filename)
             cppProj$addClass(modelCpp, modelDefName, filename)
             ##if compileNodes
-            ##nfFileName <- paste0(projectName, '_', Rname2CppName(modelDefName),'_nfCode')
             for(i in names(modelCpp$nodeFuns)) {
                 cppProj$addClass(modelCpp$nodeFuns[[i]], filename = nfFileName)
             }
@@ -643,13 +635,7 @@ nimbleProjectClass <- setRefClass('nimbleProjectClass',
             for(iNestedNL in seq_along(nestedListGens)) {
                 compileNimbleList(nestedListGens[[iNestedNL]], initialTypeInferenceOnly = TRUE, alreadyAdded = TRUE)
             }
-            ## for(iNestedNl in seq_along(nlList[[1]]$nestedListGenList)){
-            ##   ## create cppInfo for any nested list classes 
-            ##   compileNimbleList(nlList[[1]][[names(nlList[[1]]$nestedListGenList)[iNestedNl]]], initialTypeInferenceOnly = TRUE, alreadyAdded = TRUE)
-            ## }
             cppClass <- buildNimbleListCompilationInfo(nlList, initialTypeInferenceOnly = initialTypeInferenceOnly)
-            
-
             
             if(initialTypeInferenceOnly || returnCppClass) return(cppClass)
             message('Remaining compileNimbleList is not yet adapted')
@@ -872,14 +858,6 @@ nimbleProjectClass <- setRefClass('nimbleProjectClass',
                 ans <- nfCppDef$buildCallable(nf, dll = dll, asTopLevel = asTopLevel)
                 ok <- !is.null(ans)
             }
-            ## ok <- TRUE
-            ## if(asTopLevel) {
-            ##     if(is.null(nfCppDef$Rgenerator)) ok <- FALSE
-            ##     else ans <- nfCppDef$Rgenerator(nf, dll = dll, project = .self)
-            ## } else {
-            ##     if(is.null(nfCppDef$CmultiInterface)) ok <- FALSE
-            ##     else ans <- nfCppDef$CmultiInterface$addInstance(nf, dll = dll)
-            ## }
             if(!ok) stop("Oops, there is something in this compilation job that doesn\'t fit together.  This can happen in some cases if you are trying to compile new pieces into an exising project.  If that is the situation, please try including \"resetFunctions = TRUE\" as an argument to compileNimble.  Alternatively please try rebuilding the project from the beginning with more pieces in the same call to compileNimble.  For example, if you are compiling multiple algorithms for the same model in multiple calls to compileNimble, try compiling them all with one call.", call. = FALSE) 
 
             ans
@@ -911,7 +889,7 @@ nimbleProjectClass <- setRefClass('nimbleProjectClass',
             uniqueGeneratorNames <- unique(allGeneratorNames)
             if(initialTypeInferenceOnly || returnCppClass) {
                 ans <- list()
-                if(initialTypeInferenceOnly) oldKnownGeneratorNames <- ls(nfCompInfos)	#names(nfCompInfos)
+                if(initialTypeInferenceOnly) oldKnownGeneratorNames <- ls(nfCompInfos)
             } else ans <- vector('list', length(funList))
             for(uGN in uniqueGeneratorNames) {
                 thisBool <- allGeneratorNames == uGN
@@ -928,7 +906,7 @@ nimbleProjectClass <- setRefClass('nimbleProjectClass',
                     else ## they should all be new in this case anyway
                         ans[[ uGN ]] <- thisAns
                 } else {
-                    ans[thisBool] <- thisAns ##if(is.list(thisAns)) thisAns else list(thisAns)
+                    ans[thisBool] <- thisAns 
                 }
             }
             ans

--- a/packages/nimble/R/options.R
+++ b/packages/nimble/R/options.R
@@ -48,52 +48,14 @@ nimbleUserNamespace <- as.environment(list(sessionSpecificDll = NULL))
 
         showCompilerOutput = FALSE,
 
-        ## uses the 'new' system for dynamically generated conjugate samplers (DT, March 2016),
-        ## rather than the older 'static' system.
-        ## update May 2016: old (non-dynamic) system is no longer supported -DT
-        ##useDynamicConjugacy = TRUE,
-
-
-        ## samplerAssignmentRules system deprecated Nov 2020 -DT
-        ## samplerAssignmentRules object that controls the default sampler assignments by configureMCMC.
-        ## value is set to samplerAssignmentRules() (the defaults) in MCMC_configuration.R
         MCMCprogressBar = TRUE,
-        ##MCMCuseSamplerAssignmentRules = FALSE,
         MCMCsaveHistory = FALSE,
-        ##MCMCdefaultSamplerAssignmentRules = NULL,
         MCMCmultivariateNodesAsScalars = FALSE,
         MCMCmonitorAllSampledNodes = FALSE,
         MCMCuseConjugacy = TRUE,
         MCMCjointlySamplePredictiveBranches = TRUE,
         MCMCenableWAIC = FALSE
         
-        ## default settings for MCMC samplers
-        ## control list defaults for MCMC samplers are
-        ## now part of the sampler functions (setup code).
-        ## -DT July 2017
-        ##MCMCcontrolDefaultList = list(
-        ##    log = FALSE,
-        ##    reflective = FALSE,
-        ##    adaptive = TRUE,
-        ##    adaptScaleOnly = FALSE,
-        ##    adaptInterval = 200,
-        ##    scale = 1,
-        ##    propCov = 'identity',
-        ##    sliceWidth = 1,
-        ##    sliceMaxSteps = 100,
-        ##    sliceAdaptFactorMaxIter = 15000,  ##factorBurnIn = 15000,
-        ##    sliceAdaptFactorInterval = 1000,  ##factorAdaptInterval = 1000,
-        ##    sliceAdaptWidthMaxIter = 512,     ##sliceBurnIn = 512,
-        ##    sliceAdaptWidthTolerance = 0.1,
-        ##    scaleAdaptInterval = 200,
-        ##    sliceWidths = 'oneVec',
-        ##    pfNparticles = 1000,
-        ##    pfResample = FALSE,
-        ##    pfOptimizeNparticles = FALSE,
-        ##    pfType = 'bootstrap',
-        ##    pfLookahead = 'simulate',
-        ##    carUseConjugacy = TRUE
-        ##)
     )
 )
 

--- a/packages/nimble/R/types_modelValues.R
+++ b/packages/nimble/R/types_modelValues.R
@@ -236,7 +236,7 @@ makeCustomModelValuesClass <- function(symTab, className, vars, types, sizes, mo
                 }	
                 else if(nrow < rows){
                     for(vN in varNames){
-                        dims = nimbleInternalFunctions$dimOrLength(.self[[vN]][[1]])	#nimDim(.self[[vN]][[1]])
+                        dims = nimbleInternalFunctions$dimOrLength(.self[[vN]][[1]])
                         if(length(dims) == 0) dims = 1
                         for(i in (nrow+1):rows){
                             .self[[vN]][[i]] <- array(NA, dim = dims)

--- a/packages/nimble/R/types_nodeFxnVector.R
+++ b/packages/nimble/R/types_nodeFxnVector.R
@@ -11,7 +11,6 @@ nodeFunctionVector <-
              sortUnique = TRUE,
              errorContext = "")
 {
-    ##        model <<- model
     if(length(nodeNames) == 0) {
         gids <- numeric(0)
         indexingInfo <- list(declIDs = integer(), rowIndices = integer())

--- a/packages/nimble/R/types_symbolTable.R
+++ b/packages/nimble/R/types_symbolTable.R
@@ -97,35 +97,6 @@ argType2symbolInternal <- function(AT, neededTypes, name = character()) {
       }
     }
     return(symbolUnknown(name = name, argType = AT))
-    ## if(is.list(neededTypes)){
-    ##     ##  isANeededType <- unlist(lapply(neededTypes, function(x) return(type == x$name)))
-    ##     isANeededType <- unlist(lapply(neededTypes, `[[`, 'name')) == type
-    ##     if(any(isANeededType == 1)){
-    ##         listST <- neededTypes[[which(isANeededType == 1)[1]]]$copy(shallow  = TRUE)
-    ##         listST$name <- name
-    ##         return(listST)
-    ##     } 
-    ## }
-    ## if(name == "return"){
-    ##     possibleTypeName <- deparse(AT[[1]])
-    ##     className <- NULL
-    ##     if(exists(possibleTypeName, envir = globalenv())) {
-    ##       possibleNLgenerator <- get(possibleTypeName, envir = globalenv())
-    ##       if(is.nlGenerator(possibleNLgenerator)) {
-    ##           className <- nl.getListDef(possibleNLgenerator)$className
-    ##       }
-    ##     }
-    ##     if(!is.null(className)){
-    ##         isANeededType <- (className == names(neededTypes))
-    ##         if(any(isANeededType)){
-    ##             listST <- neededTypes[[which(isANeededType)[1]]]$copy(shallow = TRUE)
-    ##         } else {
-    ##             listST <- recurseGetListST(className, neededTypes)
-    ##         }
-    ##     listST$name <- name
-    ##     return(listST)
-    ##     }
-    ## }
 }
 
 resolveOneUnknownType <- function(unknownSym, neededTypes = NULL, nimbleProject) {
@@ -178,10 +149,8 @@ resolveOneUnknownType <- function(unknownSym, neededTypes = NULL, nimbleProject)
                 nlp <- nimbleProject$compileNimbleList(nlGen, initialTypeInferenceOnly = TRUE)
                 className <- nl.getListDef(nlGen)$className 
                 newSym <- symbolNimbleList(name = name, nlProc = nlp)
-                ##    newNeededTypes[[className]] <<- newSym  ## if returnType is a NLG, this will ensure that it can be found in argType2symbol()
                 newNeededType[[className]] <- newSym
                 returnSym <- symbolNimbleList(name = name, nlProc = nlp)
-##                symTab$addSymbol(lireturnSymstST, allowReplace = TRUE)
                 return(list(returnSym, newNeededType))
             }
         } else {
@@ -360,9 +329,6 @@ symbolSEXP <- setRefClass(
 symbolString <- setRefClass(
     Class = "symbolString",
     contains = "symbolBasic", ## inheriting from symbolBasic instead of symbolBase make initSizes work smoothly
-    ## fields   = list(
-    ##     nDim  = 'ANY',
-    ##     size = 'ANY'), 
     methods = list(
         show = function() writeLines(paste('symbolString', name)),
         genCppVar = function(...) {

--- a/packages/nimble/R/types_util.R
+++ b/packages/nimble/R/types_util.R
@@ -143,19 +143,8 @@ nl_removeNodeNamesNotInSymbolTable <- function(nodeNames, st) {
 
 nl_getVarNameFromNodeName <- function(nodeName)    gsub('\\[.*', '', nodeName)
 
-#nimDim <- function(object){
-#	rDim = dim(object)
-#	if(is.null(rDim) ) {
-#		if(is.vector(object) ) 
-#			return(length(object) ) 
-#		stop('dim called on object ', as.character(substitute(object) ), ' for which dim is undefined')
-#	}
-#	return(dim(object) ) 
-#}
-
 expandMVNames <- function(mv, varNames){
 	sizeList = mv$sizes
-#	varNames = names(sizeList)
 	nodeNames = NA
 	nodeIndex = 0 
 	for(i in seq_along(varNames) ){

--- a/packages/nimble/inst/CppCode/dllFinalizer.cpp
+++ b/packages/nimble/inst/CppCode/dllFinalizer.cpp
@@ -151,11 +151,6 @@ SEXP RNimble_Ptr_CheckAndRunAllDllFinalizers(SEXP Dll, SEXP Sforce) {
     else
       PRINTF("Warning: %i objects were found from a DLL\n", objectsFound);
   }
-  //  SEXP Sans;
-  //  PROTECT(Sans = Rf_allocVector(INTSXP, 1));
-  //  INTEGER(Sans)[0] = objectsFound;
-  //  UNPROTECT(1);
-  //  return(Sans);
 
   return(local_vectorString_2_STRSEXP(objectsFoundLabels));
 }

--- a/packages/nimble/inst/CppCode/nimDists.cpp
+++ b/packages/nimble/inst/CppCode/nimDists.cpp
@@ -415,26 +415,6 @@ void nimArr_rcar_normal(NimArr<1, double> &ans, NimArr<1, double> &adj, NimArr<1
   // since initializeModel() will call this simulate method if there are any NA's present,
   // (which is allowed for island components), which over-writes all the other valid initial values.
   //
-  //int n = num.size();
-  //NimArr<1, double> ansCopy;
-  //double *ansPtr;
-  //
-  //if(!ans.isMap()) {
-  //  ans.setSize(n);
-  //} else {
-  //  if(ans.size() != n) {
-  //    _nimble_global_output<<"Error in nimArr_rcar_normal: answer size ("<< ans.size() <<") does not match num size ("<<n<<").\n";
-  //    nimble_print_to_R(_nimble_global_output);
-  //  }
-  //}
-  //ansPtr = nimArrCopyIfNeeded<1, double>(ans, ansCopy).getPtr();
-  //for(int i = 0; i < n; i++)
-  //  ansPtr[i] = R_NaN;
-  //
-  //if(ans.isMap()) {
-  //  ans = ansCopy;
-  //}
-  //
 }
 
 
@@ -525,8 +505,5 @@ void nimArr_rcar_proper(NimArr<1, double> &ans, NimArr<1, double> &mu, NimArr<1,
   rcar_proper(ansptr, muptr, Cptr, adjptr, numptr, Mptr, tau, gamma, evsptr, N, L);
 
   if(ansptr != ans.getPtr()) {ans = ansCopy;} 
-  // if(ans.isMap()) {
-  //   ans = ansCopy;
-  // }
 }
 

--- a/packages/nimble/inst/include/nimble/RcppUtils.h
+++ b/packages/nimble/inst/include/nimble/RcppUtils.h
@@ -111,8 +111,6 @@ void rawSample(double* p, int c_samps, int N, int* ans, bool unsort, bool silent
 
 SEXP makeNewNimbleList(SEXP S_listName);
 
-//void dontDeleteFinalizer(SEXP ptr);
-
 #endif
 
 

--- a/packages/nimble/inst/include/nimble/nimbleEigenNimArr.h
+++ b/packages/nimble/inst/include/nimble/nimbleEigenNimArr.h
@@ -337,15 +337,6 @@ template<typename NimArrOutput, typename DerivedBool>
     if(nextBool) ans.push_back(i + 1); // That 1 makes it one-based indexing, which will then be adjusted back to zero-based when used for indexing something else
   }
   assignVectorToNimArr<NimArrOutput, std::vector<int> >(output, ans);
-  /* if(output.isMap()) { */
-  /*   if(output.size() != ans.size()) { */
-  /*     std::cout<<"Error: mismatched sizes in assignment from which()\n"; */
-  /*     return; */
-  /*   } */
-  /* } else { */
-  /*   output.setSize(ans.size(), false, false); // would need same scalar types before trying memcpy. */
-  /* } */
-  /* for(int i = 0; i < ans.size(); i++) output[i] = ans[i]; */
   return;
 }
 


### PR DESCRIPTION
We often comment-out code as we are working on changes.  At the time, it is to make it easier to see the changes without more git branching and to retain in-file documentation what was changed in case of new errors.  This PR removes a bunch of such changes that are now old and don't seem helpful.  Feel free to put anything back that is useful to understanding current code.  I tread more lightly on MCMC-related code.