### PR TITLE
in newMatrixClass, get returnType as the scalar of input type

### DIFF
--- a/packages/nimble/inst/include/nimble/nimbleEigen.h
+++ b/packages/nimble/inst/include/nimble/nimbleEigen.h
@@ -1639,7 +1639,8 @@ template<typename Index, typename DerivedInput>
   int dim1, dim2, totalLength, inputLength, inputRows;
   bool init; // would be a bit silly to call with init = FALSE, but it is allowed to simplify code generation
   bool recycle;
-  typedef double result_type;
+  //  typedef double result_type;
+  typedef typename DerivedInput::Scalar result_type;
  newMatrixClass(const DerivedInput &inputIn, bool initIn, bool recycleIn, int rowsIn, int colsIn) :
   input(inputIn),
     init(initIn),


### PR DESCRIPTION
This tweaks a single line in C++.

For the newMatrixClass, which is used to implement nimMatrix via nimNewMatrixD (and others), it sets the return type from the scalar type of the input, not simply defaulting to double.

This does not fix a bug.  This change would be convenient for AD, so I want to see if it causes an problems via testing.  The change seems slightly more correct than what was there, although nearly equivalent.