### PR TITLE
better error trapping for use of `~` in model without RHS distribution

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -495,6 +495,10 @@ checkUserDefinedDistribution <- function(code, userEnv) {
         
 
 replaceDistributionAliases <- function(code) {
+    if(length(code) < 3)
+        stop("Invalid model declaration: ", deparse(code), ".")
+    if(!is.call(code[[3]]))
+        stop("Invalid model declaration: ", deparse(code), " must call a density function.")
     dist <- as.character(code[[3]][[1]])
     trunc <- FALSE
     if(dist %in% c("T", "I")) {

--- a/packages/nimble/R/distributions_processInputList.R
+++ b/packages/nimble/R/distributions_processInputList.R
@@ -272,9 +272,13 @@ checkDistributionFunctions <- function(distributionInput, userEnv) {
               stop(paste0("checkDistributionFunctions: density function for ", densityName,
                           " has invalid or missing returnType, which must be 'double(0)' (or equivalently 'double()')."))
     } else nofun <- TRUE
-    if(nofun)
-        stop(paste0("checkDistributionFunctions: density function for ", densityName,
+    if(nofun) {
+        if(densityName %in% c('+','-','*','/','%%','%*%','[','[[','$','^','|','||','&','&&',':','<','<=','>','>=','!=','==')) {
+            stop(paste0("checkDistributionFunctions: expression '", densityName,
+                        "' found where a density function is expected. Did you mistakenly use `~` instead of `<-`?"))
+        } else stop(paste0("checkDistributionFunctions: density function for ", densityName,
                     " is not available.  It must be a nimbleFunction (with no setup code)."))
+    }
     if(!exists(simulateName, where = userEnv) || !is.rcf(get(simulateName, pos = userEnv))) {
         cat(paste0("Warning: random generation function for ", densityName,
                     " is not available. NIMBLE is generating a placeholder function, ", simulateName, ", that will invoke an error if an algorithm needs to simulate from this distribution. Some algorithms (such as random-walk Metropolis MCMC sampling) will work without the ability to simulate from the distribution.  If simulation is needed, provide a nimbleFunction (with no setup code) to do it.\n"))


### PR DESCRIPTION
This fixes issue #812. 