### PR TITLE
allow non-abstract do-nothing default methods in nimbleFunctionVirtual

### DIFF
--- a/packages/nimble/R/cppDefs_core.R
+++ b/packages/nimble/R/cppDefs_core.R
@@ -296,12 +296,15 @@ cppFunctionDef <- setRefClass('cppFunctionDef',
                                           }
                                            return(outputCode) 
                                       } else {
-                                          if(inherits(code$code, 'uninitializedField')) {
+                                          code_is_empty <- inherits(code$code, 'uninitializedField')
+                                          if(code_is_empty) {
                                               ## There is no code. This can occur for a nimbleFunctionVirtual, which is an abstract base class.
-                                              return(character(0))
+                                              if(abstract)
+                                                  return(character(0))
                                           }
-                                          c(paste(generateFunctionHeader(returnType, name, argsToUse, scopes, template, static = FALSE, ...), if(const) ' const ' else character(0), '{'),
-                                            code$generate(...),
+                                          c(paste(generateFunctionHeader(returnType, name, argsToUse, scopes, template, static = FALSE, ...),
+                                                  if(const) ' const ' else character(0), '{'),
+                                            if(!code_is_empty) code$generate(...) else '',
                                             list('}'))
                                       }
                                   }

--- a/packages/nimble/R/cppDefs_nimbleFunction.R
+++ b/packages/nimble/R/cppDefs_nimbleFunction.R
@@ -29,7 +29,8 @@ cppVirtualNimbleFunctionClass <- setRefClass('cppVirtualNimbleFunctionClass',
             nfProc <<- nfp
             assign('cppDef', .self, envir = environment(nfProc$nfGenerator))
             for(i in names(nfp$RCfunProcs)) { ## This is what we should do for cppNimbleFunctions too
-                functionDefs[[i]] <<- RCfunctionDef(virtual = TRUE, abstract = TRUE)
+                abstract <- !isFALSE( environment(nfProc$nfGenerator)$methodControl[[i]]$abstract ) # default = TRUE
+                functionDefs[[i]] <<- RCfunctionDef(virtual = TRUE, abstract = abstract)
                 functionDefs[[i]]$buildFunction(nfp$RCfunProcs[[i]])
             }
         }

--- a/packages/nimble/R/cppDefs_nimbleFunction.R
+++ b/packages/nimble/R/cppDefs_nimbleFunction.R
@@ -29,7 +29,7 @@ cppVirtualNimbleFunctionClass <- setRefClass('cppVirtualNimbleFunctionClass',
             nfProc <<- nfp
             assign('cppDef', .self, envir = environment(nfProc$nfGenerator))
             for(i in names(nfp$RCfunProcs)) { ## This is what we should do for cppNimbleFunctions too
-                abstract <- !isFALSE( environment(nfProc$nfGenerator)$methodControl[[i]]$abstract ) # default = TRUE
+                abstract <- !isFALSE( environment(nfProc$nfGenerator)$methodControl[[i]]$required ) # default required = TRUE.  required is a synonym for abstract.  If it's abstract, it's required in derived classes.
                 functionDefs[[i]] <<- RCfunctionDef(virtual = TRUE, abstract = abstract)
                 functionDefs[[i]]$buildFunction(nfp$RCfunProcs[[i]])
             }

--- a/packages/nimble/R/nimbleFunction_core.R
+++ b/packages/nimble/R/nimbleFunction_core.R
@@ -22,7 +22,8 @@ nf_refClassLabelMaker <- labelFunctionCreator('nfRefClass')
 nimbleFunctionVirtual <- function(contains = NULL,
                                   run = function() { },
                                   methods     = list(),
-                                  name        = NA) {
+                                  name        = NA,
+                                  methodControl = list()) {
     virtual <- TRUE
     if(is.na(name)) name <- nf_refClassLabelMaker()
     className <- name
@@ -34,7 +35,7 @@ nimbleFunctionVirtual <- function(contains = NULL,
     nfRefClassDef <- nfRefClass <- NULL ## Existence of these makes this treated like a nfGenerator
     environment(generatorFunction) <- GFenv <- new.env()
     parent.env(GFenv) <- parent.frame()
-    for(var in c('generatorFunction','nfRefClassDef','nfRefClass','run','methods','methodList','name', 'className', 'contains', 'virtual')) {
+    for(var in c('generatorFunction','nfRefClassDef','nfRefClass','run','methods','methodList','name', 'className', 'contains', 'virtual', 'methodControl')) {
         GFenv[[var]] <- get(var)
     }
     return(generatorFunction)

--- a/packages/nimble/tests/testthat/test-checkDSL.R
+++ b/packages/nimble/tests/testthat/test-checkDSL.R
@@ -354,9 +354,8 @@ test_that("nimbleFunctionVirtual works with abstract and non-abstract methods", 
     run = function(x = double()) {returnType(double())},
     methods = list(
       foo = function(x = double(1)) {returnType(double(1))},
-      hw = function(x = double(1)) {returnType(void())}
-    ),
-    methodControl = list(hw = list(abstract = FALSE))
+      hw = function(x = double(1)) {a < 1; returnType(void())}    ),
+    methodControl = list(hw = list(required = FALSE))
   )
 
   dNFa <- nimbleFunction(

--- a/packages/nimble/tests/testthat/test-checkDSL.R
+++ b/packages/nimble/tests/testthat/test-checkDSL.R
@@ -334,6 +334,88 @@ test_that("Handling of negative indexing in nimbleFunction code", {
     
 })
 
+test_that("nimbleFunctionVirtual works with abstract and non-abstract methods", {
+  # methods in nimbleFunctionVirtual are by default *abstract*, which means they
+  # are declared in the base class but are not defined. (In C++ they have "=0" at the
+  # end of the declaration.)  Hence they can't be called.
+  # This means that any derived class *must* provide a definition to become a
+  # fully defined (non-abstract) class and thus be usable.
+  #
+  # In order to provide nimbleFunctionVirtual methods that are not abstract,
+  # make an entry in the methodControl list setting abstract=FALSE,
+  # as shown in baseNF below. 
+  # non-abstract methods are limited to default do-nothing ({}) behavior.
+  # This means that to do anything interesting, a method must still be defined in
+  # a derived class.  But the do-nothing behavior allows the method to be
+  # simply ignored in a derived class that doesn't want to define it.
+  # This is a bare-bones feature that could be expanded in the future (e.g.
+  # by a meaningful base class method definition instead of simply {}).
+  baseNF <- nimbleFunctionVirtual(
+    run = function(x = double()) {returnType(double())},
+    methods = list(
+      foo = function(x = double(1)) {returnType(double(1))},
+      hw = function(x = double(1)) {returnType(void())}
+    ),
+    methodControl = list(hw = list(abstract = FALSE))
+  )
+
+  dNFa <- nimbleFunction(
+    contains = baseNF,
+    setup = TRUE,
+    run = function(x = double()) {
+      return(x + 1)
+      returnType(double())
+    },
+    methods = list(
+      foo = function(x = double(1)) {
+        return(x + 1)
+        returnType(double(1))
+      },
+      hw = function(x = double(1)) {
+        cat("hello world from a dNFa object.\n")
+      }
+    )
+  )
+
+  dNFb <- nimbleFunction(
+    contains = baseNF,
+    setup = TRUE,
+    run = function(x = double()) {
+      return(x + 2)
+      returnType(double())
+    },
+    methods = list(
+      foo = function(x = double(1)) {
+        return(x + 2)
+        returnType(double(1))
+      } # NO how method provided.
+    )
+  )
+
+  useBase <- nimbleFunction(
+    setup = function() {
+      NFlist <- nimbleFunctionList(baseNF)
+      NFlist[[1]] <- dNFa()
+      NFlist[[2]] <- dNFb()
+    },
+    run = function(x = double(1)) {
+      for(i in 1:2) {
+        x[1] <- NFlist[[i]]$run(x[1])
+        x <- NFlist[[i]]$foo(x)
+        NFlist[[i]]$hw(x)
+      }
+      return(x)
+      returnType(double(1))
+    }
+  )
+
+  useBase1 <- useBase()
+  CuseBase1 <- compileNimble(useBase1)
+  res <- capture.output(ans <- CuseBase1$run( c(10, 100) ))
+  expect_identical(ans, c(16, 103))
+  expect_true(grepl("hello world", res)) 
+})
+
 
 options(warn = RwarnLevel)
 nimbleOptions(verbose = nimbleVerboseSetting)


### PR DESCRIPTION
This is not for the imminent release.

@danielturek This PR provides the features needed to modify #1181 so that `sampler_BASE` could be expanded rather than adding a `sampler_BASE2`.  Let's see if it passes tests on devel and if so pull it into ADoak.  An example of how to use it is in the new final test in test-checkDSL.R.  I put it there because that's where nimbleFunctionVirtual appears in a test, but actually the new test could fit better in a different test file, but I'm leaving it to run tests for now.
