### PR TITLE
Added samplesAsList option to runMCMC and nimbleMCMC

### DIFF
--- a/packages/nimble/R/MCMC_run.R
+++ b/packages/nimble/R/MCMC_run.R
@@ -115,6 +115,7 @@ runMCMC <- function(mcmc,
     samplesList  <- vector('list', nchains); names(samplesList)  <- paste0('chain', 1:nchains)
     samplesList2 <- vector('list', nchains); names(samplesList2) <- paste0('chain', 1:nchains)
     samplesReturnList <- samplesReturnList2 <- vector('list', nchains)
+    names(samplesReturnList) <- names(samplesReturnList2) <- paste0('chain', 1:nchains)
     thinToUseVec <- c(0, 0)
     thinToUseVec[1] <- if(!missing(thin))  thin  else mcmc$thinFromConfVec[1]
     thinToUseVec[2] <- if(!missing(thin2)) thin2 else mcmc$thinFromConfVec[2]

--- a/packages/nimble/R/types_util.R
+++ b/packages/nimble/R/types_util.R
@@ -216,13 +216,13 @@ as.list.modelValuesBaseClass <- function(x, varNames, iterationAsLastIndex = FAL
   results <- list()
   for(v in varNames) {
     samples <- x[[v]]
-    dims <- dimOrLength(samples[[1]])
+    dims <- dimOrLength(samples[[1]], scalarize = TRUE)
     matrixVersion <- do.call("c", lapply(samples, as.numeric))
     ansDims <- c(dims, nrows)
     results[[v]] <- array(matrixVersion, dim = ansDims)
     if(!iterationAsLastIndex) {
       nDim <- length(ansDims)
-      results[[v]] <- aperm(results[[v]], c(nDim, 1:(nDim-1)))
+      if(nDim > 1)   results[[v]] <- aperm(results[[v]], c(nDim, 1:(nDim-1)))
     }
   }
   results
@@ -235,13 +235,13 @@ as.list.CmodelValues <- function(x, varNames, iterationAsLastIndex = FALSE, ...)
   results <- list()
   for(v in varNames) {
     samples <- x[[v]]
-    dims <- dimOrLength(samples[[1]])
+    dims <- dimOrLength(samples[[1]], scalarize = TRUE)
     matrixVersion <- do.call("c", lapply(samples, as.numeric))
     ansDims <- c(dims, nrows)
     results[[v]] <- array(matrixVersion, dim = ansDims)
     if(!iterationAsLastIndex) {
       nDim <- length(ansDims)
-      results[[v]] <- aperm(results[[v]], c(nDim, 1:(nDim-1)))
+      if(nDim > 1)   results[[v]] <- aperm(results[[v]], c(nDim, 1:(nDim-1)))
     }
   }
   results

--- a/packages/nimble/inst/NEWS
+++ b/packages/nimble/inst/NEWS
@@ -1,4 +1,9 @@
-                            CHANGES IN VERSION 0.10.1 (Novembere 2020)
+USER LEVEL CHANGES
+
+-- Add `samplesAsList` option to `runMCMC` and `nimbleMCMC`, which allows returning posterior MCMC samples in the form of an R list object, where each named list element corresponds to a variable being monitored, matching the dimensions of the monitored variable.
+
+
+                            CHANGES IN VERSION 0.10.1 (November 2020)
                             
 USER LEVEL CHANGES
 


### PR DESCRIPTION
The title says it all.  Adds a new option `samplesAsList` to `runMCMC` and `nimbleMCMC` functions, with default value `FALSE`.  When `samplesAsList = TRUE`, the `samples` return object will be a named list, with named elements corresponding to variables being monitored.  Details:

The number of MCMC iterations will be the first dimension of each named element.  Thus, for 10 MCMC iterations, scalar variables are returned as a length-10 vector, length-3 vector variables are returned as a 10x3 arrays, and 3x4 array variables are returned as 10x3x4 arrays.  This matches the behaviour of `jagsUI`.

To achieve this, I made changes to the `modelValues` utility functions `as.list.modelValuesBaseClass` and `as.list.CmodelValues`, adding `scalarize = TRUE` to the `dimOrLength` call.  See the modified code.  I think this makes more sense, and my guess is that the missing-ness of this only reflects the total lack of usage of these `as.list` functions.  But perhaps I'm missing a part of the bigger picture here.

Also, I had to wonder, why the duplicate definitions of these functions?  Would it be simpler, and functionally identical, to say:
```
as.list.modelValuesBaseClass <- as.list.CmodelValues <- function(…) { ... }    ?
```

Our behaviour does **not** mimic that of `jagsUI`, in the case of multiple chains.

In the case of 3 chains, we will return `samples` as a list of length 3 (elements named "chain1", "chain2", and "chain3"), where the first element is a named list, with elements corresponding to the samples (of each variable) from chain 1, etc ....  In contrast, `jagsUI` will return a named list as before, with the samples from each chain concatenated.  This is a slight difference in functionality from `jagsUI`, which we could discuss.

This approach can be wasteful in terms of memory when `samplesAsList = TRUE`, since `runMCMC` will still collect samples **both** in the forms of an array, and also as a list (using this update).  This is because the **array** form of the samples is used internally for both the (optional) summary, and also the (optional) WAIC calculations, even if not returned to the user.  I'm ok with this, but flagging it for discussion.




