### PR TITLE
fix compilation of recursive RCfunction

### DIFF
--- a/packages/nimble/R/RCfunction_compile.R
+++ b/packages/nimble/R/RCfunction_compile.R
@@ -323,7 +323,8 @@ RCfunProcessing <- setRefClass(
             compileInfo$typeEnv[['.ensureNimbleBlocks']] <<- FALSE ## will be TRUE for LHS recursion after RHS sees rmnorm and other vector dist "r" calls.
             compileInfo$typeEnv[['.allowFunctionAsArgument']] <<- FALSE ## will be TRUE when recursing on optim. See sizeOptim.
             compileInfo$typeEnv[['.nimbleProject']] <<- nimbleProject
-
+            compileInfo$typeEnv[['.myUniqueName']] <<- RCfun$uniqueName
+            
             passedArgNames <-
                 as.list(compileInfo$origLocalSymTab$getSymbolNames()) 
             names(passedArgNames) <-

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -282,13 +282,16 @@ exprClasses_setSizes <- function(code, symTab, typeEnv) { ## input code is exprC
                             code,
                             'In size processing: A no-setup nimbleFunction with no internal name is being called.'),
                         call. = FALSE)
-                if(is.null(typeEnv$neededRCfuns[[uniqueName]])) {
-                    typeEnv$neededRCfuns[[uniqueName]] <- nfmObj
-                }
                 ## new with nimbleLists: we need to initiate compilation here so we can get full returnType information, including of nimbleLists
                 RCfunProc <-
                     typeEnv$.nimbleProject$compileRCfun(obj,
                                                         initialTypeInference = TRUE)
+                
+                if(is.null(typeEnv$neededRCfuns[[uniqueName]])) {
+                    if(!identical(RCfunProc$RCfun$uniqueName, typeEnv$.myUniqueName))
+                        typeEnv$neededRCfuns[[uniqueName]] <- nfmObj
+                }
+                
                 return(sizeRCfunction(code, symTab, typeEnv, nfmObj, RCfunProc))
             }
         }


### PR DESCRIPTION
fixes #1186 

In size processing, do not put a recursive call into the needed types list.