### PR TITLE
fix issue 1128

### DIFF
--- a/packages/nimble/R/BNP_samplers.R
+++ b/packages/nimble/R/BNP_samplers.R
@@ -1445,6 +1445,8 @@ sampler_CRP <- nimbleFunction(
     ## needs to be legitimate nodes because run code sets up calculate even if if() would never cause it to be used
     for(i in seq_len(n)) { # dataNodes are always needed so only create them before creating  intermNodes
       stochDeps <- model$getDependencies(targetElements[i], stochOnly = TRUE, self = FALSE)
+      if(length(stochDeps) != nObsPerClusID)
+        stop("sampler_CRP: The number of stochastic dependents is not constant across the cluster IDs (the elements of '", targetVar, '"). NIMBLE's CRP sampling is not set up to handle this case.")
       dataNodes[((i-1)*nObsPerClusID + 1) : (i*nObsPerClusID)] <- stochDeps
     }
     nIntermClusNodesPerClusID <- length(model$getDependencies(targetElements[1], determOnly = TRUE))  #nInterm
@@ -1452,7 +1454,9 @@ sampler_CRP <- nimbleFunction(
     if(nIntermClusNodesPerClusID > 0) {
       intermNodes <- rep(as.character(NA), nIntermClusNodesPerClusID * n)
       for(i in seq_len(n)) {
-        detDeps <- model$getDependencies(targetElements[i], determOnly = TRUE)
+          detDeps <- model$getDependencies(targetElements[i], determOnly = TRUE)
+          if(length(detDeps) != nIntermClusNodesPerClusID)
+              stop("sampler_CRP: The number of deterministic dependents is not constant across the cluster IDs (the elements of '", targetVar, '"). NIMBLE's CRP sampling is not set up to handle this case.")
         intermNodes[((i-1)*nIntermClusNodesPerClusID+1):(i*nIntermClusNodesPerClusID)] <- detDeps
       }
     }
@@ -1648,7 +1652,7 @@ sampler_CRP <- nimbleFunction(
         iprob <- 1
         for(j in 1:k) {
           if( xiCounts[xiUniques[j]] >= 1 ) { 
-            model[[target]][i] <<- xiUniques[j] # <<-
+            model[[target]][i] <<- xiUniques[j] 
             if(nIntermClusNodesPerClusID > 0) {
               model$calculate(intermNodes[((i-1)*nIntermClusNodesPerClusID+1):(i*nIntermClusNodesPerClusID)]) 
             }

--- a/packages/nimble/R/BNP_samplers.R
+++ b/packages/nimble/R/BNP_samplers.R
@@ -1446,7 +1446,7 @@ sampler_CRP <- nimbleFunction(
     for(i in seq_len(n)) { # dataNodes are always needed so only create them before creating  intermNodes
       stochDeps <- model$getDependencies(targetElements[i], stochOnly = TRUE, self = FALSE)
       if(length(stochDeps) != nObsPerClusID)
-        stop("sampler_CRP: The number of stochastic dependents is not constant across the cluster IDs (the elements of '", targetVar, '"). NIMBLE's CRP sampling is not set up to handle this case.")
+        stop("sampler_CRP: The number of stochastic dependents is not constant across the cluster IDs (the elements of '", targetVar, ",). NIMBLE's CRP sampling is not set up to handle this case.")
       dataNodes[((i-1)*nObsPerClusID + 1) : (i*nObsPerClusID)] <- stochDeps
     }
     nIntermClusNodesPerClusID <- length(model$getDependencies(targetElements[1], determOnly = TRUE))  #nInterm
@@ -1456,7 +1456,7 @@ sampler_CRP <- nimbleFunction(
       for(i in seq_len(n)) {
           detDeps <- model$getDependencies(targetElements[i], determOnly = TRUE)
           if(length(detDeps) != nIntermClusNodesPerClusID)
-              stop("sampler_CRP: The number of deterministic dependents is not constant across the cluster IDs (the elements of '", targetVar, '"). NIMBLE's CRP sampling is not set up to handle this case.")
+              stop("sampler_CRP: The number of deterministic dependents is not constant across the cluster IDs (the elements of '", targetVar, "'). NIMBLE's CRP sampling is not set up to handle this case.")
         intermNodes[((i-1)*nIntermClusNodesPerClusID+1):(i*nIntermClusNodesPerClusID)] <- detDeps
       }
     }

--- a/packages/nimble/tests/testthat/test-bnp.R
+++ b/packages/nimble/tests/testthat/test-bnp.R
@@ -6104,7 +6104,8 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
   expect_error(mcmc <- buildMCMC(conf), "sampler_CRP: Only the variables being clustered")
 
   ## too many xi values
-  ## This error should be trapped more cleanly.
+  ## As of issue 1128/PR 1137, this error is now trapped based on non-constant number of deps
+  ## rather than a more obscure former error.
   code <- nimbleCode({
       for(i in 1:n) {
           for(j in 1:J) {
@@ -6126,7 +6127,7 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
                 thetaTilde = matrix(rnorm(J*n), n, J))
   model <- nimbleModel(code, data = data, constants = constants, inits = inits)
   expect_silent(conf <- configureMCMC(model, print = FALSE))
-  expect_error(mcmc <- buildMCMC(conf), "replacement has length zero")
+  expect_error(mcmc <- buildMCMC(conf), "number of stochastic dependents is not constant")
 
   ## too few xi values
   code <- nimbleCode({


### PR DESCRIPTION
This adds a check when building the CRP sampler that the number of stoch deps as well as deterministic deps is constant across the groups (i.e., the dependents of each element of the clustering variable).