### PR TITLE
Correct the manual URL in the Bookdown HTML.

### DIFF
--- a/UserManual/src/_output.yml
+++ b/UserManual/src/_output.yml
@@ -5,7 +5,7 @@ bookdown::gitbook:
       before: |
         <img src="./nimble-icon.png"
              width=100>
-        <li><a href="./">NIMBLE User Manual, Version 0.12.1</a></li>
+        <li><a href="./cha-welcome-nimble.html">NIMBLE User Manual, Version 0.12.1</a></li>
         <li><a href="https://github.com/nimble-dev/nimble">NIMBLE Development Team</a></li>
         <li><a href="https://R-nimble.org">https://R-nimble.org</a></li>
       after: |


### PR DESCRIPTION
In the HTML version of the Nimble User Manual there is a "Nimble User Manual, version 0.12.1" link at the top of the left-hand side-bar:

![image](https://user-images.githubusercontent.com/25675095/141855037-06b4d1e2-a8d6-4faa-b26b-a09d50447f3c.png)

The href for this links is `https://r-nimble.org/html_manual/`.
Following this link produces a "Forbidden" error message, possibly because I'm outside the host's network:  

![image](https://user-images.githubusercontent.com/25675095/141854860-39fe7220-6279-49b0-a8b6-e863c745e88c.png)

This pull request should correct the problem by changing the link to a specific page, rather than a directory.
It may be possible to fix the issue by changing the configuration of the web host or by including a `index.html` page instead.
