### PR TITLE
fix handling of default by = 1 when not given in nimSeq

### DIFF
--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -2563,8 +2563,13 @@ sizeSeq <- function(code, symTab, typeEnv, recurse = TRUE) {
     integerTo <- isIntegerEquivalent(code$args[[2]])
     liftExprRanges <- TRUE
     if(integerFrom && integerTo) {
-        if((!byProvided && !lengthProvided) || (byProvided && !lengthProvided && is.numeric(code$args[[3]]) && code$args[[3]] == 1)) {
+        if((!byProvided && !lengthProvided) ||
+           (byProvided && !lengthProvided && is.numeric(code$args[[3]]) && code$args[[3]] == 1)) {
             code$name = ':'
+            if(length(code$args) > 2) {
+                for(i in length(code$args):3)
+                    setArg(code, i, NULL)
+            }
             asserts <- c(asserts, sizeColonOperator(code, symTab, typeEnv, recurse = FALSE))
             return(if(length(asserts)==0) NULL else asserts)
         }

--- a/packages/nimble/R/nimbleFunction_keywordProcessing.R
+++ b/packages/nimble/R/nimbleFunction_keywordProcessing.R
@@ -99,7 +99,7 @@ nimSeq_keywordInfo <- keywordInfoClass(
                 newRunCode <- substitute(nimSeqLen(FROM, TO, 0, LEN), list(FROM = code$from, TO = code$to, LEN = code$length.out))
             } else {
                 byVal <- if(useBy) code$by else 1 ## default by = 1
-                newRunCode <- substitute(nimSeqBy(FROM, TO, BY, 0), list(FROM = code$from, TO = code$to, BY = code$by))
+                newRunCode <- substitute(nimSeqBy(FROM, TO, BY, 0), list(FROM = code$from, TO = code$to, BY = byVal))
             }
         }
         return(newRunCode)

--- a/packages/nimble/tests/testthat/test-coreR.R
+++ b/packages/nimble/tests/testthat/test-coreR.R
@@ -420,6 +420,8 @@ seqTests <- list(
     ##1
     list(name = "1:5", expr = quote(out <- 1:5), args = list(),
          setArgVals = quote({}), outputType = quote(double(1)), checkEqual = TRUE),
+    list(name = "seq(1, 10)", expr = quote(out <- seq(1, 10)), args = list(),
+         setArgVals = quote({}), outputType = quote(double(1)), checkEqual = TRUE),
     list(name = "seq(.1, 10, by = .1)", expr = quote(out <- seq(.1, 10, by = .1)), args = list(),
          setArgVals = quote({}), outputType = quote(double(1))),
     list(name = "seq(.1, 10, length.out = 11)", expr = quote(out <- seq(.1, 10, length.out = 11)), args = list(),


### PR DESCRIPTION
This PR fixes a bug in default handling of a basic nimSeq case for compilation.

```
# In a nimbleFunction:
1:10 # works (and likely a reason this bug has not been revealed before)
nimSeq(1, 10, by = 1) # works
nimSeq(1, 10) # broke when inserting what should be default of 1.  fixed by this PR
```