### PR TITLE
adjust as.matrix for modelValues to better deal with no monitors or incorrect `vars` arg

### DIFF
--- a/packages/nimble/R/MCMC_run.R
+++ b/packages/nimble/R/MCMC_run.R
@@ -134,8 +134,14 @@ runMCMC <- function(mcmc,
         }
         ##model$calculate()   # shouldn't be necessary, since mcmc$run() includes call to my_initializeModel$run()
         mcmc$run(niter, nburnin = nburnin, thin = thinToUseVec[1], thin2 = thinToUseVec[2], progressBar = progressBar) #, samplerExecutionOrder = samplerExecutionOrderToUse)
-        samplesList[[i]] <- as.matrix(mcmc$mvSamples)
-        if(hasMonitors2)   samplesList2[[i]] <- as.matrix(mcmc$mvSamples2)
+        tmp <- as.matrix(mcmc$mvSamples)
+        if(!is.null(tmp))
+            samplesList[[i]] <- tmp 
+        if(hasMonitors2) {
+            tmp <- as.matrix(mcmc$mvSamples2)
+            if(!is.null(tmp))
+                samplesList2[[i]] <- tmp 
+        }
     }
     if(WAIC) {
         if(nchains > 1) {
@@ -154,8 +160,11 @@ runMCMC <- function(mcmc,
         if(hasMonitors2)   samplesList2 <- as.mcmc.list(lapply(samplesList2, as.mcmc))
     }
     if(nchains == 1) {
-        samplesList <- samplesList[[1]]                       ## returns matrix when nchains = 1
-        if(hasMonitors2)   samplesList2 <- samplesList2[[1]]  ## returns matrix when nchains = 1
+        if(length(samplesList))
+            samplesList <- samplesList[[1]] else samplesList <- NULL   ## returns matrix when nchains = 1
+        if(hasMonitors2)
+            if(length(samplesList2))
+                samplesList2 <- samplesList2[[1]] else samplesList2 <- NULL  ## returns matrix when nchains = 1
     }
     if(summary) {
         if(nchains == 1) {

--- a/packages/nimble/R/cppInterfaces_modelValues.R
+++ b/packages/nimble/R/cppInterfaces_modelValues.R
@@ -100,7 +100,10 @@ CmodelValues <- setRefClass(
         	jnk <- eval(call('.Call', nimbleUserNamespace$sessionSpecificDll$setVecNimArrRows, ptr, as.integer(rows), TRUE))
         	jnk <- eval(call('.Call', nimbleUserNamespace$sessionSpecificDll$manualSetNRows, extptr, as.integer(rows)) )  	
         	},
-        getSize = function() {	eval(call('.Call', nimbleUserNamespace$sessionSpecificDll$getNRow, componentExtptrs[[1]])) } ## formerly getCRows(componentExtptrs[[1]])		}
+        getSize = function() {
+            if(length(componentExtptrs))
+                eval(call('.Call', nimbleUserNamespace$sessionSpecificDll$getNRow, componentExtptrs[[1]])) else 0
+        } ## formerly getCRows(componentExtptrs[[1]])		}
         )
     )
 

--- a/packages/nimble/R/types_util.R
+++ b/packages/nimble/R/types_util.R
@@ -180,10 +180,12 @@ expandMVNames <- function(mv, varNames){
 
 as.matrix.modelValuesBaseClass <- function(x, varNames, ...){
 	if(missing(varNames))
-			varNames <- x$varNames
+            varNames <- x$varNames
+        if(!length(varNames))
+            return(NULL)
 	nrows = getsize(x)
 	flatNames = expandMVNames(x, varNames)
-	ans <- matrix(0.1, nrow = nrows, ncol = length(flatNames))
+	ans <- matrix(as.numeric(NA), nrow = nrows, ncol = length(flatNames))
 	colIndex = 1
 	for(i in seq_along(varNames)){
 		.Call(fastMatrixInsert, ans, modelValuesElement2Matrix(x, varNames[i]) , as.integer(1), as.integer(colIndex) ) 		
@@ -196,10 +198,12 @@ as.matrix.modelValuesBaseClass <- function(x, varNames, ...){
 
 as.matrix.CmodelValues <- function(x, varNames, ...){
 	if(missing(varNames))
-			varNames <- x$varNames
+            varNames <- x$varNames
+        if(!length(varNames))
+            return(NULL)
 	nrows = getsize(x)
 	flatNames = expandMVNames(x, varNames)
-	ans <- matrix(0.1, nrow = nrows, ncol = length(flatNames))
+	ans <- matrix(as.numeric(NA), nrow = nrows, ncol = length(flatNames))
 	colIndex = 1
 	for(i in seq_along(varNames)){
 		.Call(fastMatrixInsert, ans, modelValuesElement2Matrix(x, varNames[i]) , as.integer(1), as.integer(colIndex) ) 		


### PR DESCRIPTION
See issue #1140 