### PR TITLE
RJMCMC errors out for non-constant hyperparameters

### DIFF
--- a/packages/nimble/R/MCMC_RJ.R
+++ b/packages/nimble/R/MCMC_RJ.R
@@ -299,6 +299,8 @@ configureRJ <- function(conf, targetNodes, indicatorNodes = NULL, priorProb = NU
             nodeControl <- list(priorProb = priorProb[i], mean = mean[i],
                                 scale = scale[i], fixedValue = fixedValue[i])
             for(j in 1:length(nodeAsScalar)) {
+                ## RJ system does not support non-constant hyperparameters of target RJ nodes:
+                if(length(conf$model$getParents(nodeAsScalar[j], stochOnly = TRUE, includeData = FALSE)) > 0) stop('Reversible jump target node \"', nodeAsScalar[j], '\" appears to have a non-constant hyper-parameter, which is not currently supported for reversible jump MCMC.  Please contact the nimble development team at <nimble.stats@gmail.com> if support for this case would be helpful.')
                 currentConf <- conf$getSamplers(nodeAsScalar[j])
                 ## check on node configuration
                 if(length(currentConf) == 0) {
@@ -338,6 +340,8 @@ configureRJ <- function(conf, targetNodes, indicatorNodes = NULL, priorProb = NU
                 stop(paste0("configureRJ: indicatorNodes node '", indicatorNodes[i] ,"' does not match '", targetNodes[i], "' size."))
             nodeControl  = list(mean = mean[i], scale = scale[i])
             for(j in 1:length(nodeAsScalar)) {
+                ## RJ system does not support non-constant hyperparameters of target RJ nodes:
+                if(length(conf$model$getParents(nodeAsScalar[j], stochOnly = TRUE, includeData = FALSE)) > 0) stop('Reversible jump target node \"', nodeAsScalar[j], '\" appears to have a non-constant hyper-parameter, which is not currently supported for reversible jump MCMC.  Please contact the nimble development team at <nimble.stats@gmail.com> if support for this case would be helpful.')
                 nodeControl$targetNode <- nodeAsScalar[j]
                 currentConf <- conf$getSamplers(nodeAsScalar[j])
                 ## check on node configuration

--- a/packages/nimble/inst/NEWS
+++ b/packages/nimble/inst/NEWS
@@ -9,6 +9,9 @@ have terms of the form "a[i] + x[i] * beta" (or more simply "x[i] * beta" or
 provided via NIMBLE's constants argument and x[1] == 1 or (ii) 'a' provided
 via NIMBLE's constants argument and a[1] == 0 (PR #1172).
 
+-- Reversible jump MCMC system now detects non-constant hyperparameters
+of reversible jump target nodes, and will not operate on such nodes.
+
 DEVELOPER LEVEL CHANGES
 
 -- Use USE_FC_LEN_T-related syntax in F77 calls in dists.cpp per CRAN request

--- a/packages/nimble/tests/testthat/test-mcmcrj.R
+++ b/packages/nimble/tests/testthat/test-mcmcrj.R
@@ -488,3 +488,39 @@ test_that("Check passing node vector - indicator", {
   # }
   
 })
+
+
+test_that("Bails out for non-constant target node hyperparameters", {
+
+    code <- nimbleCode({
+        sigma ~ dunif(0, 100)
+        beta1 ~ dnorm(0, sd = 100)
+        beta2 ~ dnorm(0, sd = sigma)
+        sigma2 <- sigma^2
+        beta3 ~ dnorm(0, sd = sigma2)
+        z ~ dbern(0.5)
+        Ypred <- beta0 + beta1 * z * x1 + beta2 * z * x2 + beta3 * z * x3
+        Y ~ dnorm(Ypred, sd = sigma)
+    })
+
+    Rmodel <- nimbleModel(code)
+
+    conf <- configureMCMC(Rmodel)
+    expect_error(configureRJ(conf, targetNodes = 'beta1', indicatorNodes = 'z'), NA)
+
+    conf <- configureMCMC(Rmodel)
+    expect_error(configureRJ(conf, targetNodes = 'beta2', indicatorNodes = 'z'))
+
+    conf <- configureMCMC(Rmodel)
+    expect_error(configureRJ(conf, targetNodes = 'beta3', indicatorNodes = 'z'))
+
+    conf <- configureMCMC(Rmodel)
+    expect_error(configureRJ(conf, targetNodes = 'beta1', priorProb = 0.5, NA))
+
+    conf <- configureMCMC(Rmodel)
+    expect_error(configureRJ(conf, targetNodes = 'beta2', priorProb = 0.5))
+
+    conf <- configureMCMC(Rmodel)
+    expect_error(configureRJ(conf, targetNodes = 'beta3', priorProb = 0.5))
+
+})


### PR DESCRIPTION
`configureRJ` uses `model$getParents()` to find non-data stochastic parents of RJ target nodes.  In the event of finding any non-constant hyperparameters, `configureRJ` bails out, with the message:

"Reversible jump target node [node name] appears to have a non-constant hyper-parameter, which is not currently supported for reversible jump MCMC.  Please contact the nimble development team at nimble.stats@gmail.com if support for this case would be helpful."

Also added tests for these cases to `test-mcmcjr.r`.