### PR TITLE
fix issue 1131 by truncating result of deparse in dynamic index warning

### DIFF
--- a/packages/nimble/R/all_utils.R
+++ b/packages/nimble/R/all_utils.R
@@ -180,3 +180,13 @@ printErrors <- function(excludeWarnings = TRUE) {
         cat(errors, sep = "\n")
     } else cat("No error file found.")
 }
+
+safeDeparse <- function(expr, width.cutoff = 200L, nlines = 1, ...) {
+    out <- deparse(expr, width.cutoff = width.cutoff, nlines = nlines, ...)
+    if(nlines > 1 && length(out) > 1)
+        out <- paste0(out, collapse = '')
+    if(nchar(out) >= 200)
+        out <- paste0(out, "...")
+    return(out)
+}
+

--- a/packages/nimble/R/nimbleFunction_nodeFunction.R
+++ b/packages/nimble/R/nimbleFunction_nodeFunction.R
@@ -24,7 +24,7 @@ ndf_createDetermSimulate <- function(LHS, RHS, dynamicIndexLimitsExpr, RHSnonRep
                                 RHS = RHS,
                                 NANEXPR = nanExpr,
                                 CONDITION = dynamicIndexLimitsExpr,
-                                TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced))))
+                                TEXT = paste0("Warning: dynamic index out of bounds: ", safeDeparse(RHSnonReplaced))))
     } else code <- substitute(LHS <<- RHS,
                               list(LHS = LHS,
                                    RHS = RHS))
@@ -53,7 +53,7 @@ ndf_createStochSimulate <- function(LHS, RHS, dynamicIndexLimitsExpr, RHSnonRepl
                                 RHS = RHS,
                                 NANEXPR = nanExpr,
                                 CONDITION = dynamicIndexLimitsExpr,
-                                TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced))))
+                                TEXT = paste0("Warning: dynamic index out of bounds: ", safeDeparse(RHSnonReplaced))))
     } else {
         code <- substitute(LHS <<- RHS,
                            list(LHS = LHS,
@@ -147,7 +147,7 @@ ndf_createStochCalculate <- function(logProbNodeExpr, LHS, RHS, diff = FALSE, AD
                                        print(TEXT)}, # LocalNewLogProb <- -Inf,
                                    list(STOCHCALC = RHS,
                                         CONDITION = dynamicIndexLimitsExpr,
-                                        TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced))))
+                                        TEXT = paste0("Warning: dynamic index out of bounds: ", safeDeparse(RHSnonReplaced))))
             } else if(ADFunc){  ## don't want global assignment for _AD_ functions.
                 code <- substitute(if(isTRUE(CONDITION)) LOGPROB <- STOCHCALC
                                    else {LOGPROB <- NaN
@@ -155,7 +155,7 @@ ndf_createStochCalculate <- function(logProbNodeExpr, LHS, RHS, diff = FALSE, AD
                                    list(LOGPROB = logProbNodeExpr,
                                         STOCHCALC = RHS,
                                         CONDITION = dynamicIndexLimitsExpr,
-                                        TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced))))
+                                        TEXT = paste0("Warning: dynamic index out of bounds: ", safeDeparse(RHSnonReplaced))))
             } else {
 
                 code <- substitute(if(isTRUE(CONDITION)) LOGPROB <<- STOCHCALC
@@ -164,7 +164,7 @@ ndf_createStochCalculate <- function(logProbNodeExpr, LHS, RHS, diff = FALSE, AD
                                    list(LOGPROB = logProbNodeExpr,
                                         STOCHCALC = RHS,
                                         CONDITION = dynamicIndexLimitsExpr,
-                                        TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced))))
+                                        TEXT = paste0("Warning: dynamic index out of bounds: ", safeDeparse(RHSnonReplaced))))
             }
         } else {
             if(diff) {
@@ -234,7 +234,7 @@ ndf_createStochCalculateTrunc <- function(logProbNodeExpr, LHS, RHS, diff = FALS
                                        print(TEXT)}, # LocalNewLogProb <- -Inf,
                                    list(STOCHCALC = RHS,
                                         CONDITION = dynamicIndexLimitsExpr,
-                                        TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced))))
+                                        TEXT = paste0("Warning: dynamic index out of bounds: ", safeDeparse(RHSnonReplaced))))
 
     
     if(nimbleOptions()$allowDynamicIndexing && !is.null(dynamicIndexLimitsExpr)) {
@@ -268,7 +268,7 @@ ndf_createStochCalculateTrunc <- function(logProbNodeExpr, LHS, RHS, diff = FALS
                                                    PDIST_UPPER = PDIST_UPPER,
                                                    DDIST_LOWER = DDIST_LOWER,
                                                    CONDITION = dynamicIndexLimitsExpr,
-                                                   TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced))
+                                                   TEXT = paste0("Warning: dynamic index out of bounds: ", safeDeparse(RHSnonReplaced))
                                                )), list( e = substCode)))
         } else {
             if(discrete && lower != -Inf) {
@@ -301,7 +301,7 @@ ndf_createStochCalculateTrunc <- function(logProbNodeExpr, LHS, RHS, diff = FALS
                                                    PDIST_UPPER = PDIST_UPPER,
                                                    DDIST_LOWER = DDIST_LOWER,
                                                    CONDITION = dynamicIndexLimitsExpr,
-                                                   TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced))
+                                                   TEXT = paste0("Warning: dynamic index out of bounds: ", safeDeparse(RHSnonReplaced))
                                                )), list(e = substCode)))
         }
     } else {


### PR DESCRIPTION
This uses a new `safeDeparse` utility