### PR TITLE
error trap when BNP model has differing number of obs or intermediates per group

### DIFF
--- a/packages/nimble/R/BNP_samplers.R
+++ b/packages/nimble/R/BNP_samplers.R
@@ -1445,6 +1445,8 @@ sampler_CRP <- nimbleFunction(
     ## needs to be legitimate nodes because run code sets up calculate even if if() would never cause it to be used
     for(i in seq_len(n)) { # dataNodes are always needed so only create them before creating  intermNodes
       stochDeps <- model$getDependencies(targetElements[i], stochOnly = TRUE, self = FALSE)
+      if(length(stochDeps) != nObsPerClusID)
+          stop("sampler_CRP: The number of nodes that are jointly clustered must be the same for each group. For example if 'mu[i,j]' are clustered such that all nodes for a given 'i' must be in the same cluster, then the number of nodes for each 'i' must be the same.")
       dataNodes[((i-1)*nObsPerClusID + 1) : (i*nObsPerClusID)] <- stochDeps
     }
     nIntermClusNodesPerClusID <- length(model$getDependencies(targetElements[1], determOnly = TRUE))  #nInterm
@@ -1453,6 +1455,8 @@ sampler_CRP <- nimbleFunction(
       intermNodes <- rep(as.character(NA), nIntermClusNodesPerClusID * n)
       for(i in seq_len(n)) {
         detDeps <- model$getDependencies(targetElements[i], determOnly = TRUE)
+        if(length(detDeps) != nIntermClusNodesPerClusID)
+            stop("sampler_CRP: The number of intermediate deterministic nodes that are jointly clustered must be the same for each group. For example if 'mu[i,j]' are clustered such that all nodes for a given 'i' must be in the same cluster, then the number of nodes for each 'i' must be the same.")
         intermNodes[((i-1)*nIntermClusNodesPerClusID+1):(i*nIntermClusNodesPerClusID)] <- detDeps
       }
     }

--- a/packages/nimble/R/BNP_samplers.R
+++ b/packages/nimble/R/BNP_samplers.R
@@ -1446,7 +1446,7 @@ sampler_CRP <- nimbleFunction(
     for(i in seq_len(n)) { # dataNodes are always needed so only create them before creating  intermNodes
       stochDeps <- model$getDependencies(targetElements[i], stochOnly = TRUE, self = FALSE)
       if(length(stochDeps) != nObsPerClusID)
-          stop("sampler_CRP: The number of nodes that are jointly clustered must be the same for each group. For example if 'mu[i,j]' are clustered such that all nodes for a given 'i' must be in the same cluster, then the number of nodes for each 'i' must be the same.")
+          stop("sampler_CRP: The number of nodes that are jointly clustered must be the same for each group. For example if 'mu[i,j]' are clustered such that all nodes for a given 'i' must be in the same cluster, then the number of nodes for each 'i' must be the same. Group ", deparse(i), " has ", deparse(length(stochDeps)), " nodes being clustered where ", deparse(nObsPerClusID), " are expected.")
       dataNodes[((i-1)*nObsPerClusID + 1) : (i*nObsPerClusID)] <- stochDeps
     }
     nIntermClusNodesPerClusID <- length(model$getDependencies(targetElements[1], determOnly = TRUE))  #nInterm
@@ -1456,7 +1456,7 @@ sampler_CRP <- nimbleFunction(
       for(i in seq_len(n)) {
         detDeps <- model$getDependencies(targetElements[i], determOnly = TRUE)
         if(length(detDeps) != nIntermClusNodesPerClusID)
-            stop("sampler_CRP: The number of intermediate deterministic nodes that are jointly clustered must be the same for each group. For example if 'mu[i,j]' are clustered such that all nodes for a given 'i' must be in the same cluster, then the number of nodes for each 'i' must be the same.")
+            stop("sampler_CRP: The number of intermediate deterministic nodes that are jointly clustered must be the same for each group. For example if 'mu[i,j]' are clustered such that all nodes for a given 'i' must be in the same cluster, then the number of nodes for each 'i' must be the same. Group ", deparse(i), " has ", deparse(length(depDeps)), " intermediate nodes being clustered where ", deparse(nIntermClusNodesPerClusID), " are expected.")
         intermNodes[((i-1)*nIntermClusNodesPerClusID+1):(i*nIntermClusNodesPerClusID)] <- detDeps
       }
     }

--- a/packages/nimble/tests/testthat/test-bnp.R
+++ b/packages/nimble/tests/testthat/test-bnp.R
@@ -6122,7 +6122,7 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
                 thetaTilde = matrix(rnorm(J*n), n, J))
   model <- nimbleModel(code, data = data, constants = constants, inits = inits)
   expect_silent(conf <- configureMCMC(model, print = FALSE))
-  expect_error(mcmc <- buildMCMC(conf), "replacement has length zero")
+  expect_error(mcmc <- buildMCMC(conf), "The number of nodes that are jointly clustered must be the same")
 
   ## too few xi values
   code <- nimbleCode({


### PR DESCRIPTION
This fixes the error trap problem in issue #1128. The feature addition possibility is now NCT issue 316.