### PR TITLE
add error trap for incorrect [[ in nf run code

### DIFF
--- a/packages/nimble/R/nimbleFunction_keywordProcessing.R
+++ b/packages/nimble/R/nimbleFunction_keywordProcessing.R
@@ -603,6 +603,7 @@ doubleBracket_keywordInfo <- keywordInfoClass(
             }
             return(ans)			
         }
+        stop("Incorrect use of double brackets in: '", deparse(code), "'.")
     })
 
 modelMemberFun_keywordInfo <- keywordInfoClass(


### PR DESCRIPTION
This addresses an untrapped error when incorrectly using `[[` in nf run code, per NCT issue 300.