### PR TITLE
warn of dynamic indexes in a vector like `a[1:L]`

### DIFF
--- a/UserManual/src/chapter_MCMC.Rmd
+++ b/UserManual/src/chapter_MCMC.Rmd
@@ -559,7 +559,7 @@ The `run` method has an optional `reset` argument.  When `reset = TRUE` (the def
   1. All MCMC sampler functions are reset to their initial state: the initial values of any sampler control parameters (e.g., `scale`, `sliceWidth`, or `propCov`) are reset to their initial values, as were specified by the original MCMC configuration.
   1. The internal modelValues objects `mvSamples` and `mvSamples2` are each resized to the appropriate length for holding the requested number of samples (`niter/thin`, and `niter/thin2`, respectively).
 
-This means that one can run a new MCMC  without having to recompile the MCMC. This can be helpful if one wants to use the same MCMC configuration but with different starting values, different data values, or other changes to values in the model.
+This means that one can begin a new run of an existing MCMC without having to rebuild or recompile the model or the MCMC. This can be helpful if one wants to use the same model and MCMC configuration, but with different initial values, different values of data nodes (but which nodes are data nodes must be the same), changes to covariate values(or other non-data, non-parameter values) in the model, or a different number of MCMC iterations, thinning interval or burn-in.
 
 In contrast, when `mcmc$run(niter, reset = FALSE)` is called, the MCMC picks up from where it left off, continuing the previous chain and expanding the output as needed.  No values in the model are checked or altered, and sampler functions are not reset to their initial states.
 

--- a/packages/nimble/R/BUGS_BUGSdecl.R
+++ b/packages/nimble/R/BUGS_BUGSdecl.R
@@ -889,6 +889,8 @@ getSymbolicParentNodesRecurse <- function(code, constNames = list(), indexNames 
             if(isRonly & !allContentsReplaceable) {
                 if(!exists(funName, envir))
                     stop("R function '", funName,"' does not exist.")
+                if(funName == ":") ## dynamic indexing in a vector of indices
+                    stop("Dynamic indexing found in a vector of indices, ", deparse(code), ". Only scalar indices, such as 'idx' in 'x[idx]', can be dynamic. One can instead use dynamic indexing in a vector of indices inside a nimbleFunction.") 
                 unreplaceable <-
                     sapply(contents[!contentsReplaceable],
                            function(x) as.character(x$code)

--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -1,5 +1,5 @@
 #' Class \code{modelBaseClass}
-#' @aliases modelBaseClass getVarNames getNodeNames topologicallySortNodes resetData setData isData isEndNode getDistribution isDiscrete isBinary isStoch isDeterm isTruncated isUnivariate isMultivariate getDimension getDependencies getDependenciesList getDownstream expandNodeNames setInits checkConjugacy getCode newModel [[,modelBaseClass-method [[<-,modelBaseClass-method initializeInfo
+#' @aliases modelBaseClass getVarNames getNodeNames topologicallySortNodes resetData setData isData isEndNode getDistribution isDiscrete isBinary isStoch isDeterm isTruncated isUnivariate isMultivariate getDimension getDependencies getDependenciesList getDownstream expandNodeNames setInits checkConjugacy getCode newModel getParents [[,modelBaseClass-method [[<-,modelBaseClass-method initializeInfo
 #' @export
 #' @description
 #' This class underlies all NIMBLE model objects: both R model objects created from the return value of nimbleModel(), and compiled model objects.

--- a/packages/nimble/R/MCMC_run.R
+++ b/packages/nimble/R/MCMC_run.R
@@ -300,7 +300,7 @@ nimbleMCMC <- function(code,
     if(!missing(code) && inherits(code, 'modelBaseClass')) model <- code   ## let's handle it, if model object is provided as un-named first argument to nimbleMCMC
     if(missing(model)) {  ## model object not provided
         if(!missing(inits)) {
-            if(!is.function(inits) && !is.list(inits)) stop('inits must be a function, a list of initial values, or a list (of length nchains) of lists of inital values')
+            if(!is.function(inits) && !is.list(inits)) stop('inits must be a function, a list of initial values, or a list (of length nchains) of lists of initial values')
             if(is.list(inits) && (length(inits) > 0) && is.list(inits[[1]]) && (length(inits) != nchains)) stop('inits must be a function, a list of initial values, or a list (of length nchains) of lists of inital values')
             if(is.function(inits)) {
                 if(is.numeric(setSeed) || setSeed) { if(is.numeric(setSeed)) set.seed(setSeed[1]) else set.seed(0) }

--- a/packages/nimble/tests/testthat/dynamicIndexingTestLists.R
+++ b/packages/nimble/tests/testthat/dynamicIndexingTestLists.R
@@ -573,7 +573,7 @@ testsInvalidDynIndex <- list(
         }), 
         inits = list(mu = rnorm(5)),
         expectError = TRUE,
-        expectErrorMsg = "arguments that cannot be evaluated"
+        expectErrorMsg = "Dynamic indexing found in a vector"
     ),
     list(
         case = 'dynamic index sequence, multiple dynamic indexes (invalid)',
@@ -584,7 +584,7 @@ testsInvalidDynIndex <- list(
         }), 
         inits = list(mu = rnorm(5)),
         expectError = TRUE,
-        expectErrorMsg = "arguments that cannot be evaluated"
+        expectErrorMsg = "Dynamic indexing found in a vector"
     ),
     list(
         case = 'dynamic indexing of constants',


### PR DESCRIPTION
This partially addresses NCT issue 315 by giving a more interpretable error message than before.

It intercedes before the existing error: `R function `:` has arguments that cannot be evaluated; either the function must be a nimbleFunction or values for the following inputs must be specified as constants in the model` and instead says:

```
"Dynamic indexing found in a vector of indices, ", deparse(code), ". Only scalar indices, such as 'idx' in 'x[idx]', can be dynamic. One can instead use dynamic indexing in a vector of indices inside a nimbleFunction."
```