### PR TITLE
WIP: online WAIC

### DIFF
--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -426,6 +426,11 @@ buildMCMC <- nimbleFunction(
             logAvgProb <<- lppd1 - dataNodeLengthWAIC * log(varCount)
             pWAIC <<- sum(sspWAIC / (varCount - 1))
             WAIC <<- -2 * (logAvgProb - pWAIC)
+            ## check for large pWAIC values
+            badpWAIC <- sum(((sspWAIC / (varCount -1))>0.4))
+            if (badpWAIC>0) {
+                print("There are pWAIC values that are greater than 0.4, WAIC estimate may be unstable" )
+            }
         },
         getWAIC = function() {
             returnType(WAICList())


### PR DESCRIPTION
Do not merge. I'm opening this PR to centralize discussion with Josh (for now, me and Josh; bringing Perry and Daniel in later) on the code.

@guhauhsoj a few mostly minor comments on the code. I'm going to wait for now to work on making the WAIC stuff into a separate nimbleFunction.

1. I think all the WAIC args should be part of a list, called `waicControl`.
2. We tend to spell things out in names a bit more than you do. So I think we want: `thWAIC` -> `thinWAIC`, `disableOnlWAIC` -> `disableOnlineWAIC`, `latNodes` -> `latentNodes`.
3. I think best to rename `noOnline` to `onlineWAIC`
4. In line 182, you shouldn't need `expandNodeNames` because the next call to `getDependencies` should do it.
5. I think `mWAICMC` would be better named `mWAICnIts`
6. Please move the `nimCopy` of the latent nodes into `updateWAICstats`, unless there is a reason I'm not understanding for doing it in the main run code.
7. Perry had suggested we delay doing the finalize until a user requested the results. Can you have `finalizeWAIC` called from within `getWAIC` and then only if it hasn't been called already?
8. In line 418 comment, best to say this is Welford's algorithm.
9. In line 390, you continually use `sum` to determine indexing, but I don't think anything about that is changing. I think instead of storing the number of data nodes in each group in `groupIndicesWAIC` you can calculate the cumulative number in the groups and use that in line 390. E.g. if you have `groupIndicesWAIC` being 3,4,2, you'd stored 3,7,9 instead and you shouldn't need the `sum` invocations. 