### PR TITLE
small changes to fix casting the RHS to match a LHS type for non-scalars

### DIFF
--- a/packages/nimble/R/genCpp_eigenization.R
+++ b/packages/nimble/R/genCpp_eigenization.R
@@ -479,6 +479,12 @@ eigenCast <- function(expr, argIndex, newType) {
 eigenize_assign_before_recurse <- function(code, symTab, typeEnv, workEnv) {
     setupExprs <- list()
     if(length(code$args) != 2) stop(exprClassProcessingErrorMsg(code, 'There is an assignment without 2 arguments.'), call. = FALSE)
+
+  #  if(code$nDim > 0) {
+      promoteArgTypes(code)
+  #    code$type <- code$args[[1]]$type
+  #  }
+
     workEnv$OnLHSnow <- TRUE
     setupExprs <- c(setupExprs, exprClasses_eigenize(code$args[[1]], symTab, typeEnv, workEnv))
     workEnv$OnLHSnow <- NULL ## allows workEnv[['OnLHSnow']] to be NULL if is does not exist or if set to NULL

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -1946,7 +1946,8 @@ sizeAssignAfterRecursing <- function(code, symTab, typeEnv, NoEigenizeMap = FALS
         ## should already be annotated if it is an indexed assignment.
         ## It should be harmless to re-annotated EXCEPT in case like out[1:5] <- scalar
         code$nDim <- code$args[[1]]$nDim <- RHSnDim
-        code$type <- code$args[[1]]$type <- RHStype
+        code$type <- RHStype
+        # code$type <- code$args[[1]]$type <- RHStype
         code$sizeExprs <- code$args[[1]]$sizeExprs <- RHSsizeExprs
     }
     if(RHSname %in% assignmentAsFirstArgFuns) {

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -1946,8 +1946,7 @@ sizeAssignAfterRecursing <- function(code, symTab, typeEnv, NoEigenizeMap = FALS
         ## should already be annotated if it is an indexed assignment.
         ## It should be harmless to re-annotated EXCEPT in case like out[1:5] <- scalar
         code$nDim <- code$args[[1]]$nDim <- RHSnDim
-        code$type <- RHStype
-        # code$type <- code$args[[1]]$type <- RHStype
+        code$type <- code$args[[1]]$type <- RHStype
         code$sizeExprs <- code$args[[1]]$sizeExprs <- RHSsizeExprs
     }
     if(RHSname %in% assignmentAsFirstArgFuns) {

--- a/packages/nimble/tests/testthat/test_utils.R
+++ b/packages/nimble/tests/testthat/test_utils.R
@@ -201,6 +201,8 @@ test_coreRfeature_batch_internal <- function(input_batch, verbose = nimbleOption
             dimOutR <- attr(out_nfR, 'dim')
             dimOutC <- attr(out_nfC, 'dim')
             attributes(out) <- attributes(out_nfR) <- attributes(out_nfC) <- NULL
+            if(!is.null(input[['storage.mode']]))
+                storage.mode(out) <- storage.mode(out_nfR) <- storage.mode(out_nfC) <- input[['storage.mode']]
             attr(out, 'dim') <- dimOut
             attr(out_nfR, 'dim') <- dimOutR
             attr(out_nfC, 'dim') <- dimOutC


### PR DESCRIPTION
Do not merge.  This potentially fixes #1129 but it also touches all non-scalar assignments so could easily kick up unintended consequences.  Let's see what testing shows.