### PR TITLE
WIP: pass `where` into `nf_checkDSLcode`

### DIFF
--- a/packages/nimble/R/RCfunction_compile.R
+++ b/packages/nimble/R/RCfunction_compile.R
@@ -146,16 +146,16 @@ RCvirtualFunProcessing <- setRefClass(
 RCfunction <- function(f, name = NA, returnCallable = TRUE, check, where = NULL) {
     if(is.na(name))
         name <- rcFunLabelMaker(envName = environmentName(where))
-    nfm <- nfMethodRC$new(f, name, check = check)
+    nfm <- nfMethodRC$new(f, name, check = check, where = where)
     if(returnCallable)
         nfm$generateFunctionObject(keep.nfMethodRC = TRUE, where = where)
     else
         nfm
 }
 
-is.rcf <- function(x, inputIsName = FALSE) {
+is.rcf <- function(x, inputIsName = FALSE, where = -1) {
     if(inputIsName)
-        x <- get(x)
+        x <- get(x, pos = where)
     if(inherits(x, 'nfMethodRC'))
         return(TRUE)
     if(is.function(x)) {

--- a/packages/nimble/R/RCfunction_core.R
+++ b/packages/nimble/R/RCfunction_core.R
@@ -65,7 +65,8 @@ nfMethodRC <- setRefClass(
                               name,
                               check = FALSE,
                               methodNames = NULL,
-                              setupVarNames = NULL) {
+                              setupVarNames = NULL,
+                              where = NULL) {
             ## uniqueName is only needed for a pure RC function.
             ## It is not needed for a nimbleFunction method.
             if(!missing(name)) uniqueName <<- name 
@@ -81,7 +82,7 @@ nfMethodRC <- setRefClass(
             generateArgs()
 
             if(check && "package:nimble" %in% search()) 
-                nf_checkDSLcode(code, methodNames, setupVarNames, names(arguments))
+                nf_checkDSLcode(code, methodNames, setupVarNames, names(arguments), where)
 
             generateTemplate() ## used for argument matching
             removeAndSetReturnType(check = check)
@@ -186,7 +187,7 @@ findMethodsInExprClass <- function(expr) {
     return(NULL)
 }
 
-nf_checkDSLcode <- function(code, methodNames, setupVarNames, args) {
+nf_checkDSLcode <- function(code, methodNames, setupVarNames, args, where = NULL) {
     validCalls <- c(names(sizeCalls),
                     otherDSLcalls,
                     names(specificCallReplacements),
@@ -203,7 +204,7 @@ nf_checkDSLcode <- function(code, methodNames, setupVarNames, args) {
     ## don't check RHS of $ to ensure it is a valid nf method because no current way to easily find the methods of nf's defined in setup code
     nonDSLcalls <- calls[!(calls %in% c(validCalls, nfMethods))]
     if(length(nonDSLcalls)) {
-        objInR <- sapply(nonDSLcalls, exists)
+        objInR <- sapply(nonDSLcalls, exists, where = where)
         nonDSLnonR <- nonDSLcalls[!objInR]
         nonDSLinR <- nonDSLcalls[objInR]
         if(length(nonDSLinR))
@@ -215,16 +216,16 @@ nf_checkDSLcode <- function(code, methodNames, setupVarNames, args) {
             nonDSLinR <-
                 nonDSLinR[!(sapply(nonDSLinR,
                                    function(x)
-                                       is.nf(x, inputIsName = TRUE)) |
+                                       is.nf(x, inputIsName = TRUE, where = where)) |
                             sapply(nonDSLinR,
                                    function(x)
-                                       is(get(x), 'nimbleFunctionList')) |
+                                       is(get(x, envir = where), 'nimbleFunctionList')) |
                             sapply(nonDSLinR,
                                    function(x)
-                                       is.rcf(x, inputIsName = TRUE)) |
+                                       is.rcf(x, inputIsName = TRUE, where = where)) |
                             sapply(nonDSLinR,
                                    function(x)
-                                       is.nlGenerator(x, inputIsName = TRUE)))]
+                                       is.nlGenerator(x, inputIsName = TRUE, where = where)))]
         if(length(nonDSLinR))
             warning(paste0("Detected possible use of R functions in nimbleFunction run code. For this nimbleFunction to compile, these objects must be defined as nimbleFunctions, nimbleFunctionLists, or nimbleLists: ", paste(nonDSLinR, collapse = ', '), "."), call. = FALSE)
         if(length(nonDSLnonR))

--- a/packages/nimble/R/nimbleFunction_core.R
+++ b/packages/nimble/R/nimbleFunction_core.R
@@ -98,7 +98,7 @@ nimbleFunction <- function(setup         = NULL,
     # simply pass in names of vars in setup code so that those can be used in nf_checkDSLcode; to be more sophisticated we would only pass vars that are the result of nimbleListDefs or nimbleFunctions
     if(nimbleOptions('experimentalEnableDerivs') && length(enableDerivs)>0) methodList <- c(methodList, buildDerivMethods(methodList, enableDerivs))
     else if(!nimbleOptions('experimentalEnableDerivs') && length(enableDerivs)>0) stop('To enable nimbleFunction derivatives, you must first set "nimbleOptions(experimentalEnableDerivs = TRUE)".')
-    methodList <- lapply(methodList, nfMethodRC, check = check, methodNames = names(methodList), setupVarNames = c(all.vars(body(setup)), names(formals(setup))))
+    methodList <- lapply(methodList, nfMethodRC, check = check, methodNames = names(methodList), setupVarNames = c(all.vars(body(setup)), names(formals(setup))), where = where)
     ## record any setupOutputs declared by setupOutput()
     setupOutputsDeclaration <- nf_processSetupFunctionBody(setup, returnSetupOutputDeclaration = TRUE)
     declaredSetupOutputNames <- nf_getNamesFromSetupOutputDeclaration(setupOutputsDeclaration)

--- a/packages/nimble/R/nimbleFunction_util.R
+++ b/packages/nimble/R/nimbleFunction_util.R
@@ -20,22 +20,22 @@ nfGetDefVar <- function(f, var) {
 #'
 #' @seealso \code{\link{nimbleFunction}} for how to create a nimbleFunction
 #' @export
-is.nf <- function(f, inputIsName = FALSE) {
-    if(inputIsName) f <- get(f)
+is.nf <- function(f, inputIsName = FALSE, where = -1) {
+    if(inputIsName) f <- get(f, pos = where)
     if(inherits(f, 'nimbleFunctionBase')) return(TRUE)
     return(is.function(f) && !is.null(environment(f)) &&  
                existsFunctionEnvVar(f, 'nfRefClassObject') ) 	
 }
 
 #' @export
-is.Cnf <- function(f, inputIsName = FALSE) {
-    if(inputIsName) f <- get(f)
+is.Cnf <- function(f, inputIsName = FALSE, where = -1) {
+    if(inputIsName) f <- get(f, pos = where)
     if(inherits(f, 'CnimbleFunctionBase')) return(TRUE)
     return(FALSE)
 }
 
-is.nfGenerator <- function(f, inputIsName = FALSE) {
-    if(inputIsName) f <- get(f)
+is.nfGenerator <- function(f, inputIsName = FALSE, where = -1) {
+    if(inputIsName) f <- get(f, pos = where)
     return(is.function(f) && 
                existsFunctionEnvVar(f, 'generatorFunction') &&
                existsFunctionEnvVar(f, 'nfRefClassDef') &&

--- a/packages/nimble/R/nimbleList_core.R
+++ b/packages/nimble/R/nimbleList_core.R
@@ -460,8 +460,8 @@ is.nl <- function(l){
   return(FALSE)
 }
 
-is.nlGenerator <- function(x, inputIsName = FALSE) {
-    if(inputIsName) x <- get(x)
+is.nlGenerator <- function(x, inputIsName = FALSE, where = -1) {
+    if(inputIsName) x <- get(x, pos = where)
     if(is.list(x) && is.function(x$new)) {
         if(is.null(environment(x$new))) return(FALSE)
         if(exists('nlDefClassObject', envir = environment(x$new), inherits = FALSE)) return(TRUE)


### PR DESCRIPTION
This addresses the issue raised by @dochvam in email that `nimbleEcology` install was triggering warnings from `nf_checkDSLcode` when a nimbleFunction (without setup code, but should be the situation regardless of setup code) calls another nimbleFunction.

The issue is that `nf_checkDSLcode` was looking its enclosing environment (the nimble namespace) and during package install for nimble-depending packages, that doesn't end up looking in the relevant environment containing the functions in the package.

I have not thought through yet whether this change could have unintended side effects. That said, the passing of `where` is now consistent with what we are doing when we call `nimbleFunction`.