### PR TITLE
robustify `nimble::deparse` to allow truncation to only first element of result

### DIFF
--- a/packages/nimble/R/BNP_samplers.R
+++ b/packages/nimble/R/BNP_samplers.R
@@ -1338,7 +1338,7 @@ sampler_CRP <- nimbleFunction(
     
     if(any(clusterVarInfo$nTilde == 0)) {
       var <- which(clusterVarInfo$nTilde == 0)
-      stop("sampler_CRP: Detected unusual indexing in ", deparse(clusterVarInfo$indexExpr[[var[1]]]),
+      stop("sampler_CRP: Detected unusual indexing in ", deparse(clusterVarInfo$indexExpr[[var[1]]], maxlen = 1),
            " . NIMBLE's CRP MCMC sampling is not designed for this case.")
     }
     
@@ -1403,8 +1403,8 @@ sampler_CRP <- nimbleFunction(
                 if(!identical(clusterVarInfo$clusterNodes[[idx1]], clusterVarInfo$clusterNodes[[idx2]]) &&
                    any(clusterVarInfo$clusterNodes[[idx1]] %in% clusterVarInfo$clusterNodes[[idx2]]))
                     stop("sampler_CRP: Inconsistent indexing in or inconsistent dependencies of ",
-                         deparse(clusterVarInfo$indexExpr[[idx1]]), " and ",
-                         deparse(clusterVarInfo$indexExpr[[idx2]]), ".")
+                         deparse(clusterVarInfo$indexExpr[[idx1]], maxlen = 1), " and ",
+                         deparse(clusterVarInfo$indexExpr[[idx2]], maxlen = 1), ".")
     
     nData <- length(dataNodes)
 
@@ -1412,7 +1412,7 @@ sampler_CRP <- nimbleFunction(
     ## It's likely that if we set the non-conjugate sampler and turn off wrapping omits sampling of empty clusters
     ## (which is not set up correctly for this case), that the existing code would give correct sampling.
     if(any(clusterVarInfo$multipleStochIndexes))
-        stop("sampler_CRP: Detected use of multiple stochastic indexes of a variable: ", deparse(clusterVarInfo$indexExpr[[1]]), ". NIMBLE's CRP sampling is not yet set up to handle this case. Please contact the NIMBLE development team if you are interested in this functionality.")
+        stop("sampler_CRP: Detected use of multiple stochastic indexes of a variable: ", deparse(clusterVarInfo$indexExpr[[1]], maxlen = 1), ". NIMBLE's CRP sampling is not yet set up to handle this case. Please contact the NIMBLE development team if you are interested in this functionality.")
 
     ## Check there is at least one or more "observation" per random index.
     ## Note that cases like mu[xi[i],xi[j]] are being trapped in findClusterNodes().
@@ -1849,7 +1849,7 @@ findClusterNodes <- function(model, target) {
         while(k <= len) {
             if(sum(all.vars(subExpr[[k]]) == targetVar)) {
                 if(foundTarget) {
-                    stop("findClusterNodes: CRP variable used multiple times in ", deparse(subExpr),
+                    stop("findClusterNodes: CRP variable used multiple times in ", deparse(subExpr, maxlen = 1),
                            ". NIMBLE's CRP MCMC sampling not designed for this situation.")
                 } else {
                     foundTarget <- TRUE

--- a/packages/nimble/R/BUGS_BUGSdecl.R
+++ b/packages/nimble/R/BUGS_BUGSdecl.R
@@ -260,13 +260,13 @@ BUGSdeclClass$methods(
                 code[[3]][[1]] != "I"))
                 stop(
                     paste0('Improper syntax for stochastic declaration: ',
-                           deparse(code))
+                           deparse(code, maxlen = 1))
                 )
         } else if(code[[1]] == '<-') {
             type <<- 'determ'
         } else {
             stop(paste0('Improper syntax for declaration: ',
-                        deparse(code))
+                        deparse(code, maxlen = 1))
                  )
         }
         
@@ -296,7 +296,7 @@ BUGSdeclClass$methods(
                     ## There are subscripts inside the transformation
                     if(targetNodeExpr[[1]] != '[') {
                         print(paste("Invalid subscripting for",
-                                    deparse(targetExpr)))
+                                    deparse(targetExpr, maxlen = 1)))
                     }
                     indexExpr <<- as.list(targetNodeExpr[-c(1,2)])
                     targetVarExpr <<- targetNodeExpr[[2]]
@@ -377,7 +377,7 @@ makeIndexNamePieces <- function(indexCode) {
     ## Diagnostic for messed up indexing here
     if(as.character(indexCode[[1]] != ':'))
         stop(paste0("Error processing model: something is wrong with the index ",
-                    deparse(indexCode),
+                    deparse(indexCode, maxlen = 1),
                     ".\nIndexing in model code requires this syntax: '(start expression):(end expression)'."),
              call. = FALSE)
     p1 <- indexCode[[2]]
@@ -465,7 +465,7 @@ BUGSdeclClass$methods(
             )
         if(inherits(targetIndexNamePieces, 'try-error'))
             stop(paste('Error occurred defining ',
-                       deparse(targetExprReplaced)),
+                       deparse(targetExprReplaced, maxlen = 1)),
                  call. = FALSE)
     if(!nimbleOptions()$allowDynamicIndexing) {
         parentIndexNamePieces <<-
@@ -591,13 +591,13 @@ BUGSdeclClass$methods(
                        is.numeric(boundExprs$upper_) &&
                        boundExprs$lower_ >= boundExprs$upper_)
                         warning(paste0("Lower bound is greater than or equal to upper bound in ",
-                                       deparse(codeReplaced),
+                                       deparse(codeReplaced, maxlen = 1),
                                        "; proceeding anyway, but this is likely to cause numerical issues."))
                     if(is.numeric(boundExprs$lower_) &&
                        is.numeric(distRange$lower) &&
                        boundExprs$lower_ < distRange$lower) {
                         warning(paste0("Lower bound is less than or equal to distribution lower bound in ",
-                                       deparse(codeReplaced), "; ignoring user-provided lower bound."))
+                                       deparse(codeReplaced, maxlen = 1), "; ignoring user-provided lower bound."))
                         boundExprs$lower_ <<- distRange$lower
                         codeReplaced[[3]]['lower_'] <<- distRange$lower
                     }
@@ -605,7 +605,7 @@ BUGSdeclClass$methods(
                        is.numeric(distRange$upper) &&
                        boundExprs$upper_ > distRange$upper) {
                         warning(paste0("Upper bound is greater than or equal to distribution upper bound in ",
-                                       deparse(codeReplaced),
+                                       deparse(codeReplaced, maxlen = 1),
                                        "; ignoring user-provided upper bound."))
                         boundExprs$upper_ <<- distRange$upper
                         codeReplaced[[3]]['upper_'] <<- distRange$upper
@@ -762,7 +762,7 @@ getSymbolicParentNodesRecurse <- function(code, constNames = list(), indexNames 
             ## error if it looks like mu[i][j] where i is a for-loop index
             if(variable$hasIndex)
                 stop('Error: Variable',
-                     deparse(code[[2]]),
+                     deparse(code[[2]], maxlen = 1),
                      'on outside of [ contains a BUGS code index.')
             
             if(variable$replaceable) {
@@ -770,7 +770,7 @@ getSymbolicParentNodesRecurse <- function(code, constNames = list(), indexNames 
                 ## block[i], so block is replaceable
                 if(!all(contentsReplaceable)) 
                     ## dynamic index on a constant
-                    stop('getSymbolicParentNodesRecurse: dynamic indexing of constants is not allowed in ', deparse(code), '. Try adding the dynamically-indexed constant as data instead (using the data argument of nimbleModel).')
+                    stop('getSymbolicParentNodesRecurse: dynamic indexing of constants is not allowed in ', deparse(code, maxlen = 1), '. Try adding the dynamically-indexed constant as data instead (using the data argument of nimbleModel).')
                 boolIndexingBlock <-
                     unlist(
                         lapply(code[-c(1,2)],
@@ -802,7 +802,7 @@ getSymbolicParentNodesRecurse <- function(code, constNames = list(), indexNames 
                 } else { ## non-replaceable indices are dynamic indices (or constant vectors, which are not allowed)
                     if(!nimbleOptions()$allowDynamicIndexing) {
                         warning("It appears you are trying to use dynamic indexing (i.e., the index of a variable is determined by something that is not a constant) in: ",
-                                deparse(code),
+                                deparse(code, maxlen = 1),
                                 ". This is now allowed as of version 0.6-6 (as an optional beta feature) and by default as of version 0.6-7. Please set 'nimbleOptions(allowDynamicIndexing = TRUE)' and report any issues to the NIMBLE users group.")
                         dynamicIndexParent <- code[[2]]
                     } else {
@@ -811,7 +811,7 @@ getSymbolicParentNodesRecurse <- function(code, constNames = list(), indexNames 
                                    detectNonscalarIndex))
                            )
                             stop("getSymbolicParentNodesRecurse: only scalar indices are allowed; vector indexing found in ",
-                                 deparse(code))
+                                 deparse(code, maxlen = 1))
                         indexedVariable <- deparse(code[[2]])
                         dynamicIndexParent <-
                             addUnknownIndexToVarNameInBracketExpr(code, contextID)
@@ -905,7 +905,7 @@ getSymbolicParentNodesRecurse <- function(code, constNames = list(), indexNames 
         }
     }
     stop(paste('Something went wrong in getSymbolicVariablesRecurse with',
-               deparse(code)))
+               deparse(code, maxlen = 1)))
 }
 
 checkNimbleOrRfunctionNames <- function(functionName, envir) {
@@ -1060,7 +1060,7 @@ genReplacementsAndCodeRecurse <- function(code,
             isRonly <- FALSE
         if(isRonly & !allContentsReplaceable)
             stop(paste0('Error, R function \"',
-                        deparse(code[[1]]),
+                        deparse(code[[1]], maxlen = 1),
                         '\" has non-replaceable node values as arguments.  Must be a nimble function.')
                  )
         if(isRfunction & allContentsReplaceable)
@@ -1072,7 +1072,7 @@ genReplacementsAndCodeRecurse <- function(code,
                                 startingAt=2))
     }
     stop(paste('Something went wrong in genReplacementsAndCodeRecurse with',
-               deparse(code)))
+               deparse(code, maxlen = 1)))
 }
 
 replaceAllCodeSuccessfully <- function(code) {

--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -1030,7 +1030,7 @@ Checks for size/dimension mismatches and for presence of NAs in model variables 
                                                           LHSsize <- LHSsize[LHSsize != 1]
 
                                                       if(!identical(LHSsize, RHSsize))
-                                                          stop("Size/dimension mismatch between left-hand side and right-hand size of BUGS expression: ", deparse(declInfo$code))
+                                                          stop("Size/dimension mismatch between left-hand side and right-hand size of BUGS expression: ", deparse(declInfo$code, maxlen = 1))
                                                   }
                                                   ## these lines caused a problem for functions such as chol() in BUGS code
                                                   ## removed by DT April 2016
@@ -1105,9 +1105,9 @@ Checks for size/dimension mismatches and for presence of NAs in model variables 
                                                       matCols <- unlist(sapply(sizes[mats], `[`, 2))
                                                       if(!length(unique(c(matRows, matCols, unlist(sizes[vecs])))) <= 1)
                                                           if(dist %in% names(nimble:::distributionsInputList)) {
-                                                              stop("Size/dimension mismatch amongst vectors and matrices in BUGS expression: ", deparse(declInfo$code))
+                                                              stop("Size/dimension mismatch amongst vectors and matrices in BUGS expression: ", deparse(declInfo$code, maxlen = 1))
                                                           } else {
-                                                              warning("Possible size/dimension mismatch amongst vectors and matrices in BUGS expression: ", deparse(declInfo$code), ". Ignore this warning if the user-provided distribution has multivariate parameters with distinct sizes or if size of variable differs from sizes of parameters.")                                                                                                                                   }
+                                                              warning("Possible size/dimension mismatch amongst vectors and matrices in BUGS expression: ", deparse(declInfo$code, maxlen = 1), ". Ignore this warning if the user-provided distribution has multivariate parameters with distinct sizes or if size of variable differs from sizes of parameters.")                                                                                                                                   }
                                                   }
 
                                               }
@@ -1280,7 +1280,7 @@ insertSingleIndexBrackets <- function(code, varInfo) {
         }
         return(code)
     }
-    if(!is.null(code)) message(paste('confused about reaching end of insertSingleBrackets with ', deparse(code)))
+    if(!is.null(code)) message(paste('confused about reaching end of insertSingleBrackets with ', deparse(code, maxlen = 1)))
     return(code)
 }
 

--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -1210,7 +1210,7 @@ cc_expandDetermNodesInExpr <- function(model, expr, targetNode = NULL, skipExpan
             expr[[i]] <- cc_expandDetermNodesInExpr(model, expr[[i]], targetNode, skipExpansionsNode)
         return(expr)
     }
-    stop(paste0('something went wrong processing: ', deparse(expr)))
+    stop(paste0('something went wrong processing: ', deparse(expr, maxlen = 1)))
 }
 
 
@@ -1325,7 +1325,7 @@ cc_getNodesInExpr <- function(expr) {
     if(is.logical(expr)) return(character(0))   ## expr is logical
     if(is.name(expr) || (is.call(expr) && (expr[[1]] == '[') && is.name(expr[[2]]))) return(deparse(expr))   ## expr is a node name
     if(is.call(expr)) return(unlist(lapply(expr[-1], cc_getNodesInExpr)))   ## expr is some general call
-    stop(paste0('something went wrong processing: ', deparse(expr)))
+    stop(paste0('something went wrong processing: ', deparse(expr, maxlen = 1)))
 }
 
 ## if targetNode is vectorized: determines if any components of targetNode appear in expr

--- a/packages/nimble/R/RCfunction_compile.R
+++ b/packages/nimble/R/RCfunction_compile.R
@@ -212,7 +212,7 @@ nf_substituteExceptFunctionsAndDollarSigns <- function(code, subList) {
                        subList)
         return(code)
     }
-    stop(paste("Error doing replacement for code ", deparse(code)))
+    stop(paste("Error doing replacement for code ", deparse(code, maxlen = 1)))
 }
 
 RCfunProcessing <- setRefClass(
@@ -356,7 +356,7 @@ RCfunProcessing <- setRefClass(
                          message <-
                              paste(eMessage,
                                    'There was some problem in the the setSizes processing step for this code:',
-                                   paste(deparse(compileInfo$origRcode), collapse = '\n'))
+                                   paste(deparse(compileInfo$origRcode, maxlen = 1), collapse = '\n'))
                          if(getNimbleOption('verboseErrors')) {
                              message <- paste(message,
                                               'Internal Error:',
@@ -386,7 +386,7 @@ RCfunProcessing <- setRefClass(
             if(inherits(tryResult, 'try-error')) {
                 stop(
                     paste('There is some problem at the insertAdditions processing step for this code:\n',
-                          paste(deparse(compileInfo$origRcode),
+                          paste(deparse(compileInfo$origRcode, maxlen = 1),
                                 collapse = '\n'),
                           collapse = '\n'),
                     call. = FALSE)
@@ -409,7 +409,7 @@ RCfunProcessing <- setRefClass(
             if(inherits(tryResult, 'try-error')) {
                 stop(
                     paste('There is some problem at the Eigen labeling processing step for this code:\n',
-                          paste(deparse(compileInfo$origRcode),
+                          paste(deparse(compileInfo$origRcode, maxlen = 1),
                                 collapse = '\n'),
                           collapse = '\n'),
                     call. = FALSE)
@@ -427,7 +427,7 @@ RCfunProcessing <- setRefClass(
             if(inherits(tryResult, 'try-error')) {
                 stop(
                     paste('There is some problem at the Eigen processing step for this code:\n',
-                          paste(deparse(compileInfo$origRcode),
+                          paste(deparse(compileInfo$origRcode, maxlen = 1),
                                 collapse = '\n'),
                           collapse = '\n'),
                     call. = FALSE)

--- a/packages/nimble/R/RCfunction_core.R
+++ b/packages/nimble/R/RCfunction_core.R
@@ -129,7 +129,7 @@ nfMethodRC <- setRefClass(
                 if(check) {
                     if(!("return" %in% all.names(code))) {
                         writeLines("Problem in this code:")
-                        writeLines(deparse(code))
+                        writeLines(deparse(code, maxlen = 1))
                         stop('returnType() declaration was provided but there is no return() statement.  At least one return() statement must be provided', call. = FALSE)
                     }
                 }

--- a/packages/nimble/R/all_utils.R
+++ b/packages/nimble/R/all_utils.R
@@ -134,13 +134,19 @@ getsize <- function(container) {
 }
 
 # simply adds width.cutoff = 500 as the default to deal with creation of long variable names from expressions
-deparse <- function(...) {
+deparse <- function(..., maxlen = NULL) {
     if("width.cutoff" %in% names(list(...))) {
-        base::deparse(..., control = "digits17")
+        out <- base::deparse(..., control = "digits17")
     } else {
-        base::deparse(..., width.cutoff = 500L, control = "digits17")
+        out <- base::deparse(..., width.cutoff = 500L, control = "digits17")
     }
+    if(!is.null(maxlen) && length(out) > maxlen) {
+        out <- out[1:maxlen]
+        out[maxlen] <- paste0(out[maxlen], ' ...')
+    }
+    return(out)
 }
+
 
 
 ## creates objects in the parent.frame(), named by names(lst), values are eval(lst[[i]])

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -1916,7 +1916,7 @@ sizeAssignAfterRecursing <- function(code, symTab, typeEnv, NoEigenizeMap = FALS
                                     newExpr$type <- LHS$type
                                     newExpr$nDim <- RHS$nDim
                                     if(!is.numeric(LHS$sizeExprs[[1]]) | !is.numeric(RHS$sizeExprs[[2]])) {
-                                        assertMessage <- paste0("Run-time size error: expected ", deparse(LHS$sizeExprs[[1]]), " == ", deparse(RHS$sizeExprs[[2]]))
+                                        assertMessage <- paste0("Run-time size error: expected ", deparse(LHS$sizeExprs[[1]], maxlen = 1), " == ", deparse(RHS$sizeExprs[[2]], maxlen = 1))
                                         thisAssert <- identityAssert(LHS$sizeExprs[[1]], RHS$sizeExprs[[2]], assertMessage)
                                         if(!is.null(thisAssert)) assert[[length(assert) + 1]] <- thisAssert 
                                     } else {
@@ -2972,7 +2972,7 @@ sizeMatrixMult <- function(code, symTab, typeEnv) {
     code$sizeExprs <- list(a1$sizeExprs[[1]], a2$sizeExprs[[2]])
     code$type <- setReturnType(code$name, arithmeticOutputType(a1$type, a2$type))
     if(!nimbleOptions('experimentalNewSizeProcessing') ) code$toEigenize <- 'yes'
-    assertMessage <- paste0("Run-time size error: expected ", deparse(a1$sizeExprs[[2]]), " == ", deparse(a2$sizeExprs[[1]]))
+    assertMessage <- paste0("Run-time size error: expected ", deparse(a1$sizeExprs[[2]], maxlen = 1), " == ", deparse(a2$sizeExprs[[1]], maxlen = 1))
     newAssert <- identityAssert(a1$sizeExprs[[2]], a2$sizeExprs[[1]], assertMessage)
     if(is.null(newAssert))
         return(asserts)
@@ -2993,9 +2993,9 @@ sizeSolveOp <- function(code, symTab, typeEnv) { ## this is for solve(A, b) or f
     if(code$nDim == 1) { code$sizeExprs <- c(a1$sizeExprs[[1]])
                      } else { code$sizeExprs <- c(a1$sizeExprs[[1]], a2$sizeExprs[[2]]) }
     code$toEigenize <- 'yes'
-    assertMessage <- paste0("Run-time size error: expected ", deparse(a1$sizeExprs[[1]]), " == ", deparse(a1$sizeExprs[[2]]))
+    assertMessage <- paste0("Run-time size error: expected ", deparse(a1$sizeExprs[[1]], maxlen = 1), " == ", deparse(a1$sizeExprs[[2]], maxlen = 1))
     assert1 <- identityAssert(a1$sizeExprs[[1]], a1$sizeExprs[[2]], assertMessage)
-    assertMessage <- paste0("Run-time size error: expected ", deparse(a1$sizeExprs[[1]]), " == ", deparse(a2$sizeExprs[[1]]))
+    assertMessage <- paste0("Run-time size error: expected ", deparse(a1$sizeExprs[[1]], maxlen = 1), " == ", deparse(a2$sizeExprs[[1]], maxlen = 1))
     assert2 <- identityAssert(a1$sizeExprs[[1]], a2$sizeExprs[[1]], assertMessage)
     asserts <- c(asserts, assert1, assert2)
     return(asserts)
@@ -3182,7 +3182,7 @@ sizeBinaryCwise <- function(code, symTab, typeEnv) {
                 a2$nDim <- a1nDim
                 a1ind <- if(a1IsCol) 1 else 2
                 if(!is.numeric(a1sizeExprs[[a1ind]]) | !is.numeric(a2sizeExprs[[1]])) { ## Really do want original a2sizeExprs
-                    assertMessage <- paste0("Run-time size error: expected ", deparse(a1sizeExprs[[a1ind]]), " == ", deparse(a2sizeExprs[[1]]))
+                    assertMessage <- paste0("Run-time size error: expected ", deparse(a1sizeExprs[[a1ind]], maxlen = 1), " == ", deparse(a2sizeExprs[[1]], maxlen = 1))
                     thisAssert <- identityAssert(a1sizeExprs[[a1ind]], a2sizeExprs[[1]], assertMessage)
                     if(!is.null(thisAssert)) asserts[[length(asserts) + 1]] <- thisAssert
                 } else {
@@ -3199,7 +3199,7 @@ sizeBinaryCwise <- function(code, symTab, typeEnv) {
                 a1$nDim <- a1nDim <- a2nDim
                 a2ind <- if(a2IsCol) 1 else 2
                 if(!is.numeric(a1sizeExprs[[1]]) | !is.numeric(a2sizeExprs[[a2ind]])) { ## Really do want the original a1sizeExprs[[1]], not the modified one.
-                    assertMessage <- paste0("Run-time size error: expected ", deparse(a1sizeExprs[[1]]), " == ", deparse(a2sizeExprs[[a2ind]]))
+                    assertMessage <- paste0("Run-time size error: expected ", deparse(a1sizeExprs[[1]], maxlen = 1), " == ", deparse(a2sizeExprs[[a2ind]], maxlen = 1))
                     thisAssert <- identityAssert(a1sizeExprs[[1]], a2sizeExprs[[a2ind]], assertMessage)
                     if(!is.null(thisAssert)) asserts[[length(asserts) + 1]] <- thisAssert 
                 } else {
@@ -3217,18 +3217,18 @@ sizeBinaryCwise <- function(code, symTab, typeEnv) {
             ## but add run-time size checks of which dimension must match
             ## This is currently limited in what it will handle
             ## Specifically, it assumes things should be columns
-            assertMessage <- paste0("Run-time size error: expected ", deparse(a1sizeExprs[[1]]), " == ", deparse(a2sizeExprs[[1]]))
+            assertMessage <- paste0("Run-time size error: expected ", deparse(a1sizeExprs[[1]], maxlen = 1), " == ", deparse(a2sizeExprs[[1]], maxlen = 1))
                 thisAssert <- identityAssert(a1sizeExprs[[1]], a2sizeExprs[[1]], assertMessage)
                 if(!is.null(thisAssert)) asserts[[length(asserts) + 1]] <- thisAssert
 
             if(a1nDim == 1 & a2nDim == 2) {
-                assertMessage <- paste0("Run-time size error: expected ", deparse(a2sizeExprs[[2]]), " == ", 1)
+                assertMessage <- paste0("Run-time size error: expected ", deparse(a2sizeExprs[[2]], maxlen = 1), " == ", 1)
                 thisAssert <- identityAssert(a2sizeExprs[[2]], 1, assertMessage)
                 if(!is.null(thisAssert)) asserts[[length(asserts) + 1]] <- thisAssert                
                 code$sizeExprs <- a2sizeExprs
             } else {
                 if(a1nDim == 2 & a2nDim == 1) {
-                    assertMessage <- paste0("Run-time size error: expected ", deparse(a1sizeExprs[[2]]), " == ", 1)
+                    assertMessage <- paste0("Run-time size error: expected ", deparse(a1sizeExprs[[2]], maxlen = 1), " == ", 1)
                     thisAssert <- identityAssert(a1sizeExprs[[2]], 1, assertMessage)
                     if(!is.null(thisAssert)) asserts[[length(asserts) + 1]] <- thisAssert
                     code$sizeExprs <- a1sizeExprs
@@ -3244,7 +3244,7 @@ sizeBinaryCwise <- function(code, symTab, typeEnv) {
         if(nDim > 0) {
             for(i in 1:nDim) {
                 if(!is.numeric(a1sizeExprs[[i]]) | !is.numeric(a2sizeExprs[[i]])) {
-                    assertMessage <- paste0("Run-time size error: expected ", deparse(a1sizeExprs[[i]]), " == ", deparse(a2sizeExprs[[i]]))
+                    assertMessage <- paste0("Run-time size error: expected ", deparse(a1sizeExprs[[i]], maxlen = 1), " == ", deparse(a2sizeExprs[[i]], maxlen = 1))
                     thisAssert <- identityAssert(a1sizeExprs[[i]], a2sizeExprs[[i]], assertMessage)
                     if(!is.null(thisAssert)) asserts[[length(asserts) + 1]] <- thisAssert 
                 } else {

--- a/packages/nimble/R/nimbleFunction_keywordProcessing.R
+++ b/packages/nimble/R/nimbleFunction_keywordProcessing.R
@@ -120,7 +120,7 @@ values_keywordInfo <- keywordInfoClass(
       useAccessorVectorByIndex <- FALSE
       if(hasBracket(accessArgList$nodes)) { 
             useAccessorVectorByIndex <- TRUE
-            if(length(accessArgList$nodes) != 3) stop(paste0('Problem with ', deparse(code),'. If you need to index on the nodes argument there should be only one index.'))
+            if(length(accessArgList$nodes) != 3) stop(paste0('Problem with ', deparse(code, maxlen = 1),'. If you need to index on the nodes argument there should be only one index.'))
             nodesIndexExpr <- accessArgList$nodes[[3]]
             accessArgList$nodes <- accessArgList$nodes[[2]]
             accessArgList$sortUnique <- FALSE   
@@ -142,7 +142,7 @@ getParam_keywordInfo <- keywordInfoClass(
     processor = function(code, nfProc) {
         if(!isCodeArgBlank(code, 'nodeFunction'))
             return(code)
-        errorContext <- deparse(code)
+        errorContext <- deparse(code, maxlen = 1)
         nodeFunVec_ArgList <- list(model = code$model, nodes = code$node, includeData = TRUE, sortUnique = TRUE, errorContext = errorContext)
         if(!isCodeArgBlank(code, 'nodeFunctionIndex')) { ## new case: calculate(myNodeFunctionVector, nodeFunctionIndex = i), if myNodeFunctionVector was hand-created in setup code
             if(!isCodeArgBlank(code, 'nodes'))
@@ -158,7 +158,7 @@ getParam_keywordInfo <- keywordInfoClass(
         useNodeFunctionVectorByIndex <- FALSE
         if(hasBracket(nodeFunVec_ArgList$nodes)) { ## like calculate(model, nodes[i]), which could have started as model$calculate(nodes[i])
             useNodeFunctionVectorByIndex <- TRUE
-            if(length(nodeFunVec_ArgList$nodes) != 3) stop(paste0('Problem with ', deparse(code),'. If you need to index on the nodes argument there should be only one index.'))
+            if(length(nodeFunVec_ArgList$nodes) != 3) stop(paste0('Problem with ', deparse(code, maxlen = 1),'. If you need to index on the nodes argument there should be only one index.'))
             nodesIndexExpr <- nodeFunVec_ArgList$nodes[[3]]
             nodeFunVec_ArgList$nodes <- nodeFunVec_ArgList$nodes[[2]]
             nodeFunVec_ArgList$sortUnique <- FALSE
@@ -190,7 +190,7 @@ getBound_keywordInfo <- keywordInfoClass(
     processor = function(code, nfProc) {
         if(!isCodeArgBlank(code, 'nodeFunction'))
             return(code)
-        errorContext <- deparse(code)
+        errorContext <- deparse(code, maxlen = 1)
         nodeFunVec_ArgList <- list(model = code$model, nodes = code$node, includeData = TRUE, sortUnique = TRUE, errorContext = errorContext)
         if(!isCodeArgBlank(code, 'nodeFunctionIndex')) { ## new case: calculate(myNodeFunctionVector, nodeFunctionIndex = i), if myNodeFunctionVector was hand-created in setup code
             if(!isCodeArgBlank(code, 'nodes'))
@@ -206,7 +206,7 @@ getBound_keywordInfo <- keywordInfoClass(
         useNodeFunctionVectorByIndex <- FALSE
         if(hasBracket(nodeFunVec_ArgList$nodes)) { ## like calculate(model, nodes[i]), which could have started as model$calculate(nodes[i])
             useNodeFunctionVectorByIndex <- TRUE
-            if(length(nodeFunVec_ArgList$nodes) != 3) stop(paste0('Problem with ', deparse(code),'. If you need to index on the nodes argument there should be only one index.'))
+            if(length(nodeFunVec_ArgList$nodes) != 3) stop(paste0('Problem with ', deparse(code, maxlen = 1),'. If you need to index on the nodes argument there should be only one index.'))
             nodesIndexExpr <- nodeFunVec_ArgList$nodes[[3]]
             nodeFunVec_ArgList$nodes <- nodeFunVec_ArgList$nodes[[2]]
             nodeFunVec_ArgList$sortUnique <- FALSE
@@ -239,7 +239,7 @@ calculate_keywordInfo <- keywordInfoClass(
     processor = function(code, nfProc){
         if(!isCodeArgBlank(code, 'nodeFxnVector'))
             return(code)
-        errorContext <- deparse(code)
+        errorContext <- deparse(code, maxlen = 1)
         nodeFunVec_ArgList <- list(model = code$model, nodes = code$nodes, includeData = TRUE, sortUnique = TRUE, errorContext = errorContext)
         
         if(!isCodeArgBlank(code, 'nodeFunctionIndex')) { ## new case: calculate(myNodeFunctionVector, nodeFunctionIndex = i), if myNodeFunctionVector was hand-created in setup code
@@ -258,7 +258,7 @@ calculate_keywordInfo <- keywordInfoClass(
         useNodeFunctionVectorByIndex <- FALSE
         if(hasBracket(nodeFunVec_ArgList$nodes)) { ## like calculate(model, nodes[i]), which could have started as model$calculate(nodes[i])
             useNodeFunctionVectorByIndex <- TRUE
-            if(length(nodeFunVec_ArgList$nodes) != 3) stop(paste0('Problem with ', deparse(code),'. If you need to index on the nodes argument there should be only one index.'))
+            if(length(nodeFunVec_ArgList$nodes) != 3) stop(paste0('Problem with ', deparse(code, maxlen = 1),'. If you need to index on the nodes argument there should be only one index.'))
             nodesIndexExpr <- nodeFunVec_ArgList$nodes[[3]]
             nodeFunVec_ArgList$nodes <- nodeFunVec_ArgList$nodes[[2]]
             nodeFunVec_ArgList$sortUnique <- FALSE
@@ -281,7 +281,7 @@ calculateDiff_keywordInfo <- keywordInfoClass(
     processor = function(code, nfProc){
         if(!isCodeArgBlank(code, 'nodeFxnVector'))
             return(code)
-        errorContext <- deparse(code)
+        errorContext <- deparse(code, maxlen = 1)
         nodeFunVec_ArgList <- list(model = code$model, nodes = code$nodes, includeData = TRUE, sortUnique = TRUE, errorContext = errorContext)
         if(!isCodeArgBlank(code, 'nodeFunctionIndex')) { ## new case: calculate(myNodeFunctionVector, nodeFunctionIndex = i), if myNodeFunctionVector was hand-created in setup code
             if(!isCodeArgBlank(code, 'nodes'))
@@ -300,7 +300,7 @@ calculateDiff_keywordInfo <- keywordInfoClass(
         useNodeFunctionVectorByIndex <- FALSE
         if(hasBracket(nodeFunVec_ArgList$nodes)) { ## like calculate(model, nodes[i]), which could have started as model$calculate(nodes[i])
             useNodeFunctionVectorByIndex <- TRUE
-            if(length(nodeFunVec_ArgList$nodes) != 3) stop(paste0('Problem with ', deparse(code),'. If you need to index on the nodes argument there should be only one index.'))
+            if(length(nodeFunVec_ArgList$nodes) != 3) stop(paste0('Problem with ', deparse(code, maxlen = 1),'. If you need to index on the nodes argument there should be only one index.'))
             nodesIndexExpr <- nodeFunVec_ArgList$nodes[[3]]
             nodeFunVec_ArgList$nodes <- nodeFunVec_ArgList$nodes[[2]]
             nodeFunVec_ArgList$sortUnique <- FALSE
@@ -327,7 +327,7 @@ simulate_keywordInfo <- keywordInfoClass(
         }
         if(!isCodeArgBlank(code, 'INDEXEDNODEINFO_'))
             return(code)
-        errorContext <- deparse(code)
+        errorContext <- deparse(code, maxlen = 1)
         nodeFunVec_ArgList <- list(model = code$model, nodes = code$nodes, includeData = code$includeData, sortUnique = TRUE, errorContext = errorContext)
         if(!isCodeArgBlank(code, 'nodeFunctionIndex')) { ## new case: calculate(myNodeFunctionVector, nodeFunctionIndex = i), if myNodeFunctionVector was hand-created in setup code
             if(!isCodeArgBlank(code, 'nodes'))
@@ -345,7 +345,7 @@ simulate_keywordInfo <- keywordInfoClass(
         useNodeFunctionVectorByIndex <- FALSE
         if(hasBracket(nodeFunVec_ArgList$nodes)) { ## like calculate(model, nodes[i]), which could have started as model$calculate(nodes[i])
             useNodeFunctionVectorByIndex <- TRUE
-            if(length(nodeFunVec_ArgList$nodes) != 3) stop(paste0('Problem with ', deparse(code),'. If you need to index on the nodes argument there should be only one index.'))
+            if(length(nodeFunVec_ArgList$nodes) != 3) stop(paste0('Problem with ', deparse(code, maxlen = 1),'. If you need to index on the nodes argument there should be only one index.'))
             nodesIndexExpr <- nodeFunVec_ArgList$nodes[[3]]
             nodeFunVec_ArgList$nodes <- nodeFunVec_ArgList$nodes[[2]]
             nodeFunVec_ArgList$sortUnique <- FALSE # If includeData = FALSE, this can trigger error from nodeFunctionVector if nodes does contain data
@@ -369,7 +369,7 @@ getLogProb_keywordInfo <- keywordInfoClass(
     processor = function(code, nfProc){
         if(!isCodeArgBlank(code, 'nodeFxnVector'))
             return(code)
-        errorContext <- deparse(code)
+        errorContext <- deparse(code, maxlen = 1)
         nodeFunVec_ArgList <- list(model = code$model, nodes = code$nodes, includeData = TRUE, sortUnique = TRUE, errorContext = errorContext)
         if(!isCodeArgBlank(code, 'nodeFunctionIndex')) { ## new case: calculate(myNodeFunctionVector, nodeFunctionIndex = i), if myNodeFunctionVector was hand-created in setup code
             if(!isCodeArgBlank(code, 'nodes'))
@@ -387,7 +387,7 @@ getLogProb_keywordInfo <- keywordInfoClass(
         useNodeFunctionVectorByIndex <- FALSE
         if(hasBracket(nodeFunVec_ArgList$nodes)) { ## like calculate(model, nodes[i]), which could have started as model$calculate(nodes[i])
             useNodeFunctionVectorByIndex <- TRUE
-            if(length(nodeFunVec_ArgList$nodes) != 3) stop(paste0('Problem with ', deparse(code),'. If you need to index on the nodes argument there should be only one index.'))
+            if(length(nodeFunVec_ArgList$nodes) != 3) stop(paste0('Problem with ', deparse(code, maxlen = 1),'. If you need to index on the nodes argument there should be only one index.'))
             nodesIndexExpr <- nodeFunVec_ArgList$nodes[[3]]
             nodeFunVec_ArgList$nodes <- nodeFunVec_ArgList$nodes[[2]]
             nodeFunVec_ArgList$sortUnique <- FALSE
@@ -541,8 +541,8 @@ doubleBracket_keywordInfo <- keywordInfoClass(
             if(is.character(nodeArg)){
                 if(length(nodeArg) > 1)
                     stop(paste0("Problem in ",
-                                deparse(code), ". ",
-                                deparse(code[[3]]),
+                                deparse(code, maxlen = 1), ". ",
+                                deparse(code[[3]], maxlen = 1),
                                 " is too long.  It can only have one element."),
                          call. = FALSE)
                 varAndIndices <- nimbleInternalFunctions$getVarAndIndices(nodeArg)
@@ -554,7 +554,7 @@ doubleBracket_keywordInfo <- keywordInfoClass(
                         stop(paste0("Length of ",
                                     nodeArg,
                                     " requested from ",
-                                    deparse(singleAccess_ArgList$model),
+                                    deparse(singleAccess_ArgList$model, maxlen = 1),
                                     " using '[[' is ",
                                     length(nodeArg),
                                     ". It must be 1.")
@@ -563,7 +563,7 @@ doubleBracket_keywordInfo <- keywordInfoClass(
                 } )
 
                 if(length(unique(allNDims)) > 1)
-                    stop(paste0('Error for ', deparse(code),
+                    stop(paste0('Error for ', deparse(code, maxlen = 1),
                                 '. Inconsistent numbers of dimensions for different instances.'),
                          call. = FALSE)
                 nDim <- allNDims[[1]]
@@ -586,7 +586,7 @@ doubleBracket_keywordInfo <- keywordInfoClass(
             }
             else{
                 allNDims <- determineNdimsFromNfproc(singleAccess_ArgList$model, nodeArg, nfProc)
-                if(length(unique(allNDims)) > 1) stop(paste0('Error for ', deparse(code), '. Inconsistent numbers of dimensions for different instances.'), call. = FALSE)
+                if(length(unique(allNDims)) > 1) stop(paste0('Error for ', deparse(code, maxlen = 1), '. Inconsistent numbers of dimensions for different instances.'), call. = FALSE)
                 nDim <- allNDims[[1]]
                 useMap <- nDim > 0
             }
@@ -603,7 +603,7 @@ doubleBracket_keywordInfo <- keywordInfoClass(
             }
             return(ans)			
         }
-        stop("Incorrect use of double brackets in: '", deparse(code), "'.")
+        stop("Incorrect use of double brackets in: '", deparse(code, maxlen = 1), "'.")
     })
 
 modelMemberFun_keywordInfo <- keywordInfoClass(
@@ -721,7 +721,7 @@ singleBracket_keywordInfo <- keywordInfoClass(
         class <- symTypeFromSymTab(code[[2]], nfProc$setupSymTab)
         if(class == 'symbolModelValues'){
             if(length(code) < 4) {
-                stop(paste0("incorrect syntax for accessing element of modelValues: ", deparse(code)))
+                stop(paste0("incorrect syntax for accessing element of modelValues: ", deparse(code, maxlen = 1)))
             }
             singleMVAccess_ArgList <- list(code = code, modelValues = code[[2]], var = code[[3]], row = code[[4]])
             accessName <- singleModelValuesAccessor_SetupTemplate$makeName(singleMVAccess_ArgList)
@@ -925,13 +925,13 @@ processKeywordCodeMemberFun <- function(code, nfProc) { ## handle cases like a$b
     if(length(objectPart) != 1) isModel <- FALSE ## a case like a[[i]]$b(), which can only be a nimbleFunction list
     else {
         symObj <- nfProc$setupSymTab$getSymbolObject(as.character(objectPart))
-        if(is.null(symObj)) stop(paste0("In processKeywordCodeMemberFun: not sure what to do with ", deparse(code)))
+        if(is.null(symObj)) stop(paste0("In processKeywordCodeMemberFun: not sure what to do with ", deparse(code, maxlen = 1)))
         if(inherits(symObj, 'symbolModel'))
             isModel <- TRUE
     }
     if(isModel) {
         thisKeywordInfo <- keywordListModelMemberFuns[[ as.character(dollarSignPart[[3]]) ]]
-        if(is.null(thisKeywordInfo)) stop(paste0("In processKeywordCodeMemberFun, don't know what do with: ", deparse(code)))
+        if(is.null(thisKeywordInfo)) stop(paste0("In processKeywordCodeMemberFun, don't know what do with: ", deparse(code, maxlen = 1)))
         rearrangedCode <- thisKeywordInfo$processor(code, nfProc)
         rearrangedCode <- matchKeywordCode(rearrangedCode, nfProc)
         return(processKeywords_recurse(rearrangedCode, nfProc))
@@ -1250,7 +1250,7 @@ getSymObj_recurse <- function(code, symTab, recurse = FALSE) { #code will be lik
     } else {
         return(symObject)
     }
-    stop(paste0('Problem (ii) working through ', deparse(code)), .call = FALSE)
+    stop(paste0('Problem (ii) working through ', deparse(code, maxlen = 1)), .call = FALSE)
 }
 
 symTypeFromSymTab <- function(codeName, symTab, options = character(0) ){
@@ -1316,9 +1316,9 @@ determineNdimsFromNfproc <- function(modelExpr, varOrNodeExpr, nfProc) {
         lab <- eval(varOrNodeExpr, envir = x)
         if(length(lab) != 1)
             stop(paste0("Length of ",
-                        deparse(varOrNodeExpr),
+                        deparse(varOrNodeExpr, maxlen = 1),
                         " requested from ",
-                        deparse(modelExpr),
+                        deparse(modelExpr, maxlen = 1),
                         " using '[[' is ",
                         length(lab),
                         ". It must be 1." )
@@ -1348,8 +1348,8 @@ matchKeywordCodeMemberFun <- function(code, nfProc) {  ## handles cases like a$b
                 nestedLeftSide <- TRUE
             } else {
                 nfNestedCall <- leftSide[[1]]
-                if(length(nfNestedCall) != 1) stop(paste0("Cannot handle this expression: ", deparse(code)))
-                if(deparse(nfNestedCall) != '[[') stop(paste0("Cannot handle this expression: ", deparse(code)))
+                if(length(nfNestedCall) != 1) stop(paste0("Cannot handle this expression: ", deparse(code, maxlen = 1)))
+                if(deparse(nfNestedCall) != '[[') stop(paste0("Cannot handle this expression: ", deparse(code, maxlen = 1)))
                 leftLeftSide <- leftSide[[2]]
                 if(length(leftLeftSide) != 1) {
                     if(deparse(leftLeftSide[[1]]) == '$') { ##a$b[[i]]$foo()
@@ -1383,10 +1383,10 @@ matchKeywordCodeMemberFun <- function(code, nfProc) {  ## handles cases like a$b
                 if(is.nlGenerator(possibleNLgen)) {
                     thisFunctionMatch <- makeNimbleListTemplateWithBlankFirstArg(nl.getListDef(possibleNLgen))
                 } else {
-                    stop(paste0('problem with ', deparse(code)))
+                    stop(paste0('problem with ', deparse(code, maxlen = 1)))
                 }
             } else {
-                stop(paste0('problem with ', deparse(code)))
+                stop(paste0('problem with ', deparse(code, maxlen = 1)))
             }
         } else {
             thisFunctionMatch <- makeNimbleListTemplateWithBlankFirstArg(nl.getListDef(symObj$nlProc$nlGenerator))
@@ -1402,14 +1402,14 @@ matchKeywordCodeMemberFun <- function(code, nfProc) {  ## handles cases like a$b
     
     if(symObj$type == 'nimbleFunction') {
         thisRCfunProc <- symObj$nfProc$RCfunProcs[[memFunName]] 
-        if(is.null(thisRCfunProc)) stop(paste0("Cannot handle this expression (member function may not exist): ", deparse(code)), call. = FALSE)
+        if(is.null(thisRCfunProc)) stop(paste0("Cannot handle this expression (member function may not exist): ", deparse(code, maxlen = 1)), call. = FALSE)
         thisFunctionMatch <- thisRCfunProc$RCfun$template
         return(matchAndFill.call(thisFunctionMatch, code ) )
     } 
     if(inherits(symObj, 'symbolModel')) {
         if(nestedLeftSide) stop('Access to a model cannot be nested.')
         thisFunctionMatch <- matchModelMemberFunctions[[ memFunName ]]
-        if(is.null(thisFunctionMatch)) stop(paste0("Cannot handle this expression (looks like a model with an invalid member function call?): ", deparse(code)))
+        if(is.null(thisFunctionMatch)) stop(paste0("Cannot handle this expression (looks like a model with an invalid member function call?): ", deparse(code, maxlen = 1)))
         return(matchAndFill.call(thisFunctionMatch, code) )
     }
     if(inherits(symObj, 'symbolNimbleFunctionList')) {
@@ -1417,7 +1417,7 @@ matchKeywordCodeMemberFun <- function(code, nfProc) {  ## handles cases like a$b
         thisFunctionMatch <- environment(symObj$baseClass)$methodList[[memFunName]]$template
         return(matchAndFill.call(thisFunctionMatch, code ) )
     }
-    stop(paste0("Cannot handle this expression: ", deparse(code))) 
+    stop(paste0("Cannot handle this expression: ", deparse(code, maxlen = 1))) 
 }
 
 
@@ -1431,7 +1431,7 @@ matchKeywordCode <- function(code, nfProc){
             symObj <- nfProc$setupSymTab$getSymbolObject(modCallName)
             if(inherits(symObj, "symbolMemberFunction")) {
                 thisRCfunProc <- nfProc$RCfunProcs[[modCallName]]
-                if(is.null(thisRCfunProc)) stop(paste0("Cannot handle this expression (looks like a member function but something is wrong): ", deparse(code)), call. = FALSE)
+                if(is.null(thisRCfunProc)) stop(paste0("Cannot handle this expression (looks like a member function but something is wrong): ", deparse(code, maxlen = 1)), call. = FALSE)
                 thisFunctionMatch <- thisRCfunProc$RCfun$template
                 return(matchAndFill.call(thisFunctionMatch, code ) )
             }
@@ -1580,7 +1580,7 @@ getVarAndIndices <- function(code) {
             varName <- code[[2]]
             indices <- as.list(code[-c(1,2)])
         } else {
-            stop(paste('Error:', deparse(code), 'is a malformed node label.'))
+            stop(paste('Error:', deparse(code, maxlen = 1), 'is a malformed node label.'))
         }
     } else {
         varName <- code

--- a/packages/nimble/R/nimbleFunction_nodeFunction.R
+++ b/packages/nimble/R/nimbleFunction_nodeFunction.R
@@ -24,7 +24,7 @@ ndf_createDetermSimulate <- function(LHS, RHS, dynamicIndexLimitsExpr, RHSnonRep
                                 RHS = RHS,
                                 NANEXPR = nanExpr,
                                 CONDITION = dynamicIndexLimitsExpr,
-                                TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced))))
+                                TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced, maxlen = 1))))
     } else code <- substitute(LHS <<- RHS,
                               list(LHS = LHS,
                                    RHS = RHS))
@@ -53,7 +53,7 @@ ndf_createStochSimulate <- function(LHS, RHS, dynamicIndexLimitsExpr, RHSnonRepl
                                 RHS = RHS,
                                 NANEXPR = nanExpr,
                                 CONDITION = dynamicIndexLimitsExpr,
-                                TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced))))
+                                TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced, maxlen = 1))))
     } else {
         code <- substitute(LHS <<- RHS,
                            list(LHS = LHS,
@@ -147,7 +147,7 @@ ndf_createStochCalculate <- function(logProbNodeExpr, LHS, RHS, diff = FALSE, AD
                                        print(TEXT)}, # LocalNewLogProb <- -Inf,
                                    list(STOCHCALC = RHS,
                                         CONDITION = dynamicIndexLimitsExpr,
-                                        TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced))))
+                                        TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced, maxlen = 1))))
             } else if(ADFunc){  ## don't want global assignment for _AD_ functions.
                 code <- substitute(if(isTRUE(CONDITION)) LOGPROB <- STOCHCALC
                                    else {LOGPROB <- NaN
@@ -155,7 +155,7 @@ ndf_createStochCalculate <- function(logProbNodeExpr, LHS, RHS, diff = FALSE, AD
                                    list(LOGPROB = logProbNodeExpr,
                                         STOCHCALC = RHS,
                                         CONDITION = dynamicIndexLimitsExpr,
-                                        TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced))))
+                                        TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced, maxlen = 1))))
             } else {
 
                 code <- substitute(if(isTRUE(CONDITION)) LOGPROB <<- STOCHCALC
@@ -164,7 +164,7 @@ ndf_createStochCalculate <- function(logProbNodeExpr, LHS, RHS, diff = FALSE, AD
                                    list(LOGPROB = logProbNodeExpr,
                                         STOCHCALC = RHS,
                                         CONDITION = dynamicIndexLimitsExpr,
-                                        TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced))))
+                                        TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced, maxlen = 1))))
             }
         } else {
             if(diff) {
@@ -234,7 +234,7 @@ ndf_createStochCalculateTrunc <- function(logProbNodeExpr, LHS, RHS, diff = FALS
                                        print(TEXT)}, # LocalNewLogProb <- -Inf,
                                    list(STOCHCALC = RHS,
                                         CONDITION = dynamicIndexLimitsExpr,
-                                        TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced))))
+                                        TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced, maxlen = 1))))
 
     
     if(nimbleOptions()$allowDynamicIndexing && !is.null(dynamicIndexLimitsExpr)) {
@@ -268,7 +268,7 @@ ndf_createStochCalculateTrunc <- function(logProbNodeExpr, LHS, RHS, diff = FALS
                                                    PDIST_UPPER = PDIST_UPPER,
                                                    DDIST_LOWER = DDIST_LOWER,
                                                    CONDITION = dynamicIndexLimitsExpr,
-                                                   TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced))
+                                                   TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced, maxlen = 1))
                                                )), list( e = substCode)))
         } else {
             if(discrete && lower != -Inf) {
@@ -301,7 +301,7 @@ ndf_createStochCalculateTrunc <- function(logProbNodeExpr, LHS, RHS, diff = FALS
                                                    PDIST_UPPER = PDIST_UPPER,
                                                    DDIST_LOWER = DDIST_LOWER,
                                                    CONDITION = dynamicIndexLimitsExpr,
-                                                   TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced))
+                                                   TEXT = paste0("Warning: dynamic index out of bounds: ", deparse(RHSnonReplaced, maxlen = 1))
                                                )), list(e = substCode)))
         }
     } else {

--- a/packages/nimble/R/types_symbolTable.R
+++ b/packages/nimble/R/types_symbolTable.R
@@ -78,7 +78,7 @@ argType2symbolInternal <- function(AT, neededTypes, name = character()) {
     if(type %in% c('double', 'integer', 'character', 'logical', 'void')){
       nDim <- if(length(AT)==1) 0 else AT[[2]]
       if(!is.numeric(nDim) || nDim %% 1 != 0)
-          stop("argType2symbol: unexpected dimension, '", AT[[2]], "', found in argument '", deparse(AT), "'. Dimension should be integer-valued.")
+          stop("argType2symbol: unexpected dimension, '", AT[[2]], "', found in argument '", deparse(AT, maxlen = 1), "'. Dimension should be integer-valued.")
       size <- if(nDim == 0) 1 else {
           if(length(AT) < 3)
               as.numeric(rep(NA, nDim))


### PR DESCRIPTION
This fixes issue #1131 

This avoids getting a multi-element character vector when the deparse result is longer than 500 chars. I also use this functionality in all warning/error messages where `deparse()` is used in our codebase. 

More discussion of how we might robustify further in `deparse`  and `nimDeparse` are in issue #1131 .