### PR TITLE
truncate names that are too long after adding "lifted_"

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -1048,7 +1048,9 @@ modelDefClass$methods(liftExpressionArgs = function() {
                 if(!isExprLiftable(paramExpr, types[[paramName]]))    next     ## if this param isn't an expression, go ahead to next parameter
                 requireNewAndUniqueDecl <- any(contexts[[BUGSdecl$contextID]]$indexVarNames %in% all.vars(paramExpr))
                 uniquePiece <- if(requireNewAndUniqueDecl) paste0("_L", BUGSdecl$sourceLineNumber) else ""
-                newNodeNameExpr <- as.name(paste0('lifted_', Rname2CppName(paramExpr, colonsOK = TRUE), uniquePiece))   ## create the name of the new node ##nameMashup
+                ## Pass through Rname2CppName twice so that long names truncated if adding 'lifted_' puts them over nchar limit
+                newNodeNameExpr <- as.name(paste0(Rname2CppName(paste0('lifted_',
+                                                  Rname2CppName(paramExpr, colonsOK = TRUE)), colonsOK = TRUE), uniquePiece))   ## create the name of the new node ##nameMashup
                 if(safeDeparse(paramExpr[[1]], warn = TRUE) %in% liftedCallsDoNotAddIndexing) {   ## skip adding indexing to mixed-size calls
                     newNodeNameExprIndexed <- newNodeNameExpr
                 } else {


### PR DESCRIPTION
We truncate node names that are very long by adding "___TRUNC___". However we were doing that before adding "lifted_" to the node name. The result was that if the name was not over the character limit before adding "lifted_", it would not be truncated. This was causing some naming inconsistencies such that there were compilation errors. This PR passes the name of the lifted node through `Rname2CppName` twice. The first time makes sure that special characters in  `paramExpr` are transformed. The second time does the truncation. It can't be done in one pass because one can't paste "lifted_" to `paramExpr` and get a result that can be properly handled by `Rname2CppName` .

Here's an example that fails without this change:

```
code <- nimbleCode({
    for(i in 1:3) {
        eta[i] ~ dnorm(0,1)
        alpha[i] ~ dnorm(0,1)
        gamma[i] ~ dnorm(0,1)
    }
    ## This is just long enough, but not too long, to trigger the bug.
    constraint ~ dconstraint( eta[1] > eta[2] & eta[2] < 3 & 
                              eta[2] > eta[3] & 
                              exp(alpha[2]+gamma[2]) > exp(alpha[1]+gamma[1]) &
                              exp(alpha[3]+gamma[3]) > exp(alpha[2]+gamma[2])
                             )
})

m <- nimbleModel(code)
cm <- compileNimble(m)
```