### PR TITLE
treat mixed data/non-data mv nodes as data

### DIFF
--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -541,7 +541,7 @@ Arguments:
 
 ...:  Arguments may be provided as named elements with numeric values or as character names of model variables.  These may be provided in a single list, a single character vector, or as multiple arguments.  When a named element with a numeric value is provided, the size and dimension must match the corresponding model variable.  This value will be copied to the model variable and any non-NA elements will be marked as data.  When a character name is provided, the value of that variable in the model is not changed but any currently non-NA values are marked as data.  Examples: setData(\'x\', y = 1:10) will mark both x and y as data and will set the value of y to 1:10.  setData(list(\'x\', y = 1:10)) is equivalent.  setData(c(\'x\',\'y\')) or setData(\'x\',\'y\') will mark both x and y as data.
 
-Details: If a provided value (or the current value in the model when only a name is specified) contains some NA values, then the model nodes corresponding to these NAs will not have their value set, and will not be designated as \'data\'.  Only model nodes corresponding to numeric values in the argument list elements will be designated as data.  Designating a deterministic model node as \'data\' will result in an error.  Designating part of a multivariate node as \'data\' and part as non-data (NA) will result in an error; multivariate nodes must be entirely data, or entirely non-data.
+Details: If a provided value (or the current value in the model when only a name is specified) contains some NA values, then the model nodes corresponding to these NAs will not have their value set, and will not be designated as \'data\'.  Only model nodes corresponding to numeric values in the argument list elements will be designated as data.  Designating a deterministic model node as \'data\' will result in an error.  Designating part of a multivariate node as \'data\' and part as non-data (NA) is allowed, but \'isData()\' will report such a node as being \'data\', calculations with the node will generally return NA, and MCMC samplers will not be assigned to such nodes.
 '
                                           ## new functionality for setData():
                                           ## ... can be a list, a character vector of variable names, or a mix of both
@@ -643,19 +643,19 @@ Arguments:
 
 nodes: A character vector of node or variable names.
 
-Details: The variable or node names specified is expanded into a vector of model node names.  A logical vector is returned, indicating whether each model node has been flagged as containing \'data\'.
+Details: The variable or node names specified is expanded into a vector of model node names. A logical vector is returned, indicating whether each model node has been flagged as containing \'data\'. Multivariate nodes for which any elements are flagged as containing \'data\' will be assigned a value of TRUE.
 '
                                                 g_id = modelDef$nodeName2GraphIDs(nodes, unique = FALSE)
                                   		return(isDataFromGraphID(g_id))
                                   },
 
                                   isDataFromGraphID = function(g_id){
-                                      ## notice this uses only the first element for multivariate nodes
+                                      ## returns TRUE if any elements are flagged as data
                                       nodeNames <- modelDef$maps$graphID_2_nodeName[g_id]
                                   	ret <- unlist(lapply(as.list(nodeNames),
                                                   function(nn)
-                                                    return(as.vector(eval(parse(text=nn, keep.source = FALSE)[[1]],
-                                                                                envir=isDataEnv))[[1]])))
+                                                    return(any(eval(parse(text=nn, keep.source = FALSE)[[1]],
+                                                                                envir=isDataEnv)))))
                                     if(is.null(ret))   ret <- logical(0)
                                     return(ret)
                                   },

--- a/packages/nimble/tests/testthat/test-setData.R
+++ b/packages/nimble/tests/testthat/test-setData.R
@@ -161,5 +161,24 @@ test_that("set 1-length data vector", {
     expect_equal(model$isData('a'), TRUE)
 })
 
+test_that("mixed data/NAs in multivariate nodes treated as a data node", {
+    code <- nimbleCode({
+        y[1:3] ~ dmnorm(mu[1:3], pr[1:3,1:3])
+        y[4] ~ dnorm(0,1)
+    })
+    m  <- nimbleModel(code)
+    ## first element missing
+    m$setData(y = c(NA, 3, 5, 3))
+    expect_true(m$isData('y[4]'))
+    expect_true(m$isData('y[1:3]'))
+    expect_identical(m$isDataEnv$y, c(FALSE, TRUE, TRUE, TRUE))
+    ## non-first element missing
+    m$setData(y = c(3, NA, 5, NA))
+    expect_false(m$isData('y[4]'))
+    expect_true(m$isData('y[1:3]'))
+    expect_identical(m$isDataEnv$y, c(TRUE, FALSE, TRUE, FALSE))
+})
+    
+
 options(warn = RwarnLevel)
 nimbleOptions(verbose = nimbleVerboseSetting)


### PR DESCRIPTION
This addresses the buggy aspect of issue #1126 by having `isData` report a mv node as data if any of the elements of its `isDataEnv` elements are TRUE (formerly `isData` just looked at the first element. I've also cleaned up our roxygen documentation for `isData` and `setData` to be more clear about how we handle such cases.

I decided not to warn users in such cases, as doing so in `setData` is not straightforward because `setData` operates at the variable level and we've noted previously that checking for mixed cases at the node level (e.g., via `testDataFlags`) can be time-consuming for large models.