### PR TITLE
WIP: add lkj tranform to parameter transform system

### DIFF
--- a/packages/nimble/R/parameterTransform.R
+++ b/packages/nimble/R/parameterTransform.R
@@ -28,6 +28,7 @@ parameterTransform <- nimbleFunction(
         ## 6: multivariate {normal, t}
         ## 7: multivariate {wishart, inverse-wishart}
         ## 8: multivariate dirichlet
+        ## 9: LKJ 
         transformType <- as.integer(rep(NA, (nNodes+1)))  ## must be integer for nimSwitch, and also ensure as a vector
         ## transformData
         transformData <- array(NA, dim = c(nNodes, 6))
@@ -115,6 +116,16 @@ parameterTransform <- nimbleFunction(
                     transformData[i,TIND2] <- transformData[i,TIND1] + d - 2
                     transformData[i,DATA1] <- d
                     next }
+                if(dist == 'dlkj_corr_cholesky') {                ## 9: LKJ
+                    transformType[i] <- 9L
+                    dSq <- length(model$expandNodeNames(node, returnScalarComponents = TRUE))
+                    d <- sqrt(dSq)
+                    dd <- d * (d-1) / 2  # number of transformed params
+                    transformData[i,NIND2] <- transformData[i,NIND1] + dSq - 1
+                    transformData[i,TIND2] <- transformData[i,TIND1] + dd - 1
+                    transformData[i,DATA1] <- d
+                    transformData[i,DATA2] <- dd
+                    next }
                 stop(paste0('parameterTransform doesn\'t handle \'', dist, '\' distributions.'), call. = FALSE)
             }
         }
@@ -132,7 +143,7 @@ parameterTransform <- nimbleFunction(
             for(iNode in 1:nNodes) {
                 theseValues <- nodeValuesFromModel[transformData[iNode,NIND1]:transformData[iNode,NIND2]]
                 thisType <- transformType[iNode]
-                nimSwitch(thisType, 1:8,
+                nimSwitch(thisType, 1:9,
                           theseTransformed <- theseValues,         ## 1: scalar unconstrained
                           theseTransformed <- log(theseValues),    ## 2: scalar semi-interval (0, Inf)
                           theseTransformed <- logit(theseValues),  ## 3: scalar interval-constrained (0, 1)
@@ -164,6 +175,27 @@ parameterTransform <- nimbleFunction(
                                       theseTransformed[j] <- logit( theseValues[j] / (1-runningSum) )
                                   }
                               }
+                          },
+                          {                                        ## 9: LKJ
+                              d <- transformData[iNode,DATA1]
+                              dd <- transformData[iNode,DATA2]
+                              theseTransformed <- nimNumeric(dd)
+                              if(d > 1) {
+                                  cnt <- 1
+                                  ## More efficient to calc partialSum at start of 'i' loop
+                                  for(j in 2:d) {
+                                      theseTransformed[cnt] <- atanh(theseValues[1, j])
+                                      cnt <- cnt + 1
+                                      if(j > 2) {
+                                          partialSum <- 1 - theseValues[1, j]^2
+                                          for(i in 2:(j-1)) {
+                                              theseTransformed[cnt] <- atahn(theseValues[i, j] / sqrt(partialSum))
+                                              cnt <- cnt + 1
+                                              partialSum <- partialSum - theseValues[i, j]^2
+                                          }
+                                      }
+                                  }
+                              }
                           })
                 transformed[transformData[iNode,TIND1]:transformData[iNode,TIND2]] <- theseTransformed
             }
@@ -179,7 +211,7 @@ parameterTransform <- nimbleFunction(
                 ind2 <- transformData[iNode,TIND2]
                 theseValues <- transformedValues[ind1:ind2]
                 thisType <- transformType[iNode]
-                nimSwitch(thisType, 1:8,
+                nimSwitch(thisType, 1:9,
                           theseInvTransformed <- theseValues,          ## 1: scalar unconstrained
                           theseInvTransformed <- exp(theseValues),     ## 2: scalar semi-interval (0, Inf)
                           theseInvTransformed <- ilogit(theseValues),  ## 3: scalar interval-constrained (0, 1)
@@ -212,6 +244,31 @@ parameterTransform <- nimbleFunction(
                                   }
                               }
                               theseInvTransformed[dd] <- 1 - sum(theseInvTransformed[1:ddm1])
+                          },
+                          {                                            ## 9: LKJ
+                              d <- transformData[iNode,DATA1]
+                              theseInvTransformed <- nimNumeric(d*d, value = 0, init = TRUE)
+                              theseInvTransformed[1] <- 1
+                              if(d > 1) {
+                                  cntT <- 2
+                                  ## More efficient to calc partialSum at start of 'i' loop
+                                  for(j in 2:d) {
+                                      cntI <- (j-1)*d + 1
+                                      theseInvTransformed[cntI] <- tanh(theseValues[cntT])
+                                      partialSum <- 1 - theseInvTransformed[cntT]^2
+                                      cntI <- cntI + 1
+                                      cntT <- cntT + 1
+                                      if(j > 2) {
+                                          for(i in 2:(j-1)) {
+                                              theseInvTransformed[cntI] <- tahn(theseValues[cntT]) * sqrt(partialSum)
+                                              partialSum <- partialSum - theseInvTransformed[cntT]^2
+                                              cntI <- cntI + 1
+                                              cntT <- cntT + 1
+                                          }
+                                      }
+                                      theseInvTransformed[cntI] <- 1  ## diagonal
+                                  }
+                              }
                           })
                 ind1 <- transformData[iNode,NIND1]
                 ind2 <- transformData[iNode,NIND2]
@@ -228,7 +285,7 @@ parameterTransform <- nimbleFunction(
             for(iNode in 1:nNodes) {
                 theseValues <- transformedValues[transformData[iNode,TIND1]:transformData[iNode,TIND2]]
                 thisType <- transformType[iNode]
-                nimSwitch(thisType, 1:8,
+                nimSwitch(thisType, 1:9,
                           lpAdd <- 0,               ## 1: scalar unconstrained
                           lpAdd <- theseValues[1],  ## 2: scalar semi-interval (0, Inf)
                           {                         ## 3: scalar interval-constrained (0, 1)
@@ -268,6 +325,28 @@ parameterTransform <- nimbleFunction(
                                       runningSum <- runningSum + theseInvTransformed[i-1]
                                       x <- theseValues[i]
                                       lpAdd <- lpAdd + log(1-runningSum) - log(exp(x)+exp(-x)+2)   ## alternate: -2*log(1+exp(-x))-x)
+                                  }
+                              }
+                          },
+                          {                                            ## 9: LKJ
+                              d <- transformData[iNode,DATA1]
+                              lpAdd <- 0
+                              if(d > 1) {
+                                  cntT <- 1
+                                  ## More efficient to have transform and partialSum calc'ed at start of 'i' loop
+                                  for(j in 2:d) {
+                                      lpAdd <- lpAdd - 2*log(cosh(theseValues[cntT]))
+                                      theseInvTransformed <- tanh(theseValues[cntT])
+                                      partialSum <- 1 - theseInvTransformed^2
+                                      cntT <- cntT + 1
+                                      if(j > 2) {
+                                          for(i in 2:(j-1)) {
+                                              lpAdd <- lpAdd - 2*log(cosh(theseValues[cntT])) + 0.5*log(partialSum)
+                                              theseInvTransformed <- tahn(theseValues[cntT]) * sqrt(partialSum)
+                                              partialSum <- partialSum - theseInvTransformed^2
+                                              cntT <- cntT + 1
+                                          }
+                                      }
                                   }
                               }
                           })

--- a/packages/nimble/R/parameterTransform.R
+++ b/packages/nimble/R/parameterTransform.R
@@ -120,11 +120,11 @@ parameterTransform <- nimbleFunction(
                     transformType[i] <- 9L
                     dSq <- length(model$expandNodeNames(node, returnScalarComponents = TRUE))
                     d <- sqrt(dSq)
-                    dd <- d * (d-1) / 2  # number of transformed params
+                    p <- d * (d-1) / 2  # number of transformed params
                     transformData[i,NIND2] <- transformData[i,NIND1] + dSq - 1
-                    transformData[i,TIND2] <- transformData[i,TIND1] + dd - 1
+                    transformData[i,TIND2] <- transformData[i,TIND1] + p - 1
                     transformData[i,DATA1] <- d
-                    transformData[i,DATA2] <- dd
+                    transformData[i,DATA2] <- p
                     next }
                 stop(paste0('parameterTransform doesn\'t handle \'', dist, '\' distributions.'), call. = FALSE)
             }
@@ -177,13 +177,13 @@ parameterTransform <- nimbleFunction(
                               }
                           },
                           {                                        ## 9: LKJ
-                              d <- transformData[iNode,DATA1]
-                              dd <- transformData[iNode,DATA2]
-                              theseTransformed <- nimNumeric(dd)
-                              if(d > 1) {
+                              dd <- transformData[iNode,DATA1]
+                              pp <- transformData[iNode,DATA2]
+                              theseTransformed <- nimNumeric(pp)
+                              if(dd > 1) {
                                   cnt <- 1
                                   ## More efficient to calc partialSum at start of 'i' loop
-                                  for(j in 2:d) {
+                                  for(j in 2:dd) {
                                       theseTransformed[cnt] <- atanh(theseValues[1, j])
                                       cnt <- cnt + 1
                                       if(j > 2) {
@@ -246,15 +246,15 @@ parameterTransform <- nimbleFunction(
                               theseInvTransformed[dd] <- 1 - sum(theseInvTransformed[1:ddm1])
                           },
                           {                                            ## 9: LKJ
-                              d <- transformData[iNode,DATA1]
+                              dd <- transformData[iNode,DATA1]
                               ## Directly fill in the vectorized form of the U matrix
-                              theseInvTransformed <- nimNumeric(d*d, value = 0, init = TRUE)
+                              theseInvTransformed <- nimNumeric(dd*dd, value = 0, init = TRUE)
                               theseInvTransformed[1] <- 1
-                              if(d > 1) {
+                              if(dd > 1) {
                                   cntT <- 1
                                   ## Fill in j'th column
-                                  for(j in 2:d) {
-                                      cntI <- (j-1)*d + 1
+                                  for(j in 2:dd) {
+                                      cntI <- (j-1)*dd + 1
                                       theseInvTransformed[cntI] <- tanh(theseValues[cntT])
                                       partialSum <- 1 - theseInvTransformed[cntI]^2
                                       cntI <- cntI + 1
@@ -330,11 +330,11 @@ parameterTransform <- nimbleFunction(
                               }
                           },
                           {                                            ## 9: LKJ
-                              d <- transformData[iNode,DATA1]
+                              dd <- transformData[iNode,DATA1]
                               lpAdd <- 0
-                              if(d > 1) {
+                              if(dd > 1) {
                                   cntT <- 1
-                                  for(j in 2:d) {
+                                  for(j in 2:dd) {
                                       lpAdd <- lpAdd - 2*log(cosh(theseValues[cntT]))
                                       theseInvTransformed <- tanh(theseValues[cntT])
                                       partialSum <- 1 

--- a/packages/nimble/R/parameterTransform.R
+++ b/packages/nimble/R/parameterTransform.R
@@ -336,15 +336,15 @@ parameterTransform <- nimbleFunction(
                               if(dd > 1) {
                                   cntT <- 1
                                   for(j in 2:dd) {
-                                      lpAdd <- lpAdd - 2*log(cosh(theseValues[cntT]))
-                                      theseInvTransformed <- tanh(theseValues[cntT])
-                                      partialSum <- 1 
+                                      z <- tanh(theseValues[cntT])
+                                      lpAdd <- lpAdd - 2*log(cosh(theseValues[cntT])) +
+                                          0.5*(dd-2)*log(1-z^2)
                                       cntT <- cntT + 1
                                       if(j > 2) {
                                           for(i in 2:(j-1)) {
-                                              partialSum <- partialSum - theseInvTransformed^2
-                                              lpAdd <- lpAdd - 2*log(cosh(theseValues[cntT])) + 0.5*log(partialSum)
-                                              theseInvTransformed <- tanh(theseValues[cntT]) * sqrt(partialSum)
+                                              z <- tanh(theseValues[cntT])
+                                              lpAdd <- lpAdd - 2*log(cosh(theseValues[cntT])) +
+                                                  0.5*(dd-i-1)*log(1-z^2)
                                               cntT <- cntT + 1
                                           }
                                       }

--- a/packages/nimble/R/parameterTransform.R
+++ b/packages/nimble/R/parameterTransform.R
@@ -180,17 +180,18 @@ parameterTransform <- nimbleFunction(
                               dd <- transformData[iNode,DATA1]
                               pp <- transformData[iNode,DATA2]
                               theseTransformed <- nimNumeric(pp)
+                              theseValuesMatrix <- nimArray(theseValues, dim = c(dd, dd))
                               if(dd > 1) {
                                   cnt <- 1
                                   ## More efficient to calc partialSum at start of 'i' loop
                                   for(j in 2:dd) {
-                                      theseTransformed[cnt] <- atanh(theseValues[1, j])
+                                      theseTransformed[cnt] <- atanh(theseValuesMatrix[1, j])
                                       cnt <- cnt + 1
                                       if(j > 2) {
                                           partialSum <- 1 
                                           for(i in 2:(j-1)) {
-                                              partialSum <- partialSum - theseValues[i-1, j]^2
-                                              theseTransformed[cnt] <- atahn(theseValues[i, j] / sqrt(partialSum))
+                                              partialSum <- partialSum - theseValuesMatrix[i-1, j]^2
+                                              theseTransformed[cnt] <- atanh(theseValuesMatrix[i, j] / sqrt(partialSum))
                                               cnt <- cnt + 1
                                           }
                                       }
@@ -261,7 +262,7 @@ parameterTransform <- nimbleFunction(
                                       cntT <- cntT + 1
                                       if(j > 2) {
                                           for(i in 2:(j-1)) {
-                                              theseInvTransformed[cntI] <- tahn(theseValues[cntT]) * sqrt(partialSum)
+                                              theseInvTransformed[cntI] <- tanh(theseValues[cntT]) * sqrt(partialSum)
                                               partialSum <- partialSum - theseInvTransformed[cntI]^2
                                               cntI <- cntI + 1
                                               cntT <- cntT + 1
@@ -343,7 +344,7 @@ parameterTransform <- nimbleFunction(
                                           for(i in 2:(j-1)) {
                                               partialSum <- partialSum - theseInvTransformed^2
                                               lpAdd <- lpAdd - 2*log(cosh(theseValues[cntT])) + 0.5*log(partialSum)
-                                              theseInvTransformed <- tahn(theseValues[cntT]) * sqrt(partialSum)
+                                              theseInvTransformed <- tanh(theseValues[cntT]) * sqrt(partialSum)
                                               cntT <- cntT + 1
                                           }
                                       }

--- a/packages/nimble/R/parameterTransform.R
+++ b/packages/nimble/R/parameterTransform.R
@@ -187,11 +187,11 @@ parameterTransform <- nimbleFunction(
                                       theseTransformed[cnt] <- atanh(theseValues[1, j])
                                       cnt <- cnt + 1
                                       if(j > 2) {
-                                          partialSum <- 1 - theseValues[1, j]^2
+                                          partialSum <- 1 
                                           for(i in 2:(j-1)) {
+                                              partialSum <- partialSum - theseValues[i-1, j]^2
                                               theseTransformed[cnt] <- atahn(theseValues[i, j] / sqrt(partialSum))
                                               cnt <- cnt + 1
-                                              partialSum <- partialSum - theseValues[i, j]^2
                                           }
                                       }
                                   }
@@ -247,26 +247,27 @@ parameterTransform <- nimbleFunction(
                           },
                           {                                            ## 9: LKJ
                               d <- transformData[iNode,DATA1]
+                              ## Directly fill in the vectorized form of the U matrix
                               theseInvTransformed <- nimNumeric(d*d, value = 0, init = TRUE)
                               theseInvTransformed[1] <- 1
                               if(d > 1) {
-                                  cntT <- 2
-                                  ## More efficient to calc partialSum at start of 'i' loop
+                                  cntT <- 1
+                                  ## Fill in j'th column
                                   for(j in 2:d) {
                                       cntI <- (j-1)*d + 1
                                       theseInvTransformed[cntI] <- tanh(theseValues[cntT])
-                                      partialSum <- 1 - theseInvTransformed[cntT]^2
+                                      partialSum <- 1 - theseInvTransformed[cntI]^2
                                       cntI <- cntI + 1
                                       cntT <- cntT + 1
                                       if(j > 2) {
                                           for(i in 2:(j-1)) {
                                               theseInvTransformed[cntI] <- tahn(theseValues[cntT]) * sqrt(partialSum)
-                                              partialSum <- partialSum - theseInvTransformed[cntT]^2
+                                              partialSum <- partialSum - theseInvTransformed[cntI]^2
                                               cntI <- cntI + 1
                                               cntT <- cntT + 1
                                           }
                                       }
-                                      theseInvTransformed[cntI] <- 1  ## diagonal
+                                      theseInvTransformed[cntI] <- sqrt(partialSum)
                                   }
                               }
                           })
@@ -333,17 +334,16 @@ parameterTransform <- nimbleFunction(
                               lpAdd <- 0
                               if(d > 1) {
                                   cntT <- 1
-                                  ## More efficient to have transform and partialSum calc'ed at start of 'i' loop
                                   for(j in 2:d) {
                                       lpAdd <- lpAdd - 2*log(cosh(theseValues[cntT]))
                                       theseInvTransformed <- tanh(theseValues[cntT])
-                                      partialSum <- 1 - theseInvTransformed^2
+                                      partialSum <- 1 
                                       cntT <- cntT + 1
                                       if(j > 2) {
                                           for(i in 2:(j-1)) {
+                                              partialSum <- partialSum - theseInvTransformed^2
                                               lpAdd <- lpAdd - 2*log(cosh(theseValues[cntT])) + 0.5*log(partialSum)
                                               theseInvTransformed <- tahn(theseValues[cntT]) * sqrt(partialSum)
-                                              partialSum <- partialSum - theseInvTransformed^2
                                               cntT <- cntT + 1
                                           }
                                       }

--- a/packages/nimble/R/parameterTransform.R
+++ b/packages/nimble/R/parameterTransform.R
@@ -342,15 +342,15 @@ parameterTransform <- nimbleFunction(
                               if(dd > 1) {
                                   cntT <- 1
                                   for(j in 2:dd) {
-                                      z <- tanh(theseValues[cntT])
-                                      lpAdd <- lpAdd - 2*log(cosh(theseValues[cntT])) +
-                                          0.5*(dd-2)*log(1-z^2)
+                                      lpAdd <- lpAdd - 2*log(cosh(theseValues[cntT]))
+                                      theseInvTransformed <- tanh(theseValues[cntT])
+                                      partialSum <- 1 
                                       cntT <- cntT + 1
                                       if(j > 2) {
                                           for(i in 2:(j-1)) {
-                                              z <- tanh(theseValues[cntT])
-                                              lpAdd <- lpAdd - 2*log(cosh(theseValues[cntT])) +
-                                                  0.5*(dd-i-1)*log(1-z^2)
+                                              partialSum <- partialSum - theseInvTransformed^2
+                                              lpAdd <- lpAdd - 2*log(cosh(theseValues[cntT])) + 0.5*log(partialSum)
+                                              theseInvTransformed <- tanh(theseValues[cntT]) * sqrt(partialSum)
                                               cntT <- cntT + 1
                                           }
                                       }


### PR DESCRIPTION
In conjunction with PR #993 , this adds lkj transform to the parameter transform system.

There is testing, but it won't run, because the lkj distribution will be first merged into devel via PR #993 and is not actually available in ADoak or ADoak-addLKJ yet. The tests should pass once everything is integrated together, as I did check them under a hacked version of things. 

One good thing to do would be to compare NIMBLE HMC on a basic lkj test case to Stan. I have Stan code for this and have compared Stan to NIMBLE's non-HMC lkj samplers in the lkj branch that will be merged into devel.