### PR TITLE
Remove checking for index variables in node name

### DIFF
--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -1592,7 +1592,7 @@ getParentNodesC <-  function(nodes, model, returnType = 'names', stochOnly = FAL
 #'
 #' @param inputType The method of graph exploration depends on what the nodes argument represents.  For \code{latent}, the input \code{nodes} are interpreted as latent states, from which both parent and descendent graph exploration should be done to find nodes in the same set (nodes that are NOT conditionally independent from each other).  For \code{param}, the input \code{nodes} are interpreted as parameters, so graph exploration begins from the  top (input) and explores descendents.  For \code{data}, the input \code{nodes} are interpreted as data nodes, so graph exploration begins from the bottom (input) explores parent nodes.
 #' 
-#' @param stochOnly Logcal for whether only stochastic nodes should be returned (default = TRUE).  If FALSE, both deterministic and stochastic nodes are returned.
+#' @param stochOnly Logical for whether only stochastic nodes should be returned (default = TRUE).  If FALSE, both deterministic and stochastic nodes are returned.
 #' 
 #' @param returnType Either \code{names} for returned nodes to be node names or \code{ids} for returned nodes to be graph IDs.
 #' 

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -2998,16 +2998,6 @@ handleOutOfBounds <- function(x, env) {
 }
 
 parseEvalNumericMany <- function(x, env, ignoreNotFound = FALSE) {
-    ## avoid evaluating variables in index expr, such as "y[idx]".
-    if(nimbleOptions('checkForIndexVariablesInNodeNames')) {
-        parsedx <- parse(text = x)[[1]]
-        if(length(parsedx) > 1 && deparse(parsedx[[1]]) %in% c('[', '[[')) {
-            allVars <- all.vars(parsedx)
-            allVars <- allVars[allVars != parsedx[[2]]]
-            if(length(allVars))
-                stop("parseEvalNumericMany: a variable was found in the indexing in '", x, "'.")
-        }
-    }
     if(ignoreNotFound) {  ## Return NA when not found.
         if(length(x) > 1) {
             ## First try to do as vectorized call.
@@ -3039,16 +3029,6 @@ parseEvalNumericMany <- function(x, env, ignoreNotFound = FALSE) {
 
 
 parseEvalNumericManyList <- function(x, env, ignoreNotFound = FALSE) {
-    ## avoid evaluating variables in index expr, such as "y[idx]".
-    if(nimbleOptions('checkForIndexVariablesInNodeNames')) {
-        parsedx <- parse(text = x)[[1]]
-        if(length(parsedx) > 1 && deparse(parsedx[[1]]) %in% c('[', '[[')) {
-            allVars <- all.vars(parsedx)
-            allVars <- allVars[allVars != parsedx[[2]]]
-            if(length(allVars))
-                stop("parseEvalNumericManyList: a variable was found in the indexing in '", x, "'.")
-        }
-    }
     if(ignoreNotFound) {  ## Return NA when not found.
        output <- try(eval(.Call(makeParsedVarList, x), envir = env), silent = TRUE)
         if(!is(output, 'try-error'))

--- a/packages/nimble/R/options.R
+++ b/packages/nimble/R/options.R
@@ -41,7 +41,6 @@ nimbleUserNamespace <- as.environment(list(sessionSpecificDll = NULL))
         checkModel = FALSE,
         checkNimbleFunction = TRUE,
         checkDuplicateNodeDefinitions = TRUE,
-        checkForIndexVariablesInNodeNames = TRUE,
         verbose = TRUE,
         verboseErrors = FALSE,
 

--- a/packages/nimble/man/getConditionallyIndependentSets.Rd
+++ b/packages/nimble/man/getConditionallyIndependentSets.Rd
@@ -19,7 +19,7 @@ getConditionallyIndependentSets(model, nodes, givenNodes, omit = integer(),
 
 \item{inputType}{The method of graph exploration depends on what the nodes argument represents.  For \code{latent}, the input \code{nodes} are interpreted as latent states, from which both parent and descendent graph exploration should be done to find nodes in the same set (nodes that are NOT conditionally independent from each other).  For \code{param}, the input \code{nodes} are interpreted as parameters, so graph exploration begins from the  top (input) and explores descendents.  For \code{data}, the input \code{nodes} are interpreted as data nodes, so graph exploration begins from the bottom (input) explores parent nodes.}
 
-\item{stochOnly}{Logcal for whether only stochastic nodes should be returned (default = TRUE).  If FALSE, both deterministic and stochastic nodes are returned.}
+\item{stochOnly}{Logical for whether only stochastic nodes should be returned (default = TRUE).  If FALSE, both deterministic and stochastic nodes are returned.}
 
 \item{returnType}{Either \code{names} for returned nodes to be node names or \code{ids} for returned nodes to be graph IDs.}
 

--- a/packages/nimble/tests/testthat/test-expandNodeNames.R
+++ b/packages/nimble/tests/testthat/test-expandNodeNames.R
@@ -42,9 +42,9 @@ test_that("expandNodeNames works for various cases, including going beyond exten
    expect_equal(m$expandNodeNames(c("theta[1:3, 3:5]", "theta[3:5, 1:3]"), unique = FALSE),
                 c("theta[1, 3]","theta[2, 3]","theta[3, 3]","theta[3, 1]","theta[3, 2]","theta[3, 3]"))
                                   
-   ## indexing with a variable
-   expect_error(m$expandNodeNames("mu[a]"), "variable was found in the indexing")
-   expect_error(m$expandNodeNames("mu[[a]]"), "variable was found in the indexing")
+   ## indexing with a variable; not trapped - see NCT issue 293
+   expect_failure(expect_error(m$expandNodeNames("mu[a]"), "variable was found in the indexing"))
+   expect_failure(expect_error(m$expandNodeNames("mu[[a]]"), "variable was found in the indexing"))
 
    ## double bracket indexing is allowed but non-standard
    expect_identical(m$expandNodeNames("mu[[2]]"), "mu[2]")

--- a/packages/nimble/tests/testthat/test-models.R
+++ b/packages/nimble/tests/testthat/test-models.R
@@ -822,7 +822,8 @@ test_that("error produced when variable used in index", {
     })
     m <- nimbleModel(code)
     idx <- 1
-    expect_error(m$expandNodeNames("y[idx]"), "parseEvalNumericMany: a variable was found")
+    ## Check introduced in v0.10.1 disabled because not robust; see NCT issue 293
+    expect_failure(expect_error(m$expandNodeNames("y[idx]"), "parseEvalNumericMany: a variable was found"))
 })
 
 test_that("dmvt usage", {


### PR DESCRIPTION
This removes poorly devised checking in PRs #1064 #1113. See NCT issue 293 for more discussion.