### PR TITLE
fix name-mangling in context of nimbleFunction lists

### DIFF
--- a/packages/nimble/R/RCfunction_compile.R
+++ b/packages/nimble/R/RCfunction_compile.R
@@ -186,7 +186,8 @@ nf_substituteExceptFunctionsAndDollarSigns <- function(code, subList) {
         )
     }
     if(is.call(code)) {
-        if(length(code) == 1)
+        ## Second check avoids premature return for code such a nL[[i]]$foo().
+        if(length(code) == 1 && length(code[[1]]) == 1)
             return(code)
         else {
             if(is.call(code[[1]]))


### PR DESCRIPTION
This fixes issue #1035, which fixes an error in name-mangling in creation of C++ related to nimbleFunction lists.