### PR TITLE
fix error when model if-then-else has no else

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -205,7 +205,7 @@ codeProcessIfThenElse <- function(code, constants, envir = parent.frame()) {
             if(evaluatedCondition) return(codeProcessIfThenElse(code[[3]], constants, envir))
             else {
                 if(length(code) == 4) return(codeProcessIfThenElse(code[[4]], constants, envir))
-                else return(NULL)
+                else return(quote({}))
             }
         } else
             return(code)


### PR DESCRIPTION
This fixes issue #1076.

@perrydv I think this is just a long-standing oversight.