### PR TITLE
allow cases like `myfun()[,1]`

### DIFF
--- a/UserManual/src/chapter_MCMC.Rmd
+++ b/UserManual/src/chapter_MCMC.Rmd
@@ -909,7 +909,7 @@ llFun <- nimbleFunction(
         ll <- lfactorial(n) - lfactorial(y) - lfactorial(n-y) +
               y * log(p) + (n-y) * log(1-p)
         returnType(double())
-        return(ll)
+        return(ll[1])
     }
 )
 
@@ -922,6 +922,9 @@ mcmcConf$addSampler(target = "p", type = "RW_llFunction",
 
 Rmcmc <- buildMCMC(mcmcConf)
 ```
+
+Note that we need to return `ll[1]` and not just `ll` because there are no scalar variables in compiled models. Hence `y` and other variables, and therefore `ll`, are of dimension 1 (i.e., vectors / one-dimensional arrays), so we need to specify the first element in order to have the return type be a scalar.
+
 <!---  ### Terminal node `posterior_predictive sampler` 
 % The `posterior_predictive` sampler is only appropriate for use on terminal stochastic nodes (that is, those having no stochastic dependencies).  Note that such nodes play no role in inference but have often been included in BUGS models to accomplish posterior predictive checks.  NIMBLE allows posterior predictive values to be simulated independently of running MCMC, for example by writing a nimbleFunction to do so.  This means that in many cases where terminal stochastic nodes have been included in BUGS models, they are not needed when using NIMBLE.
 The `posterior_predictive` sampler functions by calling the `simulate` method of the relevant node, then updating model probabilities and deterministic dependent nodes.  The `posterior_predictive` sampler will automatically be assigned to all terminal, non-data stochastic nodes in a model by the default MCMC configuration, so it is uncommon to manually assign this sampler.  The `posterior_predictive` sampler accepts no control list arguments. -->

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -589,7 +589,13 @@ addMissingIndexingRecurse <- function(code, dimensionsList) {
     }
     if(is.call(code[[2]])) { ## we allow myfun()[,1], similarly to (x[1:2,1:2]%*%y[1:2,1:2])[,1]
         ## handle missing indexes within the indexing of an expression as above
+        ## handle the args of myfun in myfun()[,1]
+        len <- length(code[[2]])
+        if(len > 1)
+            for(idx in 2:len)
+                code[[2]][[idx]] <- addMissingIndexingRecurse(code[[2]][[idx]], dimensionsList)
         len <- length(code)
+        ## handle the indexing of myfun() in myfun()[,1]
         if(len > 2) 
             for(idx in 3:len)
                 if(is.call(code[[idx]]))

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -587,6 +587,15 @@ addMissingIndexingRecurse <- function(code, dimensionsList) {
                     code[[idx]] <- addMissingIndexingRecurse(code[[idx]], dimensionsList)
         return(code)
     }
+    if(is.call(code[[2]])) { ## we allow myfun()[,1], similarly to (x[1:2,1:2]%*%y[1:2,1:2])[,1]
+        ## handle missing indexes within the indexing of an expression as above
+        len <- length(code)
+        if(len > 2) 
+            for(idx in 3:len)
+                if(is.call(code[[idx]]))
+                    code[[idx]] <- addMissingIndexingRecurse(code[[idx]], dimensionsList)
+        return(code)
+    }
     if(!any(code[[2]] == names(dimensionsList))) {
       ## dimension information was NOT provided for this variable
       ## let's check to make sure all indexes are present

--- a/packages/nimble/R/distributions_processInputList.R
+++ b/packages/nimble/R/distributions_processInputList.R
@@ -483,11 +483,11 @@ prepareDistributionInput <- function(densityName, userEnv) {
 #'     r ~ dunif(0, 100)
 #' })
 #' m <- nimbleModel(code, inits = list(r = 1), data = list(y = 2))
-#' calculate(m, 'y')
+#' m$calculate('y')
 #' m$r <- 2
-#' calculate(m, 'y')
+#' m$calculate('y')
 #' m$resetData()
-#' simulate(m, 'y')
+#' m$simulate('y')
 #' m$y
 #'
 #' # alternatively, simply specify a character vector with the

--- a/packages/nimble/tests/testthat/test-models.R
+++ b/packages/nimble/tests/testthat/test-models.R
@@ -648,7 +648,10 @@ test_that("handling of missing indexes of expressions, part 2:", {
             out = matrix(x[1], 3, 3)
             return(out)
         })
-
+    temporarilyAssignInGlobalEnv(myfun0)
+    temporarilyAssignInGlobalEnv(myfun1)
+    temporarilyAssignInGlobalEnv(myfun2)
+    
     code <- nimbleCode({
         a[1:3] <- myfun0()[,1]      
     })

--- a/packages/nimble/tests/testthat/test-models.R
+++ b/packages/nimble/tests/testthat/test-models.R
@@ -624,6 +624,9 @@ test_that("handling of missing indexes of expressions:", {
                     dimensions = list(k = c(2,2)))
     cm <- compileNimble(m)  # if compilation fails, test_that should catch this; having trouble using expect_message as behavior of whether a message is detected seems to differ when running tests locally versus Travis.
 
+})
+
+test_that("handling of missing indexes of expressions, part 2:", {
     ## Testing that case like `myfun()[,1]` handled similarly to the above case.
     myfun0 <- nimbleFunction(
     run = function() {

--- a/packages/nimble/tests/testthat/test-models.R
+++ b/packages/nimble/tests/testthat/test-models.R
@@ -623,6 +623,80 @@ test_that("handling of missing indexes of expressions:", {
                     inits = list(X = matrix(1, 2, 2), beta = matrix(2,2,2), pr = diag(2)),
                     dimensions = list(k = c(2,2)))
     cm <- compileNimble(m)  # if compilation fails, test_that should catch this; having trouble using expect_message as behavior of whether a message is detected seems to differ when running tests locally versus Travis.
+
+    ## Testing that case like `myfun()[,1]` handled similarly to the above case.
+    myfun0 <- nimbleFunction(
+    run = function() {
+        returnType(double(2))
+        out = matrix(3.1, 3, 3)
+        return(out)
+    })
+
+    myfun1 <- nimbleFunction(
+        run = function(x = double(0)) {
+            returnType(double(2))
+            out = matrix(x, 3, 3)
+            return(out)
+        })
+    
+    myfun2 <- nimbleFunction(
+        run = function(x = double(1), y = double(0)) {
+            returnType(double(2))
+            out = matrix(x[1], 3, 3)
+            return(out)
+        })
+
+    code <- nimbleCode({
+        a[1:3] <- myfun0()[,1]      
+    })
+    m <- nimbleModel(code)
+    cm <- compileNimble(m)
+    expect_true(is.numeric(cm$calculate('a')))
+
+    code <- nimbleCode({
+        a[1:3] <- (myfun0())[,1]      
+    })
+    m <- nimbleModel(code)
+    cm <- compileNimble(m)
+    expect_true(is.numeric(cm$calculate('a')))
+    
+    code <- nimbleCode({
+        a[1:3] <- myfun1(b)[,1]      
+    })
+    m <- nimbleModel(code, inits = list(b = 3.1))
+    cm <- compileNimble(m)
+    expect_true(is.numeric(cm$calculate('a')))
+
+    code <- nimbleCode({
+        a[1:3] <- myfun2(b[1:3, 1], 7)[,1]      
+    })
+    m <- nimbleModel(code)
+    cm <- compileNimble(m)
+    expect_true(is.numeric(cm$calculate('a')))
+
+    code <- nimbleCode({
+        a[1:3] <- myfun2(b[ , 1], 7)[,1]      
+    })
+    expect_error(m <- nimbleModel(code), "missing indices")
+
+    code <- nimbleCode({
+        a[1:3] <- myfun2(b[1:3, 1], 7)[,1]      
+    })
+    m <- nimbleModel(code, inits = list(b = matrix(rnorm(9), 3, 3)))
+    cm <- compileNimble(m)
+    expect_true(is.numeric(cm$calculate('a')))
+
+    code <- nimbleCode({
+        a[1:3] <- myfun0()[k[,1],1]      
+    })
+    m <- nimbleModel(code, inits = list(k=matrix(2, 3,3)))
+    cm <- compileNimble(m)
+    expect_true(is.numeric(cm$calculate('a')))
+
+    code <- nimbleCode({
+        a[1:3] <- myfun0()[k[,1],1]      
+    })
+    expect_error(m <- nimbleModel(code), "missing indices")
 })
 
 test_that("warning when RHS only nodes used as dynamic indexes", {


### PR DESCRIPTION
In PR #929 we added handling of ``(expression)[indexing]`. This adds handling of `myfun()[,1]` and `myfun(b[,1])[,1]`, as discussed in NCT issue 317 by mimicing cases like `(X[1:2,1:2] %*% beta[1:2,1:2])[,1]`.

I will add a few tests.