### PR TITLE
runCrossVal expand node names before extracting from samples matrix

### DIFF
--- a/packages/nimble/R/crossValidation.R
+++ b/packages/nimble/R/crossValidation.R
@@ -78,7 +78,8 @@ calcCrossVal <- function(i,
                                    project = newModel, dirName = dirName))
       silentNull <- suppressMessages(C.modelMCMC$run(niter, progressBar = FALSE))
   }
-  MCMCout <- as.matrix(C.modelMCMC$mvSamples)[,leaveOutNames, drop = FALSE]
+  leaveOutNamesExpanded <- newModel$expandNodeNames(leaveOutNames, returnScalarComponents = TRUE)
+  MCMCout <- as.matrix(C.modelMCMC$mvSamples)[,leaveOutNamesExpanded, drop = FALSE]
   sampNum <- dim(MCMCout)[1]
   startIndex <- nburnin+1
   if(predLoss){


### PR DESCRIPTION
`runCrossVal` formerly didn't expand node names, before using the node names to index the columns of a matrix of posterior samples.  This caused an error when extracting multivariate nodes, for example `x[1:2]`, when indexing the columns as:

```
samples[, "x[1:2]" ]     ## error
```

