### PR TITLE
error trap constant negative indexes and add run-time check for dynamic negative indexes

### DIFF
--- a/packages/nimble/R/cppDefs_cppProject.R
+++ b/packages/nimble/R/cppDefs_cppProject.R
@@ -208,7 +208,6 @@ cppProjectClass <- setRefClass('cppProjectClass',
 
                                        logFile <- paste0(dllName, ".log")
                                        errorFile <- paste0(dllName, ".err")
-                                       browser()
                                        status = system2(ssdSHLIBcmd, ssdSHLIBargs, stdout = logFile, stderr = errorFile)
 
                                        if(status == 0 && showCompilerOutput) {
@@ -306,7 +305,6 @@ cppProjectClass <- setRefClass('cppProjectClass',
                                        ## We formerly used ignore.stdout = !showCompilerOutput, ignore.stderr = !showCompilerOutput
                                        ## but when ignore.stdout and ignore.stderr are TRUE nothing gets printed to stdout and stderr so
                                        ## .log and .err files are empty.
-                                       browser()
                                        status = system2(SHLIBcmd, SHLIBargs, stdout = logFile, stderr = errorFile)
                                        if(status == 0 && showCompilerOutput) {
                                            output <- c(readLines(logFile), readLines(errorFile))

--- a/packages/nimble/R/cppDefs_cppProject.R
+++ b/packages/nimble/R/cppDefs_cppProject.R
@@ -208,7 +208,7 @@ cppProjectClass <- setRefClass('cppProjectClass',
 
                                        logFile <- paste0(dllName, ".log")
                                        errorFile <- paste0(dllName, ".err")
-                                       
+                                       browser()
                                        status = system2(ssdSHLIBcmd, ssdSHLIBargs, stdout = logFile, stderr = errorFile)
 
                                        if(status == 0 && showCompilerOutput) {
@@ -306,6 +306,7 @@ cppProjectClass <- setRefClass('cppProjectClass',
                                        ## We formerly used ignore.stdout = !showCompilerOutput, ignore.stderr = !showCompilerOutput
                                        ## but when ignore.stdout and ignore.stderr are TRUE nothing gets printed to stdout and stderr so
                                        ## .log and .err files are empty.
+                                       browser()
                                        status = system2(SHLIBcmd, SHLIBargs, stdout = logFile, stderr = errorFile)
                                        if(status == 0 && showCompilerOutput) {
                                            output <- c(readLines(logFile), readLines(errorFile))

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -2632,6 +2632,8 @@ sizeColonOperator <- function(code, symTab, typeEnv, recurse = TRUE) {
     
     ## could generate an assertion that second arg is >= first arg
     if(is.numeric(code$args[[1]]) & is.numeric(code$args[[2]])) {
+        if(code$args[[1]] > code$args[[2]])
+            stop("sizeColonOperator: negative indexing cannot be compiled.")
         code$sizeExprs <- list(code$args[[2]] - code$args[[1]] + 1)
     } else { ## at least one part is an expression
         ## This is an awkward case:

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -1503,13 +1503,6 @@ identityAssert <- function(lhs, rhs, msg = "") {
     substitute(if(lhs != rhs) nimPrint(msg), list(lhs = lhs, rhs = rhs, msg = msg))
 }
 
-## Generate R code for a greater than assertion
-greaterAssert <- function(lhs, rhs, msg = "") {
-    if(is.numeric(lhs) && is.numeric(rhs) && lhs <= rhs)
-        return(NULL)  ## avoid run-time check if fixed constants
-    msg <- gsub("\"", "\\\\\"", msg)
-    substitute(if(lhs > rhs) nimPrint(msg), list(lhs = lhs, rhs = rhs, msg = msg))
-}
 
 ## Determine if LHS is less information-rich that RHS and issue a warning.
 ## e.g. if LHS is int but RHS is double.
@@ -2643,17 +2636,7 @@ sizeColonOperator <- function(code, symTab, typeEnv, recurse = TRUE) {
         code$sizeExprs <- list(substitute( A - B + 1, list(A = parse(text = nimDeparse(code$args[[2]]), keep.source = FALSE)[[1]],
                                                            B = parse(text = nimDeparse(code$args[[1]]), keep.source = FALSE)[[1]] ) ) )
     }
-    ## Add run-time check that don't have negative indexing.
-    a1 <- code$args[[1]]
-    a2 <- code$args[[2]]
-    assertMessage <- paste0("Run-time negative indexing error: second index ", nimDeparse(a2), " is less than first index ", nimDeparse(a1))
-    if(is.numeric(a1)) a1expr <- a1 else a1expr <- a1$expr
-    if(is.numeric(a2)) a2expr <- a2 else a2expr <- a2$expr
-    newAssert <- greaterAssert(a1expr, a2expr, assertMessage)
-    if(is.null(newAssert))
-        invisible(asserts)
-    else
-        invisible(c(asserts, list(newAssert)))
+    invisible(asserts)
 }
 
 sizeTranspose <- function(code, symTab, typeEnv) {

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -1505,7 +1505,8 @@ identityAssert <- function(lhs, rhs, msg = "") {
 
 ## Generate R code for a greater than assertion
 greaterAssert <- function(lhs, rhs, msg = "") {
-    ## if(lhs <= rhs) return(NULL)   ## not sure if we need this line based on identityAssert /CP
+    if(is.numeric(lhs) && is.numeric(rhs) && lhs <= rhs)
+        return(NULL)  ## avoid run-time check if fixed constants
     msg <- gsub("\"", "\\\\\"", msg)
     substitute(if(lhs > rhs) nimPrint(msg), list(lhs = lhs, rhs = rhs, msg = msg))
 }
@@ -2641,8 +2642,12 @@ sizeColonOperator <- function(code, symTab, typeEnv, recurse = TRUE) {
                                                            B = parse(text = nimDeparse(code$args[[1]]), keep.source = FALSE)[[1]] ) ) )
     }
     ## Add run-time check that don't have negative indexing.
-    assertMessage <- paste0("Run-time negative indexing error: second index ", nimDeparse(code$args[[2]]), " is less than first index ", nimDeparse(code$args[[1]]))
-    newAssert <- greaterAssert(code$args[[1]]$expr, code$args[[2]]$expr, assertMessage)
+    a1 <- code$args[[1]]
+    a2 <- code$args[[2]]
+    assertMessage <- paste0("Run-time negative indexing error: second index ", nimDeparse(a2), " is less than first index ", nimDeparse(a1))
+    if(is.numeric(a1)) a1expr <- a1 else a1expr <- a1$expr
+    if(is.numeric(a2)) a2expr <- a2 else a2expr <- a2$expr
+    newAssert <- greaterAssert(a1expr, a2expr, assertMessage)
     if(is.null(newAssert))
         invisible(asserts)
     else

--- a/packages/nimble/tests/testthat/test-checkDSL.R
+++ b/packages/nimble/tests/testthat/test-checkDSL.R
@@ -313,17 +313,24 @@ test_that("Handling of negative indexing in nimbleFunction code", {
             nimPrint(sum(x[1:3, 6:1]))
         }
     )
-
     expect_error(cTest <- compileNimble(test), "negative indexing")
 
+    test = nimbleFunction(
+        run = function(x=double(2)) {
+            for(i in 3:1) {}
+        }
+    )
+    expect_error(cTest <- compileNimble(test), "negative indexing")
+
+    ## We don't check run-time negative indexing.
     test = nimbleFunction(
         run = function(x=double(2), n1 = double(0), n2 = double(0)) {
             nimPrint(sum(x[1:3, n1:n2]))
         }
     )
     cTest <- compileNimble(test)
-    expect_message(cTest(matrix(rnorm(16), 4, 4), 3, 2),
-                   "Run-time negative indexing error")
+    expect_fail(expect_message(cTest(matrix(rnorm(16), 4, 4), 3, 2),
+                   "Run-time negative indexing error"))
     
 })
 

--- a/packages/nimble/tests/testthat/test-checkDSL.R
+++ b/packages/nimble/tests/testthat/test-checkDSL.R
@@ -307,5 +307,26 @@ test_that("Test of detection of nf methods in findMethods", {
     expect_identical(findMethodsInExprClass(expr), c('cc2', 'cc3', 'cc6', 'cc7', 'cc9', 'cc10', 'cc12', 'cc13', 'cc15', 'cc17', 'cc16'))
 })
 
+test_that("Handling of negative indexing in nimbleFunction code", {
+    test = nimbleFunction(
+        run = function(x=double(2)) {
+            nimPrint(sum(x[1:3, 6:1]))
+        }
+    )
+
+    expect_error(cTest <- compileNimble(test), "negative indexing")
+
+    test = nimbleFunction(
+        run = function(x=double(2), n1 = double(0), n2 = double(0)) {
+            nimPrint(sum(x[1:3, n1:n2]))
+        }
+    )
+    cTest <- compileNimble(test)
+    expect_message(cTest(matrix(rnorm(16), 4, 4), 3, 2),
+                   "Run-time negative indexing error")
+    
+})
+
+
 options(warn = RwarnLevel)
 nimbleOptions(verbose = nimbleVerboseSetting)

--- a/packages/nimble/tests/testthat/test-checkDSL.R
+++ b/packages/nimble/tests/testthat/test-checkDSL.R
@@ -329,7 +329,7 @@ test_that("Handling of negative indexing in nimbleFunction code", {
         }
     )
     cTest <- compileNimble(test)
-    expect_fail(expect_message(cTest(matrix(rnorm(16), 4, 4), 3, 2),
+    expect_failure(expect_message(cTest(matrix(rnorm(16), 4, 4), 3, 2),
                    "Run-time negative indexing error"))
     
 })


### PR DESCRIPTION
In `sizeColonOperator`, this inserts an error trap for negative constant indexes and, if indexes are not constant adds a check in run-time code for negative indexes. 

This fixes issue #1134 