### PR TITLE
WIP: fix size of `dep_dmnorm_identity_coeff` for dwish/dinvwish conjugacy with dynamic indexing

### DIFF
--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -572,17 +572,15 @@ conjugacyClass <- setRefClass(
             ## July 2017
             targetNdim <- getDimension(prior)
             targetCoeffNdim <- switch(as.character(targetNdim), `0`=0, `1`=2, `2`=2, stop())
-            targetCoeffNdimSave <- targetCoeffNdim 
+            if(targetCoeffNdim == 2 && link == 'multiplicativeScalar')   ## Handles wish/invwish. There are no cases where we allow non-scalar 'coeff'.
+                targetCoeffNdim <- 0
             for(iDepCount in seq_along(dependentCounts)) {
                 distLinkName <- names(dependentCounts)[iDepCount]
                 tmp <- strsplit(names(dependentCounts)[iDepCount], "_")[[1]]
                 distName <- tmp[[1]]
                 currentLink <- tmp[[2]]
                 if(currentLink %in% c('additive', 'multiplicative', 'multiplicativeScalar', 'linear') || (nimbleOptions()$allowDynamicIndexing && doDependentScreen)) {
-                    ## For 2-d (i.e., wish/invwish) cases, we only allow scalar coeff, including in dynamic indexing case. 
-                    if(currentLink == 'multiplicativeScalar' || (nimbleOptions()$allowDynamicIndexing && doDependentScreen && targetNdim == 2))  
-                        targetCoeffNdim <- 0
-                     ## the 2's here are *only* to prevent warnings about assigning into member variable names using
+                    ## the 2's here are *only* to prevent warnings about assigning into member variable names using
                     inputList <-  list(DEP_OFFSET_VAR2     = as.name(paste0('dep_', distLinkName, '_offset')),  ## local assignment '<-', so changed the names to "...2"
                                        DEP_COEFF_VAR2      = as.name(paste0('dep_', distLinkName, '_coeff')),   ## so it doesn't recognize the ref class field name
                                        DECLARE_SIZE_OFFSET = makeDeclareSizeField(as.name(paste0('N_dep_', distLinkName)), as.name(paste0('dep_', distLinkName, '_nodeSizeMax')), as.name(paste0('dep_', distLinkName, '_nodeSizeMax')), targetNdim),
@@ -600,7 +598,6 @@ conjugacyClass <- setRefClass(
                             DEP_OFFSET_VAR2  <- array(0, dim = DECLARE_SIZE_OFFSET)
                             DEP_COEFF_VAR2  <- array(0, dim = DECLARE_SIZE_COEFF)
                         }, inputList) 
-                    targetCoeffNdim <- targetCoeffNdimSave
                 }
             }
 
@@ -1024,7 +1021,6 @@ conjugacyClass <- setRefClass(
                                      list(N_DEP       = as.name(paste0('N_dep_', distLinkName)),
                                           FORLOOPBODY = forLoopBody$getCode()))
             }
-            ##}
         }
     )
 )

--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -579,7 +579,8 @@ conjugacyClass <- setRefClass(
                 distName <- tmp[[1]]
                 currentLink <- tmp[[2]]
                 if(currentLink %in% c('additive', 'multiplicative', 'multiplicativeScalar', 'linear') || (nimbleOptions()$allowDynamicIndexing && doDependentScreen)) {
-                    if(currentLink == 'multiplicativeScalar')  
+                    ## For 2-d (i.e., wish/invwish) cases, we only allow scalar coeff, including in dynamic indexing case. 
+                    if(currentLink == 'multiplicativeScalar' || (nimbleOptions()$allowDynamicIndexing && doDependentScreen && targetNdim == 2))  
                         targetCoeffNdim <- 0
                      ## the 2's here are *only* to prevent warnings about assigning into member variable names using
                     inputList <-  list(DEP_OFFSET_VAR2     = as.name(paste0('dep_', distLinkName, '_offset')),  ## local assignment '<-', so changed the names to "...2"
@@ -956,7 +957,6 @@ conjugacyClass <- setRefClass(
                 tmp <- strsplit(names(dependentCounts)[iDepCount], '_')[[1]]
                 distName <- tmp[[1]]
                 currentLink <- tmp[[2]]
-
                 targetCoeffNdim <- switch(as.character(targetNdim), `0`=0, `1`=2, `2`=2, stop())
                 if(targetCoeffNdim == 2 && link == 'multiplicativeScalar')   ## There are no cases where we allow non-scalar 'coeff'.
                     targetCoeffNdim <- 0


### PR DESCRIPTION
We weren't detecting that `dep_dmnorm_identity_coeff` is a vector of scalars (one per dependent) when using dynamic indexing with `dwish` and `dinvwish` in the identity relationship case.

This fixes that and adds a test, including testing that `dep_dmnorm_identity_coeff` is correct in both the `dmnorm` and `dwish` cases, correctly zeroing out potential dependencies that are not actual dependencies because of the current dynamic index values.

One thing to check (consult with Daniel) is why in lines 574 and 960 of `MCMC_conjugacy.R`, we are not simply setting `2`=0. I'd like a second opinion to try to jog my memory of why I left `2`=2 when I don't think we ever allow a 2-dim coeff in the case where we have a 2-dim target. We used to mistakenly allow this. 