### PR TITLE
fix MCMC sampling for 2x2 LKJ case

### DIFF
--- a/UserManual/src/tables/densityTableLong.md
+++ b/UserManual/src/tables/densityTableLong.md
@@ -27,7 +27,7 @@ is denoted by $x$.
   Half flat     `dhalfflat()`                               $\propto 1$ (improper)                                                                                                                                       $0$
   Inverse       `dinvgamma(shape = r, scale = ` $\lambda$`)`$\frac{ \lambda^r x^{-(r + 1)} \exp(-\lambda / x)}{ \Gamma(r)}$                                                                                              $0$
    gamma        $\lambda > 0$, $r > 0$
-  LKJ Correl'n  `dlkj_corr_cholesky(shape = ` $\eta$`,`    $\prod_{i=2}^{p} x_{kk}^{p - i + 2\eta -2}    
+  LKJ Correl'n  `dlkj_corr_cholesky(eta = ` $\eta$`,`    $\prod_{i=2}^{p} x_{kk}^{p - i + 2\eta -2}$    
    Cholesky     `size = p),` $\eta > 0$
   Logistic      `dlogis(location = ` $\mu$,                 $\frac{ \tau \exp\{(x - \mu) \tau\}}{\left[1 + \exp\{(x - \mu) \tau\}\right]^2}$
                 `rate = ` $\tau$`), `$\tau > 0$

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -327,7 +327,16 @@ print: A logical argument specifying whether to print the montiors and samplers.
                         if(nodeDist == 'ddirch')              { addSampler(target = node, type = 'RW_dirichlet');       next }
                         if(nodeDist == 'dwish')               { addSampler(target = node, type = 'RW_wishart');         next }
                         if(nodeDist == 'dinvwish')            { addSampler(target = node, type = 'RW_wishart');         next }
-                        if(nodeDist == 'dlkj_corr_cholesky')  { addSampler(target = node, type = 'RW_block_lkj_corr_cholesky');  next }
+                        if(nodeDist == 'dlkj_corr_cholesky')  {
+                            if(nodeLength >= 9) {
+                                addSampler(target = node, type = 'RW_block_lkj_corr_cholesky')
+                            } else {
+                                if(nodeLength == 4) {
+                                    addSampler(target = node, type = 'RW_lkj_corr_cholesky')  ## only a scalar free param in 2x2 case
+                                } else warning("Not assigning sampler to dlkj_corr_cholesky node for 1x1 case.")
+                            }
+                            next
+                        }
                         if(nodeDist == 'dcar_normal')         { addSampler(target = node, type = 'CAR_normal');         next }
                         if(nodeDist == 'dcar_proper')         { addSampler(target = node, type = 'CAR_proper');         next }
                         if(nodeDist == 'dCRP')                {

--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -1573,9 +1573,10 @@ sampler_RW_lkj_corr_cholesky <- nimbleFunction(
         if(scaleOriginal < 0)
             stop('Cannot use RW_lkj_corr_cholesky sampler with scale control parameter less than 0.')
         ## adaptation objects
+        if(nTheta == 1) nTheta <- 2
         scaleVec            <- rep(scaleOriginal, nTheta)
         timesRan            <- 0
-        timesAcceptedVec    <- rep(nTheta, 0)
+        timesAcceptedVec    <- rep(0, nTheta)
         timesAdapted        <- 0
         optimalAR           <- 0.44
         ##
@@ -1749,7 +1750,7 @@ sampler_RW_block_lkj_corr_cholesky <- nimbleFunction(
 
         dist <- model$getDistribution(target)
         if(dist != 'dlkj_corr_cholesky') stop('RW_block_lkj_corr_cholesky sampler can only be used with the dlkj_corr_cholesky distribution.')
-        if(d < 2)                        stop('RW_block_lkj_corr_cholesky sampler requires target node dimension to be at least 2x2.')
+        if(d < 3)                        stop('RW_block_lkj_corr_cholesky sampler requires target node dimension to be at least 3x3.')
         if(adaptFactorExponent < 0)      stop('Cannot use RW_block_lkj_corr_cholesky sampler with adaptFactorExponent control parameter less than 0.')
 
     },


### PR DESCRIPTION
This uses non-block `RW_lkj_corr_cholesky` for 2x2 case and fixes and error in that sampler to avoid having scalar values where vectors are expected (issue #1190 ).