### PR TITLE
use nlines=1 in deparse to avoid multi-line output that will mess up further processing

### DIFF
--- a/packages/nimble/R/BNP_samplers.R
+++ b/packages/nimble/R/BNP_samplers.R
@@ -1338,7 +1338,7 @@ sampler_CRP <- nimbleFunction(
     
     if(any(clusterVarInfo$nTilde == 0)) {
       var <- which(clusterVarInfo$nTilde == 0)
-      stop("sampler_CRP: Detected unusual indexing in ", deparse(clusterVarInfo$indexExpr[[var[1]]]),
+      stop("sampler_CRP: Detected unusual indexing in ", safeDeparse(clusterVarInfo$indexExpr[[var[1]]]),
            " . NIMBLE's CRP MCMC sampling is not designed for this case.")
     }
     
@@ -1403,8 +1403,8 @@ sampler_CRP <- nimbleFunction(
                 if(!identical(clusterVarInfo$clusterNodes[[idx1]], clusterVarInfo$clusterNodes[[idx2]]) &&
                    any(clusterVarInfo$clusterNodes[[idx1]] %in% clusterVarInfo$clusterNodes[[idx2]]))
                     stop("sampler_CRP: Inconsistent indexing in or inconsistent dependencies of ",
-                         deparse(clusterVarInfo$indexExpr[[idx1]]), " and ",
-                         deparse(clusterVarInfo$indexExpr[[idx2]]), ".")
+                         safeDeparse(clusterVarInfo$indexExpr[[idx1]]), " and ",
+                         safeDeparse(clusterVarInfo$indexExpr[[idx2]]), ".")
     
     nData <- length(dataNodes)
 
@@ -1412,7 +1412,7 @@ sampler_CRP <- nimbleFunction(
     ## It's likely that if we set the non-conjugate sampler and turn off wrapping omits sampling of empty clusters
     ## (which is not set up correctly for this case), that the existing code would give correct sampling.
     if(any(clusterVarInfo$multipleStochIndexes))
-        stop("sampler_CRP: Detected use of multiple stochastic indexes of a variable: ", deparse(clusterVarInfo$indexExpr[[1]]), ". NIMBLE's CRP sampling is not yet set up to handle this case. Please contact the NIMBLE development team if you are interested in this functionality.")
+        stop("sampler_CRP: Detected use of multiple stochastic indexes of a variable: ", safeDeparse(clusterVarInfo$indexExpr[[1]]), ". NIMBLE's CRP sampling is not yet set up to handle this case. Please contact the NIMBLE development team if you are interested in this functionality.")
 
     ## Check there is at least one or more "observation" per random index.
     ## Note that cases like mu[xi[i],xi[j]] are being trapped in findClusterNodes().
@@ -1446,7 +1446,7 @@ sampler_CRP <- nimbleFunction(
     for(i in seq_len(n)) { # dataNodes are always needed so only create them before creating  intermNodes
       stochDeps <- model$getDependencies(targetElements[i], stochOnly = TRUE, self = FALSE)
       if(length(stochDeps) != nObsPerClusID)
-          stop("sampler_CRP: The number of nodes that are jointly clustered must be the same for each group. For example if 'mu[i,j]' are clustered such that all nodes for a given 'i' must be in the same cluster, then the number of nodes for each 'i' must be the same. Group ", deparse(i), " has ", deparse(length(stochDeps)), " nodes being clustered where ", deparse(nObsPerClusID), " are expected.")
+          stop("sampler_CRP: The number of nodes that are jointly clustered must be the same for each group. For example if 'mu[i,j]' are clustered such that all nodes for a given 'i' must be in the same cluster, then the number of nodes for each 'i' must be the same. Group ", safeDeparse(i), " has ", safeDeparse(length(stochDeps)), " nodes being clustered where ", safeDeparse(nObsPerClusID), " are expected.")
       dataNodes[((i-1)*nObsPerClusID + 1) : (i*nObsPerClusID)] <- stochDeps
     }
     nIntermClusNodesPerClusID <- length(model$getDependencies(targetElements[1], determOnly = TRUE))  #nInterm
@@ -1456,7 +1456,7 @@ sampler_CRP <- nimbleFunction(
       for(i in seq_len(n)) {
         detDeps <- model$getDependencies(targetElements[i], determOnly = TRUE)
         if(length(detDeps) != nIntermClusNodesPerClusID)
-            stop("sampler_CRP: The number of intermediate deterministic nodes that are jointly clustered must be the same for each group. For example if 'mu[i,j]' are clustered such that all nodes for a given 'i' must be in the same cluster, then the number of nodes for each 'i' must be the same. Group ", deparse(i), " has ", deparse(length(depDeps)), " intermediate nodes being clustered where ", deparse(nIntermClusNodesPerClusID), " are expected.")
+            stop("sampler_CRP: The number of intermediate deterministic nodes that are jointly clustered must be the same for each group. For example if 'mu[i,j]' are clustered such that all nodes for a given 'i' must be in the same cluster, then the number of nodes for each 'i' must be the same. Group ", safeDeparse(i), " has ", safeDeparse(length(depDeps)), " intermediate nodes being clustered where ", safeDeparse(nIntermClusNodesPerClusID), " are expected.")
         intermNodes[((i-1)*nIntermClusNodesPerClusID+1):(i*nIntermClusNodesPerClusID)] <- detDeps
       }
     }
@@ -1845,7 +1845,7 @@ findClusterNodes <- function(model, target) {
         varIdx <- varIdx + 1
         multipleStochIndexes <- c(multipleStochIndexes, FALSE)
           
-        clusterVars <- c(clusterVars, deparse(subExpr[[2]]))
+        clusterVars <- c(clusterVars, safeDeparse(subExpr[[2]], warn = TRUE))
         
         ## Determine which index the target variable occurs in.
         k <- whichIndex <- 3
@@ -1853,7 +1853,7 @@ findClusterNodes <- function(model, target) {
         while(k <= len) {
             if(sum(all.vars(subExpr[[k]]) == targetVar)) {
                 if(foundTarget) {
-                    stop("findClusterNodes: CRP variable used multiple times in ", deparse(subExpr),
+                    stop("findClusterNodes: CRP variable used multiple times in ", safeDeparse(subExpr),
                            ". NIMBLE's CRP MCMC sampling not designed for this situation.")
                 } else {
                     foundTarget <- TRUE
@@ -1894,7 +1894,7 @@ findClusterNodes <- function(model, target) {
         loopIndexes <- unlist(sapply(declInfo$symbolicParentNodes,
                                     function(x) {
                                         if(length(x) >= 3 && x[[1]] == '[' &&
-                                           x[[2]] == targetVar) return(deparse(x[[3]]))
+                                           x[[2]] == targetVar) return(safeDeparse(x[[3]], warn = TRUE))
                                         else return(NULL) }))
         if(length(loopIndexes) != 1)
             stop("findClusterNodes: found cluster membership parameters that use different indexing variables; NIMBLE's CRP sampling not designed for this case.")
@@ -1925,7 +1925,7 @@ findClusterNodes <- function(model, target) {
                     if(length(all.vars(expr[[k]])))  # prevents eval of things like 1:3, which the as.numeric would change to c(1,3)
                         templateExpr[[k]] <- as.numeric(eval(substitute(EXPR, list(EXPR = expr[[k]])),
                                                              c(as.list(unrolledIndices[i,]), e)))  # as.numeric avoids 1L, 2L, etc.
-                clusterNodes[[varIdx]][i] <- deparse(templateExpr)  # convert to node names
+                clusterNodes[[varIdx]][i] <- safeDeparse(templateExpr, warn = TRUE)  # convert to node names
             }
         } else {
             clusterNodes[[varIdx]] <- character(0)
@@ -1933,7 +1933,7 @@ findClusterNodes <- function(model, target) {
         }
       } 
       if(len >= 3 && is.call(subExpr) && subExpr[[1]] == '[' && subExpr[[2]] == targetVar)
-          targetNonIndex <- deparse(model$getDeclInfo(exampleDeps[idx])[[1]]$codeReplaced)
+          targetNonIndex <- safeDeparse(model$getDeclInfo(exampleDeps[idx])[[1]]$codeReplaced, warn = TRUE)
     }
   }
   ## Find the potential cluster nodes that are actually model nodes,
@@ -2132,7 +2132,7 @@ checkNormalInvGammaConjugacy <- function(model, clusterVarInfo, n, gammaDist = '
                 exprs <- sapply(exprs, function(expr) cc_expandDetermNodesInExpr(model, expr))
                 names(exprs) <- NULL
                 for(i in seq_along(exprs)) {
-                    varText <- deparse(exprs[[i]])
+                    varText <- safeDeparse(exprs[[i]], warn = TRUE)
                     if(length(grep(splitNodes2[[idx]][i], varText, fixed = TRUE)))  ## remove clusterNodes2[i] from expression so var expressions will be the same
                         exprs[[i]] <- parse(text = gsub(splitNodes2[[idx]][i],
                                                         "a", varText, fixed = TRUE))[[1]]
@@ -2227,7 +2227,7 @@ checkNormalInvWishartConjugacy <- function(model, clusterVarInfo, n, wishartDist
                 exprs <- sapply(exprs, function(expr) cc_expandDetermNodesInExpr(model, expr))
                 names(exprs) <- NULL
                 for(i in seq_along(exprs)) {
-                    varText <- deparse(exprs[[i]])
+                    varText <- safeDeparse(exprs[[i]], warn = TRUE)
                     if(length(grep(splitNodes2[[idx]][i], varText, fixed = TRUE)))  ## remove clusterNodes2[i] from expression so var expressions will be the same
                         exprs[[i]] <- parse(text = gsub(splitNodes2[[idx]][i],
                                                         "a", varText, fixed = TRUE))[[1]]
@@ -2294,7 +2294,7 @@ getSamplesDPmeasureNames <- function(clusterVarInfo, model, truncG, p) {
       tmp[i, ] <- sapply(seq_len(truncG),
                          function(idx) {
                            expr[[2+clusterVarInfo$indexPosition[j]]] <- as.numeric(idx)
-                           return(deparse(expr))
+                           return(safeDeparse(expr, warn = TRUE))
                          })
     }
     result <- rbind(result , tmp)

--- a/packages/nimble/R/BUGS_BUGSdecl.R
+++ b/packages/nimble/R/BUGS_BUGSdecl.R
@@ -890,7 +890,7 @@ getSymbolicParentNodesRecurse <- function(code, constNames = list(), indexNames 
                 if(!exists(funName, envir))
                     stop("R function '", funName,"' does not exist.")
                 if(funName == ":") ## dynamic indexing in a vector of indices
-                    stop("Dynamic indexing found in a vector of indices, ", safeDeparse(code, warn = TRUE), ". Only scalar indices, such as 'idx' in 'x[idx]', can be dynamic. One can instead use dynamic indexing in a vector of indices inside a nimbleFunction.") 
+                    stop("Dynamic indexing found in a vector of indices, ", safeDeparse(code), ". Only scalar indices, such as 'idx' in 'x[idx]', can be dynamic. One can instead use dynamic indexing in a vector of indices inside a nimbleFunction.") 
                 unreplaceable <-
                     sapply(contents[!contentsReplaceable],
                            function(x) as.character(x$code)

--- a/packages/nimble/R/BUGS_BUGSdecl.R
+++ b/packages/nimble/R/BUGS_BUGSdecl.R
@@ -260,13 +260,13 @@ BUGSdeclClass$methods(
                 code[[3]][[1]] != "I"))
                 stop(
                     paste0('Improper syntax for stochastic declaration: ',
-                           deparse(code))
+                           safeDeparse(code))
                 )
         } else if(code[[1]] == '<-') {
             type <<- 'determ'
         } else {
             stop(paste0('Improper syntax for declaration: ',
-                        deparse(code))
+                        safeDeparse(code))
                  )
         }
         
@@ -296,7 +296,7 @@ BUGSdeclClass$methods(
                     ## There are subscripts inside the transformation
                     if(targetNodeExpr[[1]] != '[') {
                         print(paste("Invalid subscripting for",
-                                    deparse(targetExpr)))
+                                    safeDeparse(targetExpr)))
                     }
                     indexExpr <<- as.list(targetNodeExpr[-c(1,2)])
                     targetVarExpr <<- targetNodeExpr[[2]]
@@ -310,8 +310,8 @@ BUGSdeclClass$methods(
             targetNodeExpr <<- targetVarExpr
         }
         
-        targetVarName <<- deparse(targetVarExpr)
-        targetNodeName <<- deparse(targetNodeExpr)
+        targetVarName <<- safeDeparse(targetVarExpr, warn = TRUE)
+        targetNodeName <<- safeDeparse(targetNodeExpr, warn = TRUE)
     }
 )
 
@@ -377,7 +377,7 @@ makeIndexNamePieces <- function(indexCode) {
     ## Diagnostic for messed up indexing here
     if(as.character(indexCode[[1]] != ':'))
         stop(paste0("Error processing model: something is wrong with the index ",
-                    deparse(indexCode),
+                    safeDeparse(indexCode),
                     ".\nIndexing in model code requires this syntax: '(start expression):(end expression)'."),
              call. = FALSE)
     p1 <- indexCode[[2]]
@@ -465,7 +465,7 @@ BUGSdeclClass$methods(
             )
         if(inherits(targetIndexNamePieces, 'try-error'))
             stop(paste('Error occurred defining ',
-                       deparse(targetExprReplaced)),
+                       safeDeparse(targetExprReplaced)),
                  call. = FALSE)
     if(!nimbleOptions()$allowDynamicIndexing) {
         parentIndexNamePieces <<-
@@ -591,13 +591,13 @@ BUGSdeclClass$methods(
                        is.numeric(boundExprs$upper_) &&
                        boundExprs$lower_ >= boundExprs$upper_)
                         warning(paste0("Lower bound is greater than or equal to upper bound in ",
-                                       deparse(codeReplaced),
+                                       safeDeparse(codeReplaced),
                                        "; proceeding anyway, but this is likely to cause numerical issues."))
                     if(is.numeric(boundExprs$lower_) &&
                        is.numeric(distRange$lower) &&
                        boundExprs$lower_ < distRange$lower) {
                         warning(paste0("Lower bound is less than or equal to distribution lower bound in ",
-                                       deparse(codeReplaced), "; ignoring user-provided lower bound."))
+                                       safeDeparse(codeReplaced), "; ignoring user-provided lower bound."))
                         boundExprs$lower_ <<- distRange$lower
                         codeReplaced[[3]]['lower_'] <<- distRange$lower
                     }
@@ -605,7 +605,7 @@ BUGSdeclClass$methods(
                        is.numeric(distRange$upper) &&
                        boundExprs$upper_ > distRange$upper) {
                         warning(paste0("Upper bound is greater than or equal to distribution upper bound in ",
-                                       deparse(codeReplaced),
+                                       safeDeparse(codeReplaced),
                                        "; ignoring user-provided upper bound."))
                         boundExprs$upper_ <<- distRange$upper
                         codeReplaced[[3]]['upper_'] <<- distRange$upper
@@ -762,7 +762,7 @@ getSymbolicParentNodesRecurse <- function(code, constNames = list(), indexNames 
             ## error if it looks like mu[i][j] where i is a for-loop index
             if(variable$hasIndex)
                 stop('Error: Variable',
-                     deparse(code[[2]]),
+                     safeDeparse(code[[2]]),
                      'on outside of [ contains a BUGS code index.')
             
             if(variable$replaceable) {
@@ -770,7 +770,7 @@ getSymbolicParentNodesRecurse <- function(code, constNames = list(), indexNames 
                 ## block[i], so block is replaceable
                 if(!all(contentsReplaceable)) 
                     ## dynamic index on a constant
-                    stop('getSymbolicParentNodesRecurse: dynamic indexing of constants is not allowed in ', deparse(code), '. Try adding the dynamically-indexed constant as data instead (using the data argument of nimbleModel).')
+                    stop('getSymbolicParentNodesRecurse: dynamic indexing of constants is not allowed in ', safeDeparse(code), '. Try adding the dynamically-indexed constant as data instead (using the data argument of nimbleModel).')
                 boolIndexingBlock <-
                     unlist(
                         lapply(code[-c(1,2)],
@@ -802,7 +802,7 @@ getSymbolicParentNodesRecurse <- function(code, constNames = list(), indexNames 
                 } else { ## non-replaceable indices are dynamic indices (or constant vectors, which are not allowed)
                     if(!nimbleOptions()$allowDynamicIndexing) {
                         warning("It appears you are trying to use dynamic indexing (i.e., the index of a variable is determined by something that is not a constant) in: ",
-                                deparse(code),
+                                safeDeparse(code),
                                 ". This is now allowed as of version 0.6-6 (as an optional beta feature) and by default as of version 0.6-7. Please set 'nimbleOptions(allowDynamicIndexing = TRUE)' and report any issues to the NIMBLE users group.")
                         dynamicIndexParent <- code[[2]]
                     } else {
@@ -811,8 +811,8 @@ getSymbolicParentNodesRecurse <- function(code, constNames = list(), indexNames 
                                    detectNonscalarIndex))
                            )
                             stop("getSymbolicParentNodesRecurse: only scalar indices are allowed; vector indexing found in ",
-                                 deparse(code))
-                        indexedVariable <- deparse(code[[2]])
+                                 safeDeparse(code))
+                        indexedVariable <- safeDeparse(code[[2]], warn = TRUE)
                         dynamicIndexParent <-
                             addUnknownIndexToVarNameInBracketExpr(code, contextID)
                         ## Instead of inserting NA, leave indexing
@@ -882,7 +882,7 @@ getSymbolicParentNodesRecurse <- function(code, constNames = list(), indexNames 
             }
             ## check if the function can be called only in R, not NIMBLE
             isRfunction <- !any(code[[1]] == nimbleFunctionNames)
-            funName <- deparse(code[[1]])
+            funName <- safeDeparse(code[[1]], warn = TRUE)
             isRonly <- isRfunction &
                 (!checkNimbleOrRfunctionNames(funName, envir))
             ## if it can be called only in R but not all contents are replaceable, generate error:
@@ -890,7 +890,7 @@ getSymbolicParentNodesRecurse <- function(code, constNames = list(), indexNames 
                 if(!exists(funName, envir))
                     stop("R function '", funName,"' does not exist.")
                 if(funName == ":") ## dynamic indexing in a vector of indices
-                    stop("Dynamic indexing found in a vector of indices, ", deparse(code), ". Only scalar indices, such as 'idx' in 'x[idx]', can be dynamic. One can instead use dynamic indexing in a vector of indices inside a nimbleFunction.") 
+                    stop("Dynamic indexing found in a vector of indices, ", safeDeparse(code, warn = TRUE), ". Only scalar indices, such as 'idx' in 'x[idx]', can be dynamic. One can instead use dynamic indexing in a vector of indices inside a nimbleFunction.") 
                 unreplaceable <-
                     sapply(contents[!contentsReplaceable],
                            function(x) as.character(x$code)
@@ -907,7 +907,7 @@ getSymbolicParentNodesRecurse <- function(code, constNames = list(), indexNames 
         }
     }
     stop(paste('Something went wrong in getSymbolicVariablesRecurse with',
-               deparse(code)))
+               safeDeparse(code)))
 }
 
 checkNimbleOrRfunctionNames <- function(functionName, envir) {
@@ -1036,7 +1036,7 @@ genReplacementsAndCodeRecurse <- function(code,
         ## or is a nimbleFunction (specifically, an RCfunction)
         if(
         {
-            funName <- deparse(code[[1]])
+            funName <- safeDeparse(code[[1]], warn = TRUE)
             (
                 (funName %in% functionsThatShouldNeverBeReplacedInBUGScode) ||
                 (exists(funName, envir) && is.rcf(get(funName, envir)))
@@ -1057,12 +1057,12 @@ genReplacementsAndCodeRecurse <- function(code,
         isRfunction <- !any(code[[1]] == nimbleFunctionNames)
         isRonly <-
             isRfunction &
-            !checkNimbleOrRfunctionNames(deparse(code[[1]]), envir)
-        if(deparse(code[[1]]) == '$')
+            !checkNimbleOrRfunctionNames(safeDeparse(code[[1]], warn = TRUE), envir)
+        if(safeDeparse(code[[1]], warn = TRUE) == '$')
             isRonly <- FALSE
         if(isRonly & !allContentsReplaceable)
             stop(paste0('Error, R function \"',
-                        deparse(code[[1]]),
+                        safeDeparse(code[[1]]),
                         '\" has non-replaceable node values as arguments.  Must be a nimble function.')
                  )
         if(isRfunction & allContentsReplaceable)
@@ -1074,7 +1074,7 @@ genReplacementsAndCodeRecurse <- function(code,
                                 startingAt=2))
     }
     stop(paste('Something went wrong in genReplacementsAndCodeRecurse with',
-               deparse(code)))
+               safeDeparse(code)))
 }
 
 replaceAllCodeSuccessfully <- function(code) {

--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -1029,7 +1029,7 @@ Checks for size/dimension mismatches and for presence of NAs in model variables 
                                                           LHSsize <- LHSsize[LHSsize != 1]
 
                                                       if(!identical(LHSsize, RHSsize))
-                                                          stop("Size/dimension mismatch between left-hand side and right-hand size of BUGS expression: ", deparse(declInfo$code))
+                                                          stop("Size/dimension mismatch between left-hand side and right-hand size of BUGS expression: ", safeDeparse(declInfo$code))
                                                   }
                                                   ## these lines caused a problem for functions such as chol() in BUGS code
                                                   ## removed by DT April 2016
@@ -1042,7 +1042,7 @@ Checks for size/dimension mismatches and for presence of NAs in model variables 
                                                   #   1) dims of param args match those in distInputList based on calculation
                                                   #   2) dims of param args match those in distInputList based on varInfo
                                                   #   3) sizes of vecs and row/column sizes all match for non-scalar quantities (only for Nimble-provided distributions)
-                                                  dist <- deparse(declInfo$valueExprReplaced[[1]])
+                                                  dist <- safeDeparse(declInfo$valueExprReplaced[[1]], warn = TRUE)
 
 							# nimble:::getDimension so uses function not model method
                                                   distDims <- nimble::getDimension(dist, includeParams = TRUE)
@@ -1067,17 +1067,17 @@ Checks for size/dimension mismatches and for presence of NAs in model variables 
                                                   }
                                         # check dimensions based on varInfo
                                                   if(length(declInfo$targetExprReplaced) > 1) {
-                                                      LHSvar <- deparse(declInfo$targetExprReplaced[[2]])
-                                                  } else LHSvar <- deparse(declInfo$targetExprReplaced)
+                                                      LHSvar <- safeDeparse(declInfo$targetExprReplaced[[2]], warn = TRUE)
+                                                  } else LHSvar <- safeDeparse(declInfo$targetExprReplaced, warn = TRUE)
                                                   if(.self$modelDef$varInfo[[LHSvar]]$nDim < distDims['value'])
                                                       stop("Dimension of '", LHSvar, "' does not match required dimension for the distribution '", dist, "'. Necessary dimension is ", distDims['value'], ".", ifelse(distDims['value'] > 0, paste0(" You may need to include explicit indexing information, e.g., variable_name", ifelse(distDims['value'] < 2, "[1:2].", "[1:2,1:2].")), ''))
                                                   nms2 <- nms[nms%in%names(declInfo$valueExprReplaced)]
                                                   for(k in seq_along(nms2)) {
-                                                      if(!is.numeric(declInfo$valueExprReplaced[[nms2[k]]]) && !(dist == 'dinterval' && nms2[k] == 'c') && ( length(declInfo$valueExprReplaced[[nms2[k]]]) ==1 || deparse(declInfo$valueExprReplaced[[nms2[k]]][[1]]) == '[' )) {  # can only check variables not expressions or constants
+                                                      if(!is.numeric(declInfo$valueExprReplaced[[nms2[k]]]) && !(dist == 'dinterval' && nms2[k] == 'c') && ( length(declInfo$valueExprReplaced[[nms2[k]]]) ==1 || safeDeparse(declInfo$valueExprReplaced[[nms2[k]]][[1]], warn = TRUE) == '[' )) {  # can only check variables not expressions or constants
                                                           # also dinterval can take 'c' param as scalar or vector, so don't check
                                                           if(length(declInfo$valueExprReplaced[[nms2[k]]]) > 1) {
-                                                              var <- deparse(declInfo$valueExprReplaced[[nms2[k]]][[2]])
-                                                          } else var <- deparse(declInfo$valueExprReplaced[[nms2[k]]])
+                                                              var <- safeDeparse(declInfo$valueExprReplaced[[nms2[k]]][[2]], warn = TRUE)
+                                                          } else var <- safeDeparse(declInfo$valueExprReplaced[[nms2[k]]], warn = TRUE)
                                                           if(var %in% names(.self$modelDef$varInfo) && .self$modelDef$varInfo[[var]]$nDim < distDims[nms2[k]])
                                                               # check less than because variable dim can be bigger than node dim
                                                               stop("Dimension of '", nms2[k], "' does not match required dimension for the distribution '", dist, "'. Necessary dimension is ", distDims[nms2[k]], ".", ifelse(distDims[nms2[k]] > 0, paste0(" You may need to include explicit indexing information, e.g., variable_name", ifelse(distDims[nms2[k]] < 2, "[1:2].", "[1:2,1:2].")), ''))
@@ -1104,9 +1104,9 @@ Checks for size/dimension mismatches and for presence of NAs in model variables 
                                                       matCols <- unlist(sapply(sizes[mats], `[`, 2))
                                                       if(!length(unique(c(matRows, matCols, unlist(sizes[vecs])))) <= 1)
                                                           if(dist %in% names(nimble:::distributionsInputList)) {
-                                                              stop("Size/dimension mismatch amongst vectors and matrices in BUGS expression: ", deparse(declInfo$code))
+                                                              stop("Size/dimension mismatch amongst vectors and matrices in BUGS expression: ", safeDeparse(declInfo$code))
                                                           } else {
-                                                              warning("Possible size/dimension mismatch amongst vectors and matrices in BUGS expression: ", deparse(declInfo$code), ". Ignore this warning if the user-provided distribution has multivariate parameters with distinct sizes or if size of variable differs from sizes of parameters.")                                                                                                                                   }
+                                                              warning("Possible size/dimension mismatch amongst vectors and matrices in BUGS expression: ", safeDeparse(declInfo$code), ". Ignore this warning if the user-provided distribution has multivariate parameters with distinct sizes or if size of variable differs from sizes of parameters.")                                                                                                                                   }
                                                   }
 
                                               }
@@ -1279,7 +1279,7 @@ insertSingleIndexBrackets <- function(code, varInfo) {
         }
         return(code)
     }
-    if(!is.null(code)) message(paste('confused about reaching end of insertSingleBrackets with ', deparse(code)))
+    if(!is.null(code)) message(paste('confused about reaching end of insertSingleBrackets with ', safeDeparse(code)))
     return(code)
 }
 
@@ -1326,7 +1326,7 @@ RmodelBaseClass <- setRefClass("RmodelBaseClass",
                                            RHS <- code[[3]]
                                            if(nimble::nimbleOptions('experimentalEnableDerivs')){
                                              parents <- BUGSdecl$allParentVarNames()
-                                             selfWithNoInds <-  strsplit(deparse(LHS), '[', fixed = TRUE)[[1]][1]
+                                             selfWithNoInds <-  strsplit(safeDeparse(LHS, warn = TRUE), '[', fixed = TRUE)[[1]][1]
                                              parents <- c(selfWithNoInds, parents)
                                              parentsSizeAndDims <- nimble:::makeSizeAndDimList(LHS, parents, BUGSdecl$unrolledIndicesMatrix, checkRagged = TRUE)
                                              parentsSizeAndDims <- nimble:::makeSizeAndDimList(RHS, parents, BUGSdecl$unrolledIndicesMatrix,
@@ -1334,10 +1334,10 @@ RmodelBaseClass <- setRefClass("RmodelBaseClass",
                                            } else parentsSizeAndDims <- list()
 
                                            if(nimble::nimbleOptions()$allowDynamicIndexing && length(BUGSdecl$dynamicIndexInfo)) {  ## need dim for node for generating NaN with invalid dynamic indexes
-                                               nodeSizeAndDims <- nimble:::makeSizeAndDimList(LHS, deparse(BUGSdecl$targetVarExpr),
+                                               nodeSizeAndDims <- nimble:::makeSizeAndDimList(LHS, safeDeparse(BUGSdecl$targetVarExpr, warn = TRUE),
                                                                                               BUGSdecl$unrolledIndicesMatrix,
                                                                                               checkRagged = FALSE)
-                                               nodeDim <- nodeSizeAndDims[[deparse(BUGSdecl$targetVarExpr)]][[1]]$lengths
+                                               nodeDim <- nodeSizeAndDims[[safeDeparse(BUGSdecl$targetVarExpr, warn = TRUE)]][[1]]$lengths
                                                nodeDim <- nodeDim[nodeDim != 1] ## will be NULL if scalar
                                                if(!length(nodeDim)) nodeDim <- NULL
                                            } else nodeDim <- NULL

--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -1029,7 +1029,7 @@ Checks for size/dimension mismatches and for presence of NAs in model variables 
                                                           LHSsize <- LHSsize[LHSsize != 1]
 
                                                       if(!identical(LHSsize, RHSsize))
-                                                          stop("Size/dimension mismatch between left-hand side and right-hand size of BUGS expression: ", safeDeparse(declInfo$code))
+                                                          stop("Size/dimension mismatch between left-hand side and right-hand size of BUGS expression: ", nimble:::safeDeparse(declInfo$code))
                                                   }
                                                   ## these lines caused a problem for functions such as chol() in BUGS code
                                                   ## removed by DT April 2016
@@ -1042,7 +1042,7 @@ Checks for size/dimension mismatches and for presence of NAs in model variables 
                                                   #   1) dims of param args match those in distInputList based on calculation
                                                   #   2) dims of param args match those in distInputList based on varInfo
                                                   #   3) sizes of vecs and row/column sizes all match for non-scalar quantities (only for Nimble-provided distributions)
-                                                  dist <- safeDeparse(declInfo$valueExprReplaced[[1]], warn = TRUE)
+                                                  dist <- nimble:::safeDeparse(declInfo$valueExprReplaced[[1]], warn = TRUE)
 
 							# nimble:::getDimension so uses function not model method
                                                   distDims <- nimble::getDimension(dist, includeParams = TRUE)
@@ -1067,17 +1067,17 @@ Checks for size/dimension mismatches and for presence of NAs in model variables 
                                                   }
                                         # check dimensions based on varInfo
                                                   if(length(declInfo$targetExprReplaced) > 1) {
-                                                      LHSvar <- safeDeparse(declInfo$targetExprReplaced[[2]], warn = TRUE)
-                                                  } else LHSvar <- safeDeparse(declInfo$targetExprReplaced, warn = TRUE)
+                                                      LHSvar <- nimble:::safeDeparse(declInfo$targetExprReplaced[[2]], warn = TRUE)
+                                                  } else LHSvar <- nimble:::safeDeparse(declInfo$targetExprReplaced, warn = TRUE)
                                                   if(.self$modelDef$varInfo[[LHSvar]]$nDim < distDims['value'])
                                                       stop("Dimension of '", LHSvar, "' does not match required dimension for the distribution '", dist, "'. Necessary dimension is ", distDims['value'], ".", ifelse(distDims['value'] > 0, paste0(" You may need to include explicit indexing information, e.g., variable_name", ifelse(distDims['value'] < 2, "[1:2].", "[1:2,1:2].")), ''))
                                                   nms2 <- nms[nms%in%names(declInfo$valueExprReplaced)]
                                                   for(k in seq_along(nms2)) {
-                                                      if(!is.numeric(declInfo$valueExprReplaced[[nms2[k]]]) && !(dist == 'dinterval' && nms2[k] == 'c') && ( length(declInfo$valueExprReplaced[[nms2[k]]]) ==1 || safeDeparse(declInfo$valueExprReplaced[[nms2[k]]][[1]], warn = TRUE) == '[' )) {  # can only check variables not expressions or constants
+                                                      if(!is.numeric(declInfo$valueExprReplaced[[nms2[k]]]) && !(dist == 'dinterval' && nms2[k] == 'c') && ( length(declInfo$valueExprReplaced[[nms2[k]]]) ==1 || nimble:::safeDeparse(declInfo$valueExprReplaced[[nms2[k]]][[1]], warn = TRUE) == '[' )) {  # can only check variables not expressions or constants
                                                           # also dinterval can take 'c' param as scalar or vector, so don't check
                                                           if(length(declInfo$valueExprReplaced[[nms2[k]]]) > 1) {
-                                                              var <- safeDeparse(declInfo$valueExprReplaced[[nms2[k]]][[2]], warn = TRUE)
-                                                          } else var <- safeDeparse(declInfo$valueExprReplaced[[nms2[k]]], warn = TRUE)
+                                                              var <- nimble:::safeDeparse(declInfo$valueExprReplaced[[nms2[k]]][[2]], warn = TRUE)
+                                                          } else var <- nimble:::safeDeparse(declInfo$valueExprReplaced[[nms2[k]]], warn = TRUE)
                                                           if(var %in% names(.self$modelDef$varInfo) && .self$modelDef$varInfo[[var]]$nDim < distDims[nms2[k]])
                                                               # check less than because variable dim can be bigger than node dim
                                                               stop("Dimension of '", nms2[k], "' does not match required dimension for the distribution '", dist, "'. Necessary dimension is ", distDims[nms2[k]], ".", ifelse(distDims[nms2[k]] > 0, paste0(" You may need to include explicit indexing information, e.g., variable_name", ifelse(distDims[nms2[k]] < 2, "[1:2].", "[1:2,1:2].")), ''))
@@ -1104,9 +1104,9 @@ Checks for size/dimension mismatches and for presence of NAs in model variables 
                                                       matCols <- unlist(sapply(sizes[mats], `[`, 2))
                                                       if(!length(unique(c(matRows, matCols, unlist(sizes[vecs])))) <= 1)
                                                           if(dist %in% names(nimble:::distributionsInputList)) {
-                                                              stop("Size/dimension mismatch amongst vectors and matrices in BUGS expression: ", safeDeparse(declInfo$code))
+                                                              stop("Size/dimension mismatch amongst vectors and matrices in BUGS expression: ", nimble:::safeDeparse(declInfo$code))
                                                           } else {
-                                                              warning("Possible size/dimension mismatch amongst vectors and matrices in BUGS expression: ", safeDeparse(declInfo$code), ". Ignore this warning if the user-provided distribution has multivariate parameters with distinct sizes or if size of variable differs from sizes of parameters.")                                                                                                                                   }
+                                                              warning("Possible size/dimension mismatch amongst vectors and matrices in BUGS expression: ", nimble:::safeDeparse(declInfo$code), ". Ignore this warning if the user-provided distribution has multivariate parameters with distinct sizes or if size of variable differs from sizes of parameters.")                                                                                                                                   }
                                                   }
 
                                               }
@@ -1326,7 +1326,7 @@ RmodelBaseClass <- setRefClass("RmodelBaseClass",
                                            RHS <- code[[3]]
                                            if(nimble::nimbleOptions('experimentalEnableDerivs')){
                                              parents <- BUGSdecl$allParentVarNames()
-                                             selfWithNoInds <-  strsplit(safeDeparse(LHS, warn = TRUE), '[', fixed = TRUE)[[1]][1]
+                                             selfWithNoInds <-  strsplit(nimble:::safeDeparse(LHS, warn = TRUE), '[', fixed = TRUE)[[1]][1]
                                              parents <- c(selfWithNoInds, parents)
                                              parentsSizeAndDims <- nimble:::makeSizeAndDimList(LHS, parents, BUGSdecl$unrolledIndicesMatrix, checkRagged = TRUE)
                                              parentsSizeAndDims <- nimble:::makeSizeAndDimList(RHS, parents, BUGSdecl$unrolledIndicesMatrix,
@@ -1334,10 +1334,10 @@ RmodelBaseClass <- setRefClass("RmodelBaseClass",
                                            } else parentsSizeAndDims <- list()
 
                                            if(nimble::nimbleOptions()$allowDynamicIndexing && length(BUGSdecl$dynamicIndexInfo)) {  ## need dim for node for generating NaN with invalid dynamic indexes
-                                               nodeSizeAndDims <- nimble:::makeSizeAndDimList(LHS, safeDeparse(BUGSdecl$targetVarExpr, warn = TRUE),
+                                               nodeSizeAndDims <- nimble:::makeSizeAndDimList(LHS, nimble:::safeDeparse(BUGSdecl$targetVarExpr, warn = TRUE),
                                                                                               BUGSdecl$unrolledIndicesMatrix,
                                                                                               checkRagged = FALSE)
-                                               nodeDim <- nodeSizeAndDims[[safeDeparse(BUGSdecl$targetVarExpr, warn = TRUE)]][[1]]$lengths
+                                               nodeDim <- nodeSizeAndDims[[nimble:::safeDeparse(BUGSdecl$targetVarExpr, warn = TRUE)]][[1]]$lengths
                                                nodeDim <- nodeDim[nodeDim != 1] ## will be NULL if scalar
                                                if(!length(nodeDim)) nodeDim <- NULL
                                            } else nodeDim <- NULL

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -191,7 +191,7 @@ modelDefClass$methods(setupModel = function(code, constants, dimensions, inits, 
 codeProcessIfThenElse <- function(code, constants, envir = parent.frame()) {
     codeLength <- length(code)
     if(is.name(code))
-        stop("Incomplete declaration found: '", deparse(code), "'.")
+        stop("Incomplete declaration found: '", safeDeparse(code), "'.")
         
     if(code[[1]] == '{') {
         if(codeLength > 1) for(i in 2:codeLength) code[[i]] <- codeProcessIfThenElse(code[[i]], constants, envir)
@@ -206,7 +206,7 @@ codeProcessIfThenElse <- function(code, constants, envir = parent.frame()) {
         parent.env(constantsEnv) <- envir
         evaluatedCondition <- try(eval(code[[2]], constantsEnv))
         if(inherits(evaluatedCondition, "try-error")) 
-            stop("Cannot evaluate condition of 'if' statement: ", deparse(code[[2]]), ".\nCondition must be able to be evaluated based on values in 'constants'.")
+            stop("Cannot evaluate condition of 'if' statement: ", safeDeparse(code[[2]]), ".\nCondition must be able to be evaluated based on values in 'constants'.")
         if(evaluatedCondition) return(codeProcessIfThenElse(code[[3]], constants, envir))
         else {
             if(length(code) == 4) return(codeProcessIfThenElse(code[[4]], constants, envir))
@@ -253,11 +253,11 @@ codeProcessModelMacros <- function(code,
     ## The second version allows more full control.
 
     ## Initialize possibleMacroName assuming version (ii):
-    possibleMacroName <- deparse(code[[1]])
+    possibleMacroName <- safeDeparse(code[[1]], warn = TRUE)
     ## If it is really version (i), possibleMacroName will be
     ## ~ or <- and should be updated to the call on the right-hand side:
     if(possibleMacroName %in% c('<-', '~')) {
-        possibleMacroName <- deparse(code[[3]][[1]])
+        possibleMacroName <- safeDeparse(code[[3]][[1]], warn = TRUE)
     }
     if(exists(possibleMacroName)) { ## may need to provide an envir argument
         possibleMacro <- get(possibleMacroName) ## ditto
@@ -404,9 +404,9 @@ modelDefClass$methods(initializeContexts = function() {
 })
 
 reprioritizeColonOperator <- function(code) {
-    split.code <- strsplit(deparse(code), ":")
+    split.code <- strsplit(safeDeparse(code, warn = TRUE), ":")
     if(length(split.code[[1]]) == 2) return(parse(text = paste0("(", split.code[[1]][1], "):(", split.code[[1]][2], ")"), keep.source = FALSE)[[1]])
-    if(length(split.code[[1]]) > 2) stop(paste0('Error with this code: ', deparse(code)))
+    if(length(split.code[[1]]) > 2) stop(paste0('Error with this code: ', safeDeparse(code)))
     return(code)
 }
 
@@ -468,7 +468,7 @@ modelDefClass$methods(processBUGScode = function(code = NULL, contextID = 1, lin
             BUGScontextClassObject$setup(singleContexts = singleContexts)
             contexts[[nextContextID]] <<- BUGScontextClassObject
             if(length(code[[i]][[4]])==1) {
-                stop('Error, not sure what to do with ', deparse(code[[i]]), ".")
+                stop('Error, not sure what to do with ', safeDeparse(code[[i]]), ".")
             }
             recurseCode <- if(code[[i]][[4]][[1]] == '{') {
                 code[[i]][[4]]
@@ -480,8 +480,8 @@ modelDefClass$methods(processBUGScode = function(code = NULL, contextID = 1, lin
         if(code[[i]][[1]] == '{') {  ## recursive call to a block contained in a {}, perhaps as a result of processCodeIfThenElse
             lineNumber <- processBUGScode(code[[i]], contextID, lineNumber = lineNumber, userEnv = userEnv)
         }
-        if(!deparse(code[[i]][[1]]) %in% c('~', '<-', 'for', '{')) 
-            stop("Error: ", deparse(code[[i]][[1]]), " not allowed in BUGS code in ", deparse(code[[i]]))
+        if(!safeDeparse(code[[i]][[1]], warn = TRUE) %in% c('~', '<-', 'for', '{')) 
+            stop("Error: ", safeDeparse(code[[i]][[1]]), " not allowed in BUGS code in ", safeDeparse(code[[i]]))
     }
     lineNumber
 })
@@ -501,9 +501,9 @@ checkUserDefinedDistribution <- function(code, userEnv) {
 
 replaceDistributionAliases <- function(code) {
     if(length(code) < 3)
-        stop("Invalid model declaration: ", deparse(code), ".")
+        stop("Invalid model declaration: ", safeDeparse(code), ".")
     if(!is.call(code[[3]]))
-        stop("Invalid model declaration: ", deparse(code), " must call a density function.")
+        stop("Invalid model declaration: ", safeDeparse(code), " must call a density function.")
     dist <- as.character(code[[3]][[1]])
     trunc <- FALSE
     if(dist %in% c("T", "I")) {
@@ -525,7 +525,7 @@ checkForDeterministicDorR <- function(code) {
             drFuns <- c(drFuns, dFunsUser, paste0("r", stripPrefix(dFunsUser)))
         }
         if(as.character(code[[3]][[1]]) %in% drFuns)
-            warning("Model includes deterministic assignment using '<-' of the result of a density ('d') or simulation ('r') calculation. This is likely not what you intended in: ", deparse(code), ".")
+            warning("Model includes deterministic assignment using '<-' of the result of a density ('d') or simulation ('r') calculation. This is likely not what you intended in: ", safeDeparse(code), ".")
     }
     return(NULL)
 }
@@ -611,11 +611,11 @@ addMissingIndexingRecurse <- function(code, dimensionsList) {
       ## let's check to make sure all indexes are present
       if(any(unlist(lapply(as.list(code), is.blank)))) {
         stop(paste0('Error: This part of NIMBLE is still under development.', '\n',
-                    'The model definition included the expression \'', deparse(code), '\', which contains missing indices.', '\n',
+                    'The model definition included the expression \'', safeDeparse(code), '\', which contains missing indices.', '\n',
                     'There are two options to resolve this:', '\n',
-                    '(1) Explicitly provide the missing indices in the model definition (e.g., \'', deparse(example_fillInMissingIndices(code)), '\'), or', '\n',
+                    '(1) Explicitly provide the missing indices in the model definition (e.g., \'', safeDeparse(example_fillInMissingIndices(code)), '\'), or', '\n',
                     '(2) Provide the dimensions of variable \'', code[[2]], '\' via the \'dimensions\' argument to nimbleModel(), e.g.,', '\n',
-                    '    nimbleModel(code, dimensions = list(', code[[2]], ' = ', deparse(example_getMissingDimensions(code)), '))', '\n',
+                    '    nimbleModel(code, dimensions = list(', code[[2]], ' = ', safeDeparse(example_getMissingDimensions(code)), '))', '\n',
                     'Thanks for bearing with us.'), call. = FALSE)
       }
       ## and to recurse on all elements
@@ -665,7 +665,7 @@ modelDefClass$methods(processBoundsAndTruncation = function() {
         } else {
             truncated <- TRUE
             if(callName == "I")
-                message("  [Note] Interpreting I(,) as truncation (equivalent to T(,)) in ", deparse(BUGSdecl$code), "; this is only valid when ", deparse(BUGSdecl$targetExpr), " has no unobserved (stochastic) parents.")
+                message("  [Note] Interpreting I(,) as truncation (equivalent to T(,)) in ", safeDeparse(BUGSdecl$code), "; this is only valid when ", safeDeparse(BUGSdecl$targetExpr), " has no unobserved (stochastic) parents.")
                 
             newCode <- BUGSdecl$code
             newCode[[3]] <- BUGSdecl$valueExpr[[2]]  # insert the core density function call
@@ -715,7 +715,7 @@ modelDefClass$methods(checkMultivarExpr = function() {
     checkForExpr <- function(expr) {
         ##output <- FALSE
         if(length(expr) == 1 && (inherits(expr, "name") || inherits(expr, "numeric"))) return(FALSE)
-        if(!deparse(expr[[1]]) == '[') return(TRUE)
+        if(!safeDeparse(expr[[1]], warn = TRUE) == '[') return(TRUE)
         ## recurse only on the first argument of the `[`
         return(checkForExpr(expr[[2]]))
         ## Previously we recursed more completely.  Now we stop because expressions
@@ -760,7 +760,7 @@ modelDefClass$methods(processLinks = function() {
         BUGSdecl <- declInfo[[i]]
         nextNewDeclInfoIndex <- length(newDeclInfo) + 1
         if(is.null(BUGSdecl$transExpr))     { newDeclInfo[[nextNewDeclInfoIndex]] <- BUGSdecl; next }
-        linkText <- deparse(BUGSdecl$transExpr)
+        linkText <- safeDeparse(BUGSdecl$transExpr, warn = TRUE)
         if(!(linkText %in% names(linkInverses)))    stop(paste('Error, unknown link function:',linkText))
         
         if(BUGSdecl$type == 'stoch') {   # stochastic node
@@ -823,7 +823,7 @@ modelDefClass$methods(reparameterizeDists = function() {
               if(identical(sort(unique(distRule$alts[[count]])), sort(unique(names(params)))))
                 matchedAlt <- count
             }
-            if(is.null(matchedAlt)) stop(paste0('bad parameters for distribution ', deparse(valueExpr), '. (No available re-parameterization found.)'), call. = FALSE)
+            if(is.null(matchedAlt)) stop(paste0('bad parameters for distribution ', safeDeparse(valueExpr), '. (No available re-parameterization found.)'), call. = FALSE)
           }
           nonReqdArgs <- names(params)[!(names(params) %in% distRule$reqdArgs)]
           for(iArg in 1:numArgs) {   ## loop over the required arguments
@@ -833,9 +833,9 @@ modelDefClass$methods(reparameterizeDists = function() {
               newValueExpr[[iArg + 1]] <- params[[reqdArgName]];
               next
             }
-            if(!matchedAlt) error("Something wrong - looking for alternative parameterization but supplied args are same as required args: ", deparse(valueExpr))
+            if(!matchedAlt) error("Something wrong - looking for alternative parameterization but supplied args are same as required args: ", safeDeparse(valueExpr))
             if(!reqdArgName %in% names(distRule$exprs[[matchedAlt]]))
-              stop('Error: could not find ', reqdArgName, ' in alternative parameterization number ', matchedAlt, ' for: ', deparse(valueExpr), '.')
+              stop('Error: could not find ', reqdArgName, ' in alternative parameterization number ', matchedAlt, ' for: ', safeDeparse(valueExpr), '.')
             transformedParameterPT <- distRule$exprs[[matchedAlt]][[reqdArgName]]
             ## handles pathological-case model variable names, e.g.,
             ## y ~ dnorm(0, tau = sd)
@@ -944,7 +944,7 @@ replaceConstantsRecurse <- function(code, constEnv, constNames, do.eval = TRUE) 
                 if(do.eval) {
                     origCode <- code
                     code <- as.numeric(eval(code, constEnv))
-                    if(length(code) != 1) warning(paste('Code', deparse(origCode),'was given as known but evaluates to a non-scalar.  This is probably not what you want.'))
+                    if(length(code) != 1) warning(paste('Code', safeDeparse(origCode),'was given as known but evaluates to a non-scalar.  This is probably not what you want.'))
                 }
                 return(list(code = code,
                             replaceable = TRUE))
@@ -1048,7 +1048,7 @@ modelDefClass$methods(liftExpressionArgs = function() {
                 requireNewAndUniqueDecl <- any(contexts[[BUGSdecl$contextID]]$indexVarNames %in% all.vars(paramExpr))
                 uniquePiece <- if(requireNewAndUniqueDecl) paste0("_L", BUGSdecl$sourceLineNumber) else ""
                 newNodeNameExpr <- as.name(paste0('lifted_', Rname2CppName(paramExpr, colonsOK = TRUE), uniquePiece))   ## create the name of the new node ##nameMashup
-                if(deparse(paramExpr[[1]]) %in% liftedCallsDoNotAddIndexing) {   ## skip adding indexing to mixed-size calls
+                if(safeDeparse(paramExpr[[1]], warn = TRUE) %in% liftedCallsDoNotAddIndexing) {   ## skip adding indexing to mixed-size calls
                     newNodeNameExprIndexed <- newNodeNameExpr
                 } else {
                     newNodeNameExprIndexed <- addNecessaryIndexingToNewNode(newNodeNameExpr, paramExpr, contexts[[BUGSdecl$contextID]]$indexVarExprs)  ## add indexing if necessary
@@ -1106,10 +1106,10 @@ isExprLiftable <- function(paramExpr, type = NULL) {
         if(is.vectorized(paramExpr))        return(FALSE)   ## don't lift any expression with vectorized indexing,  funName(x[1:10])
         return(TRUE)
     }
-    stop(paste0('isExprLiftable: NIMBLE cannot process this parameter expression: ', deparse(paramExpr)))
+    stop(paste0('isExprLiftable: NIMBLE cannot process this parameter expression: ', safeDeparse(paramExpr)))
 }
 addNecessaryIndexingToNewNode <- function(newNodeNameExpr, paramExpr, indexVarExprs) {
-    if(is.call(paramExpr) && deparse(paramExpr[[1]]) %in% names(liftedCallsGetIndexingFromArgumentNumbers))
+    if(is.call(paramExpr) && safeDeparse(paramExpr[[1]], warn = TRUE) %in% names(liftedCallsGetIndexingFromArgumentNumbers))
         return(addNecessaryIndexingFromArgumentNumbers(newNodeNameExpr, paramExpr, indexVarExprs))
     usedIndexVarsList <- indexVarExprs[indexVarExprs %in% all.vars(paramExpr)]    # this extracts any index variables which appear in 'paramExpr'
     vectorizedIndexExprsList <- extractAnyVectorizedIndexExprs(paramExpr)    # creates a list of any vectorized (:) indexing expressions appearing in 'paramExpr'
@@ -1574,13 +1574,13 @@ convertSplitVertexNamesToEvalSafeNames <- function(origNames, ok = TRUE) {
         boolSplitByIndex <- rep(FALSE, length(parsedName)-2)
         for(i in 3:length(parsedName)) {
             if(!is.name(parsedName[[i]])) {
-                if(deparse(parsedName[[i]][[1]]) == '%.s%') {
+                if(safeDeparse(parsedName[[i]][[1]], warn = TRUE) == '%.s%') {
                     parsedName[[i]][[1]] <- quote(`:`)
                     boolSplitByIndex[i-2] <- TRUE
                 }
             }
         }
-        deparse(parsedName)
+        safeDeparse(parsedName, warn = TRUE)
     }
     origNames[boolConvert] <- unlist(lapply(origNames[boolConvert], convertOneName))
     origNames
@@ -1903,7 +1903,7 @@ modelDefClass$methods(findDynamicIndexParticipants = function() {
                 ## That being said, compiled execution will error out with appropriate out of bounds error
                 ## because C++ will put an out-of-bound value in for 'k' in k[d[0]] or k[d[1342134]].
                 if(any(dynamicIndexes)) {
-                    indexedVar <- stripUnknownIndexFromVarName(deparse(symbolicParent[[2]]))
+                    indexedVar <- stripUnknownIndexFromVarName(safeDeparse(symbolicParent[[2]], warn = TRUE))
                     numSPNR <- length(declInfo[[iDI]]$symbolicParentNodesReplaced)
                     for(iIndex in which(dynamicIndexes)) {
                         declInfo[[iDI]]$dynamicIndexInfo[[length(declInfo[[iDI]]$dynamicIndexInfo) + 1]] <<-
@@ -2009,7 +2009,7 @@ modelDefClass$methods(genExpandedNodeAndParentNames3 = function(debug = FALSE) {
         if(BUGSdecl$type != "unknownIndex" && !all(usedIndexes) && !length(grep("^lifted", BUGSdecl$targetExpr)))
             warning(paste0("Multiple definitions for the same node. Did you forget indexing with '",
                           paste(contexts[[BUGSdecl$contextID]]$indexVarNames[!usedIndexes], collapse = ','),  
-                           "' on the left-hand side of '", deparse(BUGSdecl$code), "'?"))
+                           "' on the left-hand side of '", safeDeparse(BUGSdecl$code), "'?"))
         if(nDim > 0) {  ## pieces is a list of index text to construct node names, e.g. list("1", c("1:2", "1:3", "1:4"), c("3", "4", "5"))
             pieces <- vector('list', nDim)
             for(i in 1:nDim) {
@@ -2154,7 +2154,7 @@ modelDefClass$methods(genExpandedNodeAndParentNames3 = function(debug = FALSE) {
             if(rhsVar %in% unknownIndexNames) next ## vertex splitting occurs on lifted unknownIndex declaration, not on unknownIndex usage on RHS
             nDim <- varInfo[[rhsVar]]$nDim
             if(nDim != length(BUGSdecl$parentIndexNamePieces[[iV]]))  # this check should be redundant with equivalent check in genVarInfo3
-               stop("Dimension of ", rhsVar, " is ", nDim, ", which does not match its usage in '", deparse(BUGSdecl$code), "'.")
+               stop("Dimension of ", rhsVar, " is ", nDim, ", which does not match its usage in '", safeDeparse(BUGSdecl$code), "'.")
             if(nDim > 0) { ## Make the split.  This function is complicated.
                 splitAns <- splitVertices(vars_2_vertexOrigID[[rhsVar]], BUGSdecl$unrolledIndicesMatrix,
                                           contexts[[BUGSdecl$contextID]]$indexVarExprs, contexts[[BUGSdecl$contextID]]$indexVarNames,
@@ -2507,7 +2507,7 @@ modelDefClass$methods(genExpandedNodeAndParentNames3 = function(debug = FALSE) {
             if(BUGSdecl$numUnrolledNodes == 1) ## a singleton declaration
                 graphID_2_unrolledIndicesMatrixRow[BUGSdecl$graphIDs] <- 0
             else
-                stop(paste('confused assigning unrolledIndicesMatrixRow in case with no unrolledRows by numUnrolledNodes != 1 for code', deparse(BUGSdecl$code)))
+                stop(paste('confused assigning unrolledIndicesMatrixRow in case with no unrolledRows by numUnrolledNodes != 1 for code', safeDeparse(BUGSdecl$code)))
         } else {
             theseGraphIDs <- BUGSdecl$graphIDs
             graphID_2_unrolledIndicesMatrixRow[theseGraphIDs] <- 1:length(theseGraphIDs)
@@ -2616,11 +2616,11 @@ modelDefClass$methods(genVarInfo3 = function() {
                                                        anyDynamicallyIndexed = FALSE)
             }
             if(varInfo[[rhsVar]]$nDim != length(BUGSdecl$parentIndexNamePieces[[iV]]))
-                stop("Dimension of ", rhsVar, " is ", varInfo[[rhsVar]]$nDim, ", which does not match its usage in '", deparse(BUGSdecl$code), "'.")
+                stop("Dimension of ", rhsVar, " is ", varInfo[[rhsVar]]$nDim, ", which does not match its usage in '", safeDeparse(BUGSdecl$code), "'.")
             if(varInfo[[rhsVar]]$nDim > 0) {
                 for(iDim in 1:varInfo[[rhsVar]]$nDim) {
                     indexNamePieces <- BUGSdecl$parentIndexNamePieces[[iV]][[iDim]]
-                    if(is.null(indexNamePieces)) stop(paste0('There is a problem with some indexing in this line: ', deparse(BUGSdecl$codeReplaced), '.\nOne way this can happen is if you wanted to provide a vector of indices but did not include it in constants.'))
+                    if(is.null(indexNamePieces)) stop(paste0('There is a problem with some indexing in this line: ', safeDeparse(BUGSdecl$codeReplaced), '.\nOne way this can happen is if you wanted to provide a vector of indices but did not include it in constants.'))
                     if(is.list(indexNamePieces)) { ## a list would be made if there is a ':' operator in the index expression
                         indsLow <- if(is.numeric(indexNamePieces[[1]])) indexNamePieces[[1]] else BUGSdecl$replacementsEnv[[ indexNamePieces[[1]] ]]
                         indsHigh <- if(is.numeric(indexNamePieces[[2]])) indexNamePieces[[2]] else BUGSdecl$replacementsEnv[[ indexNamePieces[[2]] ]]
@@ -2686,7 +2686,7 @@ modelDefClass$methods(addUnknownIndexVars = function(debug = FALSE) {
             if(!(lhsVar %in% names(varInfo))) {
                 if(length(BUGSdecl$rhsVars) > 1)
                     stop("addUnknownIndexVars: more than one right-hand side variable in unknownIndex declaration: ",
-                         deparse(BUGSdecl$code))
+                         safeDeparse(BUGSdecl$code))
                 varInfo[[lhsVar]] <<- varInfo[[BUGSdecl$rhsVars]]$copy()
                 varInfo[[lhsVar]]$varName <<- lhsVar
                 varInfo[[lhsVar]]$anyStoch <<- FALSE
@@ -2770,9 +2770,9 @@ modelDefClass$methods(warnRHSonlyDynIdx = function() {
                 return(
                     unlist(lapply(seq_along(parentNodes), function(node) {
                         sapply(seq_len(nr), function(row) {
-                            deparse(eval(substitute(substitute(e, 
+                            safeDeparse(eval(substitute(substitute(e, 
                                                                as.list(decl$unrolledIndicesMatrix[row, ])),
-                                                    list(e = parentNodes[[node]]))))
+                                                    list(e = parentNodes[[node]]))), warn = TRUE)
                         })
                     })))
             })
@@ -2903,8 +2903,8 @@ modelDefClass$methods(printDI = function() {
     for(i in seq_along(declInfo)) {
         BUGSdecl <- declInfo[[i]]
         cat(paste0('[[', i, ']]  '))
-        lapply(contexts[[BUGSdecl$contextID]]$singleContexts, function(x) cat(paste0('for(', x$indexVarExpr, ' in ', deparse(x$indexRangeExpr), ') {{{   ')))
-        cat(paste0(deparse(BUGSdecl$code)))
+        lapply(contexts[[BUGSdecl$contextID]]$singleContexts, function(x) cat(paste0('for(', x$indexVarExpr, ' in ', safeDeparse(x$indexRangeExpr, warn = TRUE), ') {{{   ')))
+        cat(paste0(safeDeparse(BUGSdecl$code, warn = TRUE)))
         cat(paste0(rep('   }}}', length(contexts[[BUGSdecl$contextID]]$singleContexts)), collapse=''))
         cat('\n')
     }
@@ -2982,7 +2982,7 @@ handleOutOfBounds <- function(x, env) {
     ## Extend dimension of variable to match any greater extents indicated in 'x'.
     expr <- parse(text = x, keep.source = FALSE)[[1]]
     if(length(expr) == 1) return(NA)  ## However, should never have non-indexed expression given only invoked when subscript out of bounds
-    var <- deparse(expr[[2]])
+    var <- safeDeparse(expr[[2]], warn = TRUE)
     oldDims <- dim(env[[var]])
     newDims <- sapply(expr[3:length(expr)], function(e) {
         if(length(e) == 1) return(e)

--- a/packages/nimble/R/BUGS_readBUGS.R
+++ b/packages/nimble/R/BUGS_readBUGS.R
@@ -78,7 +78,7 @@ nimbleModel <- function(code,
                         name = NULL,
                         userEnv = parent.frame()) {
     returnModel <- !returnDef
-    if(is.null(name)) name <- paste0(gsub(" ", "_", substr(deparse(substitute(code))[1], 1, 10)),
+    if(is.null(name)) name <- paste0(gsub(" ", "_", substr(safeDeparse(substitute(code), warn = TRUE)[1], 1, 10)),
                                      '_',
                                      nimbleModelID())
     name <- gsub("::", "_cc_", name) ## :: can arise from a call via do.call, for example, giving name with "base::quote_"...
@@ -300,7 +300,7 @@ readBUGSmodel <- function(model, data = NULL, inits = NULL, dir = NULL, useInits
 
   modelFileOutput <- modelName <- NULL
   if(is.function(model) || is.character(model)) {
-      if(is.function(model)) modelText <- mergeMultiLineStatements(deparse(body(model)))
+      if(is.function(model)) modelText <- mergeMultiLineStatements(safeDeparse(body(model), warn = TRUE))
       if(is.character(model)) {
           if(skip.file.path) modelFile <- model
           else modelFile <- normalizePath(file.path(dir, model), winslash = "\\", mustWork=FALSE)  # check for "" avoids having "/model.bug" when user provides ""

--- a/packages/nimble/R/BUGS_readBUGS.R
+++ b/packages/nimble/R/BUGS_readBUGS.R
@@ -78,7 +78,7 @@ nimbleModel <- function(code,
                         name = NULL,
                         userEnv = parent.frame()) {
     returnModel <- !returnDef
-    if(is.null(name)) name <- paste0(gsub(" ", "_", substr(safeDeparse(substitute(code), warn = TRUE)[1], 1, 10)),
+    if(is.null(name)) name <- paste0(gsub(" ", "_", substr(deparse(substitute(code))[1], 1, 10)),
                                      '_',
                                      nimbleModelID())
     name <- gsub("::", "_cc_", name) ## :: can arise from a call via do.call, for example, giving name with "base::quote_"...
@@ -300,7 +300,7 @@ readBUGSmodel <- function(model, data = NULL, inits = NULL, dir = NULL, useInits
 
   modelFileOutput <- modelName <- NULL
   if(is.function(model) || is.character(model)) {
-      if(is.function(model)) modelText <- mergeMultiLineStatements(safeDeparse(body(model), warn = TRUE))
+      if(is.function(model)) modelText <- mergeMultiLineStatements(deparse(body(model)))
       if(is.character(model)) {
           if(skip.file.path) modelFile <- model
           else modelFile <- normalizePath(file.path(dir, model), winslash = "\\", mustWork=FALSE)  # check for "" avoids having "/model.bug" when user provides ""

--- a/packages/nimble/R/BUGS_utils.R
+++ b/packages/nimble/R/BUGS_utils.R
@@ -47,24 +47,24 @@ determineNodeIndexSizes <- function(node) {
 
 makeSizeAndDimList <- function(code, nodesToExtract, unrolledIndicesMatrix = NULL, allSizeAndDimList = list(), checkRagged = FALSE){
   if(is.call(code)){
-    if(deparse(code[[1]]) == '[') {
-      if(deparse(code[[2]]) %in% nodesToExtract){
+    if(safeDeparse(code[[1]], warn = TRUE) == '[') {
+      if(safeDeparse(code[[2]], warn = TRUE) %in% nodesToExtract){
         thisCodeExprList <- list()
         numInds <- length(code) - 2
         codeLength <- c()
         for(i in 1:numInds){
-          if(is.call(code[[i+2]]) && deparse(code[[i+2]][[1]]) == ':'){
+          if(is.call(code[[i+2]]) && safeDeparse(code[[i+2]][[1]], warn = TRUE) == ':'){
             if(is.numeric(code[[i+2]][[2]])){
               codeStartInds <- code[[i+2]][[2]]
             }
             else{
-              codeStartInds <- unrolledIndicesMatrix[, deparse(code[[i+2]][[2]])]
+              codeStartInds <- unrolledIndicesMatrix[, safeDeparse(code[[i+2]][[2]], warn = TRUE)]
             }
             if(is.numeric(code[[i+2]][[3]])){
               codeEndInds <- code[[i+2]][[3]]
             }
             else{
-              codeEndInds <- unrolledIndicesMatrix[, deparse(code[[i+2]][[3]])]
+              codeEndInds <- unrolledIndicesMatrix[, safeDeparse(code[[i+2]][[3]], warn = TRUE)]
             }
             thisCodeLength <- codeEndInds - codeStartInds + 1
             if(checkRagged && !all(thisCodeLength == thisCodeLength[1])){
@@ -78,8 +78,8 @@ makeSizeAndDimList <- function(code, nodesToExtract, unrolledIndicesMatrix = NUL
         }
         thisCodeExprList$lengths <- codeLength
         thisCodeExprList$nDim <- sum(codeLength > 1)
-        if(is.null(allSizeAndDimList[[deparse(code[[2]])]])) allSizeAndDimList[[deparse(code[[2]])]][[1]] <- thisCodeExprList
-        else allSizeAndDimList[[deparse(code[[2]])]][[length(allSizeAndDimList[[deparse(code[[2]])]]) + 1]] <- thisCodeExprList
+        if(is.null(allSizeAndDimList[[safeDeparse(code[[2]], warn = TRUE)]])) allSizeAndDimList[[safeDeparse(code[[2]], warn = TRUE)]][[1]] <- thisCodeExprList
+        else allSizeAndDimList[[safeDeparse(code[[2]], warn = TRUE)]][[length(allSizeAndDimList[[safeDeparse(code[[2]], warn = TRUE)]]) + 1]] <- thisCodeExprList
         return(allSizeAndDimList)
       }
     }
@@ -186,7 +186,7 @@ exprAsListDrop2 <- function(expr) {
     if(is.null(ans)) as.list(expr[-c(1,2)]) else ans
 }
 
-getCallText <- function(code)      deparse(code[[1]])
+getCallText <- function(code)      safeDeparse(code[[1]], warn = TRUE)
 
 parseTreeSubstitute <- function(pt, pattern, replacement) {
     if(identical(pt, pattern))    return(replacement)
@@ -217,7 +217,7 @@ Rname2CppName <- function(rName, colonsOK = TRUE, maxLength = 250) {
     ## This will serve to replace and combine our former Rname2CppName and nameMashupFromExpr
     ## which were largely redundant
     if (!is.character(rName)) 
-        rName <- deparse(rName)
+        rName <- safeDeparse(rName)
 
     if( colonsOK) {
         # Substitute single colons but preserve double colons.

--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -1207,7 +1207,7 @@ cc_expandDetermNodesInExpr <- function(model, expr, targetNode = NULL, skipExpan
     }
     if(is.call(expr)) {
         if(any(sapply(expr[-1], function(x) x=='')))
-            stop('Found missing indexing in ', safeDeparse(expr, maxlen = 1), ' that prevents conjugacy processing for this particular model structure.')
+            stop('Found missing indexing in ', safeDeparse(expr), ' that prevents conjugacy processing for this particular model structure.')
         for(i in seq_along(expr)[-1])
             expr[[i]] <- cc_expandDetermNodesInExpr(model, expr[[i]], targetNode, skipExpansionsNode)
         return(expr)

--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -1207,7 +1207,7 @@ cc_expandDetermNodesInExpr <- function(model, expr, targetNode = NULL, skipExpan
     }
     if(is.call(expr)) {
         if(any(sapply(expr[-1], function(x) x=='')))
-            stop('Found missing indexing in ', deparse(expr), ' that prevents conjugacy processing for this particular model structure.')
+            stop('Found missing indexing in ', deparse(expr, maxlen = 1), ' that prevents conjugacy processing for this particular model structure.')
         for(i in seq_along(expr)[-1])
             expr[[i]] <- cc_expandDetermNodesInExpr(model, expr[[i]], targetNode, skipExpansionsNode)
         return(expr)

--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -1150,7 +1150,7 @@ cc_expandDetermNodesInExpr <- function(model, expr, targetNode = NULL, skipExpan
                 numericOrVectorIndices <- sapply(indexExprs,
                       function(x) is.numeric(x) || (length(x) == 3 && x[[1]] == ':'))
                 if(!all(numericOrVectorIndices)) {
-                    if(model$getVarNames(nodes = targetNode) == model$getVarNames(nodes = deparse(expr))) {
+                    if(model$getVarNames(nodes = targetNode) == model$getVarNames(nodes = safeDeparse(expr, warn = TRUE))) {
                         ## expr var is same as target var, so plug in target indexes for
                         ## non-constant expr indexes to allow for possibility that
                         ## dynamic index will be that of target (in some cases based on allowed
@@ -1168,7 +1168,7 @@ cc_expandDetermNodesInExpr <- function(model, expr, targetNode = NULL, skipExpan
                     } else {
                         ## in this case the expr var is a different var, so shouldn't really matter what
                         ## indexes get plugged in; plug in mins of indexes as a default
-                        varInfo <- model$modelDef$varInfo[[deparse(expr[[2]])]]
+                        varInfo <- model$modelDef$varInfo[[safeDeparse(expr[[2]], warn = TRUE)]]
                         expr[which(!numericOrVectorIndices)+2] <- varInfo$mins[!numericOrVectorIndices]
                         ## sapply business gets rid of () at end of index expression
                         newExpr <- as.call(c(cc_structureExprName, expr, sapply(indexExprs[!numericOrVectorIndices], function(x) x)))
@@ -1179,7 +1179,7 @@ cc_expandDetermNodesInExpr <- function(model, expr, targetNode = NULL, skipExpan
                 }  ## else continue with processing as in non-dynamic index case
             }
         }
-        exprText <- deparse(expr)
+        exprText <- safeDeparse(expr, warn = TRUE)
         expandedNodeNamesRaw <- model$expandNodeNames(exprText)
         if(!is.null(skipExpansionsNode) && (exprText %in% model$expandNodeNames(skipExpansionsNode, returnScalarComponents=TRUE))) return(expr)
         ## if exprText is a node itself (and also part of a larger node), then we only want the expansion to be the exprText node:
@@ -1207,12 +1207,12 @@ cc_expandDetermNodesInExpr <- function(model, expr, targetNode = NULL, skipExpan
     }
     if(is.call(expr)) {
         if(any(sapply(expr[-1], function(x) x=='')))
-            stop('Found missing indexing in ', deparse(expr, maxlen = 1), ' that prevents conjugacy processing for this particular model structure.')
+            stop('Found missing indexing in ', safeDeparse(expr, maxlen = 1), ' that prevents conjugacy processing for this particular model structure.')
         for(i in seq_along(expr)[-1])
             expr[[i]] <- cc_expandDetermNodesInExpr(model, expr[[i]], targetNode, skipExpansionsNode)
         return(expr)
     }
-    stop(paste0('something went wrong processing: ', deparse(expr)))
+    stop(paste0('something went wrong processing: ', safeDeparse(expr)))
 }
 
 
@@ -1257,7 +1257,7 @@ cc_checkScalar <- function(expr) {
     ## We don't know the output dims of all functions,
     ## as there can be user-defined functions that produce non-scalar output from scalar inputs,
     ## so only say it could be scalar (based on input args) in specific known cases we enumerate.
-    if(deparse(expr[[1]]) %in% c('(','[','*','+','-','/','exp','log','^','pow','sqrt')) {
+    if(safeDeparse(expr[[1]], warn = TRUE) %in% c('(','[','*','+','-','/','exp','log','^','pow','sqrt')) {
         return(all(sapply(expr[2:length(expr)], cc_checkScalar)))
     } else return(FALSE)
 }
@@ -1325,9 +1325,9 @@ cc_nodeInExpr <- function(node, expr) { return(node %in% cc_getNodesInExpr(expr)
 cc_getNodesInExpr <- function(expr) {
     if(is.numeric(expr)) return(character(0))   ## expr is numeric
     if(is.logical(expr)) return(character(0))   ## expr is logical
-    if(is.name(expr) || (is.call(expr) && (expr[[1]] == '[') && is.name(expr[[2]]))) return(deparse(expr))   ## expr is a node name
+    if(is.name(expr) || (is.call(expr) && (expr[[1]] == '[') && is.name(expr[[2]]))) return(safeDeparse(expr, warn = TRUE))   ## expr is a node name
     if(is.call(expr)) return(unlist(lapply(expr[-1], cc_getNodesInExpr)))   ## expr is some general call
-    stop(paste0('something went wrong processing: ', deparse(expr)))
+    stop(paste0('something went wrong processing: ', safeDeparse(expr)))
 }
 
 ## if targetNode is vectorized: determines if any components of targetNode appear in expr
@@ -1355,7 +1355,7 @@ cc_checkLinearity <- function(expr, targetNode) {
     }
 
     ## expr is exactly the targetNode
-    if(identical(targetNode, deparse(expr)))
+    if(identical(targetNode, safeDeparse(expr, warn = TRUE)))
         return(list(offset = 0, scale = 1))
 
     if(!is.call(expr))   stop('cc_checkLinearity: expression is not a call object')

--- a/packages/nimble/R/MCMC_utils.R
+++ b/packages/nimble/R/MCMC_utils.R
@@ -279,7 +279,7 @@ mcmc_listContentsToStr <- function(ls, displayControlDefaults=FALSE, displayNonS
                 if(length(controlValue) > 1)
                     controlValue <- ifelse(is.null(dim(controlValue)), 'custom vector', 'custom array')
         if(inherits(controlValue, 'samplerConf'))   controlValue <- controlValue$name
-        deparsedItem <- deparse(controlValue)
+        deparsedItem <- safeDeparse(controlValue, warn = TRUE)
         if(length(deparsedItem) > 1) deparsedItem <- paste0(deparsedItem, collapse='')
         ls2[[i]] <- paste0(controlName, ': ', deparsedItem)
     }

--- a/packages/nimble/R/all_utils.R
+++ b/packages/nimble/R/all_utils.R
@@ -135,11 +135,12 @@ getsize <- function(container) {
 
 # simply adds width.cutoff = 500 as the default to deal with creation of long variable names from expressions
 deparse <- function(...) {
-    if("width.cutoff" %in% names(list(...))) {
-        base::deparse(..., control = "digits17", nlines = 1)
-    } else {
-        base::deparse(..., width.cutoff = 500L, control = "digits17", nlines = 1)
-    }
+    dotArgs <- list(...)
+    if(!"width.cutoff" %in% names(dotArgs))
+        dotArgs$nlines <- 1
+    if(!"nlines" %in% names(dotArgs))
+        dotArgs$width.cutoff <- 500L
+    base::deparse(..., control = "digits17")
 }
 
 

--- a/packages/nimble/R/all_utils.R
+++ b/packages/nimble/R/all_utils.R
@@ -160,20 +160,6 @@ safeDeparse <- function(..., warn = FALSE) {
     return(out)
 }
 
-## This version of deparse avoids splitting into multiple lines, which generally would lead to
-## problems. We keep the original nimble:::deparse above as deparse is widely used and there
-## are cases where not modifying the nlines behavior may be best. 
-## safeDeparse <- function(expr, width.cutoff = 500L, nlines = 1L, control = "digits17", warn = FALSE, ...) {
-##     out <- base::deparse(expr, width.cutoff = width.cutoff, control = control, ...)
-##     if(nlines != -1L && length(out) > nlines) {
-##         if(warn)
-##             warning("safeDeparse: truncating deparse output to ", nlines, " lines.")
-##         out <- out[1:nlines]
-##     }
-##     return(out)
-## }
-
-
 
 ## creates objects in the parent.frame(), named by names(lst), values are eval(lst[[i]])
 ## this is used for creating the conjugate sampler nimble function generators, among other things

--- a/packages/nimble/R/all_utils.R
+++ b/packages/nimble/R/all_utils.R
@@ -145,15 +145,33 @@ deparse <- function(...) {
 ## This version of deparse avoids splitting into multiple lines, which generally would lead to
 ## problems. We keep the original nimble:::deparse above as deparse is widely used and there
 ## are cases where not modifying the nlines behavior may be best. 
-safeDeparse <- function(expr, width.cutoff = 500L, nlines = 1L, control = "digits17", warn = FALSE, ...) {
-    out <- base::deparse(expr, width.cutoff = width.cutoff, control = control, ...)
-    if(nlines != -1L && length(out) > nlines) {
-        if(warn)
-            warning("safeDeparse: truncating deparse output to ", nlines, " lines.")
-        out <- out[1:nlines]
+safeDeparse <- function(...) {
+    out <- deparse(...)
+    if(nimbleOptions('useSafeDeparse')) {
+        dotArgs <- list(...)
+        if("nlines" %in% names(dotArgs))
+            nlines <- dotArgs$nlines else nlines <- 1L
+        if(nlines != -1L && length(out) > nlines) {
+            if("warn" %in% names(dotArgs) && dotArgs$warn)
+                warning("safeDeparse: truncating deparse output to ", nlines, " lines.")
+            out <- out[1:nlines]
+        }
     }
     return(out)
 }
+
+## This version of deparse avoids splitting into multiple lines, which generally would lead to
+## problems. We keep the original nimble:::deparse above as deparse is widely used and there
+## are cases where not modifying the nlines behavior may be best. 
+## safeDeparse <- function(expr, width.cutoff = 500L, nlines = 1L, control = "digits17", warn = FALSE, ...) {
+##     out <- base::deparse(expr, width.cutoff = width.cutoff, control = control, ...)
+##     if(nlines != -1L && length(out) > nlines) {
+##         if(warn)
+##             warning("safeDeparse: truncating deparse output to ", nlines, " lines.")
+##         out <- out[1:nlines]
+##     }
+##     return(out)
+## }
 
 
 

--- a/packages/nimble/R/all_utils.R
+++ b/packages/nimble/R/all_utils.R
@@ -136,9 +136,9 @@ getsize <- function(container) {
 # simply adds width.cutoff = 500 as the default to deal with creation of long variable names from expressions
 deparse <- function(...) {
     if("width.cutoff" %in% names(list(...))) {
-        base::deparse(..., control = "digits17")
+        base::deparse(..., control = "digits17", nlines = 1)
     } else {
-        base::deparse(..., width.cutoff = 500L, control = "digits17")
+        base::deparse(..., width.cutoff = 500L, control = "digits17", nlines = 1)
     }
 }
 

--- a/packages/nimble/R/all_utils.R
+++ b/packages/nimble/R/all_utils.R
@@ -135,13 +135,26 @@ getsize <- function(container) {
 
 # simply adds width.cutoff = 500 as the default to deal with creation of long variable names from expressions
 deparse <- function(...) {
-    dotArgs <- list(...)
-    if(!"width.cutoff" %in% names(dotArgs))
-        dotArgs$nlines <- 1
-    if(!"nlines" %in% names(dotArgs))
-        dotArgs$width.cutoff <- 500L
-    base::deparse(..., control = "digits17")
+    if("width.cutoff" %in% names(list(...))) {
+        base::deparse(..., control = "digits17")
+    } else {
+        base::deparse(..., width.cutoff = 500L, control = "digits17")
+    }
 }
+
+## This version of deparse avoids splitting into multiple lines, which generally would lead to
+## problems. We keep the original nimble:::deparse above as deparse is widely used and there
+## are cases where not modifying the nlines behavior may be best. 
+safeDeparse <- function(expr, width.cutoff = 500L, nlines = 1L, control = "digits17", warn = FALSE, ...) {
+    out <- base::deparse(expr, width.cutoff = width.cutoff, control = control, ...)
+    if(nlines != -1L && length(out) > nlines) {
+        if(warn)
+            warning("safeDeparse: truncating deparse output to ", nlines, " lines.")
+        out <- out[1:nlines]
+    }
+    return(out)
+}
+
 
 
 ## creates objects in the parent.frame(), named by names(lst), values are eval(lst[[i]])

--- a/packages/nimble/R/all_utils.R
+++ b/packages/nimble/R/all_utils.R
@@ -145,14 +145,14 @@ deparse <- function(...) {
 ## This version of deparse avoids splitting into multiple lines, which generally would lead to
 ## problems. We keep the original nimble:::deparse above as deparse is widely used and there
 ## are cases where not modifying the nlines behavior may be best. 
-safeDeparse <- function(...) {
+safeDeparse <- function(..., warn = FALSE) {
     out <- deparse(...)
     if(nimbleOptions('useSafeDeparse')) {
         dotArgs <- list(...)
         if("nlines" %in% names(dotArgs))
             nlines <- dotArgs$nlines else nlines <- 1L
         if(nlines != -1L && length(out) > nlines) {
-            if("warn" %in% names(dotArgs) && dotArgs$warn)
+            if(warn)
                 warning("safeDeparse: truncating deparse output to ", nlines, " lines.")
             out <- out[1:nlines]
         }

--- a/packages/nimble/R/nimbleFunction_nodeFunction.R
+++ b/packages/nimble/R/nimbleFunction_nodeFunction.R
@@ -24,7 +24,7 @@ ndf_createDetermSimulate <- function(LHS, RHS, dynamicIndexLimitsExpr, RHSnonRep
                                 RHS = RHS,
                                 NANEXPR = nanExpr,
                                 CONDITION = dynamicIndexLimitsExpr,
-                                TEXT = paste0("  [Warning] Dynamic index out of bounds: ", deparse(RHSnonReplaced))))
+                                TEXT = paste0("  [Warning] Dynamic index out of bounds: ", safeDeparse(RHSnonReplaced))))
     } else code <- substitute(LHS <<- RHS,
                               list(LHS = LHS,
                                    RHS = RHS))
@@ -53,7 +53,7 @@ ndf_createStochSimulate <- function(LHS, RHS, dynamicIndexLimitsExpr, RHSnonRepl
                                 RHS = RHS,
                                 NANEXPR = nanExpr,
                                 CONDITION = dynamicIndexLimitsExpr,
-                                TEXT = paste0("  [Warning] Dynamic index out of bounds: ", deparse(RHSnonReplaced))))
+                                TEXT = paste0("  [Warning] Dynamic index out of bounds: ", safeDeparse(RHSnonReplaced))))
     } else {
         code <- substitute(LHS <<- RHS,
                            list(LHS = LHS,
@@ -147,7 +147,7 @@ ndf_createStochCalculate <- function(logProbNodeExpr, LHS, RHS, diff = FALSE, AD
                                        print(TEXT)}, # LocalNewLogProb <- -Inf,
                                    list(STOCHCALC = RHS,
                                         CONDITION = dynamicIndexLimitsExpr,
-                                        TEXT = paste0("  [Warning] Dynamic index out of bounds: ", deparse(RHSnonReplaced))))
+                                        TEXT = paste0("  [Warning] Dynamic index out of bounds: ", safeDeparse(RHSnonReplaced))))
             } else if(ADFunc){  ## don't want global assignment for _AD_ functions.
                 code <- substitute(if(isTRUE(CONDITION)) LOGPROB <- STOCHCALC
                                    else {LOGPROB <- NaN
@@ -155,7 +155,7 @@ ndf_createStochCalculate <- function(logProbNodeExpr, LHS, RHS, diff = FALSE, AD
                                    list(LOGPROB = logProbNodeExpr,
                                         STOCHCALC = RHS,
                                         CONDITION = dynamicIndexLimitsExpr,
-                                        TEXT = paste0("  [Warning] Dynamic index out of bounds: ", deparse(RHSnonReplaced))))
+                                        TEXT = paste0("  [Warning] Dynamic index out of bounds: ", safeDeparse(RHSnonReplaced))))
             } else {
 
                 code <- substitute(if(isTRUE(CONDITION)) LOGPROB <<- STOCHCALC
@@ -164,7 +164,7 @@ ndf_createStochCalculate <- function(logProbNodeExpr, LHS, RHS, diff = FALSE, AD
                                    list(LOGPROB = logProbNodeExpr,
                                         STOCHCALC = RHS,
                                         CONDITION = dynamicIndexLimitsExpr,
-                                        TEXT = paste0("  [Warning] Dynamic index out of bounds: ", deparse(RHSnonReplaced))))
+                                        TEXT = paste0("  [Warning] Dynamic index out of bounds: ", safeDeparse(RHSnonReplaced))))
             }
         } else {
             if(diff) {
@@ -234,7 +234,7 @@ ndf_createStochCalculateTrunc <- function(logProbNodeExpr, LHS, RHS, diff = FALS
                                        print(TEXT)}, # LocalNewLogProb <- -Inf,
                                    list(STOCHCALC = RHS,
                                         CONDITION = dynamicIndexLimitsExpr,
-                                        TEXT = paste0("  [Warning] Dynamic index out of bounds: ", deparse(RHSnonReplaced))))
+                                        TEXT = paste0("  [Warning] Dynamic index out of bounds: ", safeDeparse(RHSnonReplaced))))
 
     
     if(nimbleOptions()$allowDynamicIndexing && !is.null(dynamicIndexLimitsExpr)) {
@@ -268,7 +268,7 @@ ndf_createStochCalculateTrunc <- function(logProbNodeExpr, LHS, RHS, diff = FALS
                                                    PDIST_UPPER = PDIST_UPPER,
                                                    DDIST_LOWER = DDIST_LOWER,
                                                    CONDITION = dynamicIndexLimitsExpr,
-                                                   TEXT = paste0("  [Warning] Dynamic index out of bounds: ", deparse(RHSnonReplaced))
+                                                   TEXT = paste0("  [Warning] Dynamic index out of bounds: ", safeDeparse(RHSnonReplaced))
                                                )), list( e = substCode)))
         } else {
             if(discrete && lower != -Inf) {
@@ -301,7 +301,7 @@ ndf_createStochCalculateTrunc <- function(logProbNodeExpr, LHS, RHS, diff = FALS
                                                    PDIST_UPPER = PDIST_UPPER,
                                                    DDIST_LOWER = DDIST_LOWER,
                                                    CONDITION = dynamicIndexLimitsExpr,
-                                                   TEXT = paste0("  [Warning] Dynamic index out of bounds: ", deparse(RHSnonReplaced))
+                                                   TEXT = paste0("  [Warning] Dynamic index out of bounds: ", safeDeparse(RHSnonReplaced))
                                                )), list(e = substCode)))
         }
     } else {

--- a/packages/nimble/R/options.R
+++ b/packages/nimble/R/options.R
@@ -9,6 +9,7 @@ nimbleUserNamespace <- as.environment(list(sessionSpecificDll = NULL))
     list(
         groupDetermWithGivenInCondIndSets = TRUE, # used in getConditionallyIndependentSets
         use_C_getParents = FALSE,
+        useSafeDeparse = TRUE,
         useNewConfigureMCMC = TRUE,
         oldConjugacyChecking = FALSE,
         disallow_multivariate_argument_expressions = TRUE,


### PR DESCRIPTION
This fixes issue #1131 by using the `nlines` arg to `deparse`.

This replaces PR #1154 and PR #1133 . Not sure why I had two previous solutions or why I didn't simply use `nlines=1`.

More discussion of how we might robustify further in deparse and nimDeparse are in issue #1131 .