### PR TITLE
robustify checking of uncompilable elements in nfs

### DIFF
--- a/packages/nimble/R/RCfunction_core.R
+++ b/packages/nimble/R/RCfunction_core.R
@@ -78,9 +78,11 @@ nfMethodRC <- setRefClass(
             if(code[[1]] != '{')
                 code <<- substitute({CODE}, list(CODE=code))
             ## check all code except nimble package nimbleFunctions
-            if(check && "package:nimble" %in% search()) 
-                nf_checkDSLcode(code, methodNames, setupVarNames)
             generateArgs()
+
+            if(check && "package:nimble" %in% search()) 
+                nf_checkDSLcode(code, methodNames, setupVarNames, names(arguments))
+
             generateTemplate() ## used for argument matching
             removeAndSetReturnType(check = check)
             ## Includes for .h and .cpp files when making external calls:
@@ -184,7 +186,7 @@ findMethodsInExprClass <- function(expr) {
     return(NULL)
 }
 
-nf_checkDSLcode <- function(code, methodNames, setupVarNames) {
+nf_checkDSLcode <- function(code, methodNames, setupVarNames, args) {
     validCalls <- c(names(sizeCalls),
                     otherDSLcalls,
                     names(specificCallReplacements),
@@ -192,7 +194,7 @@ nf_checkDSLcode <- function(code, methodNames, setupVarNames) {
                     methodNames,
                     setupVarNames)
     calls <- setdiff(all.names(code),
-                     all.vars(code))
+                     c(all.vars(code), args))
     
     ## Find the 'y' in cases of x$y() and x[]$y() and x[[]]$y().
 

--- a/packages/nimble/R/RCfunction_core.R
+++ b/packages/nimble/R/RCfunction_core.R
@@ -160,6 +160,30 @@ nfMethodRC <- setRefClass(
         getReturnType    = function() { return(returnType) })
 )
 
+## Helper function that walks an exprClass tree and finds methods based on positioning wrt dollar signs
+findMethodsInExprClass <- function(expr) {
+    if(is(expr, 'exprClass')) {
+        if(expr$isAssign) {
+            return(findMethodsInExprClass(expr$args[[2]]))
+        } else {
+            if(expr$isCall) {
+                if(expr$name == '$') {
+                    ## Next check ensures that RHS of $ is a call and not a field
+                    ## Check for whether it is first arg of chainedCall prevents finding
+                    ## 'foo' in m$cc(m$foo) as a method.
+                    if(!is.null(expr$caller) && expr$caller$name == 'chainedCall' &&
+                       identical(expr, expr$caller$args[[1]]))
+                        tmp <- expr$args[[2]]$name else tmp <- NULL
+                    return(c(tmp, findMethodsInExprClass(expr$args[[1]])))
+                } else {
+                    return(unlist(lapply(expr$args, findMethodsInExprClass)))
+                }
+            } 
+        }
+    } 
+    return(NULL)
+}
+
 nf_checkDSLcode <- function(code, methodNames, setupVarNames) {
     validCalls <- c(names(sizeCalls),
                     otherDSLcalls,
@@ -170,33 +194,12 @@ nf_checkDSLcode <- function(code, methodNames, setupVarNames) {
     calls <- setdiff(all.names(code),
                      all.vars(code))
     
-    ## Find cases of x$y() and x[]$y() and x[[]]$y().
-    ##
-    ## (This also unnecessarily finds x$y, x[]$y, x[[]]$y.)
-    ##
-    ## This step relies on all.names returning symbols from parse tree
-    ## in particular order
-    names <- all.names(code)
-    dollarsLhs <- dollarsRhs <- NULL
-    dollars <- which(names == "$")
-    if(length(dollars)) {
-        dollarsLhs <- dollars+1
-        dollarsRhs <- dollars+2
-        dollarsRhs[names[dollarsLhs] %in% c('[', '[[')] <-
-            dollarsRhs[names[dollarsLhs] %in% c('[', '[[')] + 1 # account for index
-        while(sum(names[dollarsLhs] %in% c('[', '[['))) {
-            ## bracket appears between $ and the lhs,rhs of the $
-            dollarsRhs[names[dollarsLhs] %in% c('[', '[[')] <-
-                dollarsRhs[names[dollarsLhs] %in% c('[', '[[')] + 1
-            dollarsLhs[names[dollarsLhs] %in% c('[', '[[')] <-
-                dollarsLhs[names[dollarsLhs] %in% c('[', '[[')] + 1
-        }
-        dollarsLhs <- unique(names[dollarsLhs[dollarsLhs <= length(names)]])
-        dollarsRhs <- unique(names[dollarsRhs[dollarsRhs <= length(names)]])
-    } 
+    ## Find the 'y' in cases of x$y() and x[]$y() and x[[]]$y().
+
+    nfMethods <- findMethodsInExprClass(RparseTree2ExprClasses(code))
     
     ## don't check RHS of $ to ensure it is a valid nf method because no current way to easily find the methods of nf's defined in setup code
-    nonDSLcalls <- calls[!(calls %in% c(validCalls, dollarsRhs))]
+    nonDSLcalls <- calls[!(calls %in% c(validCalls, nfMethods))]
     if(length(nonDSLcalls)) {
         objInR <- sapply(nonDSLcalls, exists)
         nonDSLnonR <- nonDSLcalls[!objInR]


### PR DESCRIPTION
Formerly we were pulling out the names in nimbleFunction run code and relying on ordering of those names to try to find nf methods and not warn about those in `nf_checkDSLcode` (since we can't know what the methods of potentially not-yet-defined nfs are). As shown in issue #1084 this check was not robust.

This PR converts the run code to an `exprClass` and walks the tree to find methods based on finding `$`. 

This fixes issue #1084 