### PR TITLE
check for incomplete declarations in model code

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -190,7 +190,7 @@ modelDefClass$methods(setupModel = function(code, constants, dimensions, inits, 
 
 codeProcessIfThenElse <- function(code, constants, envir = parent.frame()) {
     codeLength <- length(code)
-    if(class(code) == "name")
+    if(is.name(code))
         stop("Incomplete declaration found: '", deparse(code), "'.")
         
     if(code[[1]] == '{') {
@@ -464,7 +464,7 @@ modelDefClass$methods(processBUGScode = function(code = NULL, contextID = 1, lin
             BUGScontextClassObject$setup(singleContexts = singleContexts)
             contexts[[nextContextID]] <<- BUGScontextClassObject
             if(length(code[[i]][[4]])==1) {
-                stop(paste0('Error, not sure what to do with ', deparse(code[[i]])))
+                stop('Error, not sure what to do with ', deparse(code[[i]]), ".")
             }
             recurseCode <- if(code[[i]][[4]][[1]] == '{') {
                 code[[i]][[4]]


### PR DESCRIPTION
As seen in a recent user post, we were not error trapping cases like this (including such non-declarations inside `if` or `for`).

```
mycode <- nimbleCode({
    model
    y~dnorm(0,1)
})
m <- nimbleModel(mycode)
```

This PR catches such cases. Initially I thought we should be looking for cases where `length(code)==1` in `codeProcessIfThenElse`, but `{}` is legit and of length 1, albeit useless, and `f()` is (and should be) trapped elsewhere.

@danielturek @perrydv this seems straightforward, but a second eye would be nice, particularly as all models use this code.