### PR TITLE
make nimbleList interface of nested nimbleList for predefined use sessionSpecificDll

### DIFF
--- a/packages/generateStaticCode.R
+++ b/packages/generateStaticCode.R
@@ -15,6 +15,10 @@ directions <- 'Directions:
 4. Review changes this script has made to the predefinedNimbleLists.* files.
 5. Revert the temporary change to GENERATE_STATIC_CODE from step 2,
    and reinstall nimble.
+6. If desired (default = yes), manually update
+   inst/include/nimble/dynamicRegistrations.h to have entries for the three
+   new SEXP-returning functions for each predefined nimbleList.
+   See examples in that file.
 '
 
 how_to_add_a_new_predefined_nimbleList <- 'How to:

--- a/packages/nimble/R/cppInterfaces_nimbleFunctions.R
+++ b/packages/nimble/R/cppInterfaces_nimbleFunctions.R
@@ -247,11 +247,15 @@ makeNimbleListBindingFields <- function(symTab, cppNames, castFunName) {
         if(inherits(thisSymbol, 'symbolNimbleList')) { ## copy type 'nimbleList'
             className <- thisSymbol$nlProc$cppDef$name
             castToPtrPairName <- thisSymbol$nlProc$cppDef$ptrCastToPtrPairFun$name
+            DLLcode <- if(isTRUE( thisSymbol$nlProc$cppDef$predefined ))
+                           quote(nimbleUserNamespace$sessionSpecificDll)
+                       else
+                           quote(dll)
             eval(substitute( fieldList$VARNAME <- function(x) {
                 namedObjectsPtr <- CASTFUNCALL ##.Call(dll$CASTFUN, .ptrToPtr)
                 extPtrNL <- nimbleInternalFunctions$newObjElementPtr(namedObjectsPtr, VARNAME, dll = dll)
-                nimbleInternalFunctions$getSetNimbleList(vptr = extPtrNL, name = VARNAME, value = x, cppDef = symTab$getSymbolObject(VARNAME)$nlProc$cppDef, dll = dll )
-            }, list(VARNAME = vn, CASTFUNCALL = castFunCall, CLASSNAME = className, CASTTOPTRPAIRNAME = castToPtrPairName) ) ) ##CASTFUN = castFunName,
+                nimbleInternalFunctions$getSetNimbleList(vptr = extPtrNL, name = VARNAME, value = x, cppDef = symTab$getSymbolObject(VARNAME)$nlProc$cppDef, dll = DLL )
+            }, list(VARNAME = vn, CASTFUNCALL = castFunCall, CLASSNAME = className, CASTTOPTRPAIRNAME = castToPtrPairName, DLL = DLLcode) ) ) ##CASTFUN = castFunName,
             next
         }
         if(thisSymbol$type == "character") { ## cpp copy type 'character'  : 2 sub-cases (vector and scalar)

--- a/packages/nimble/inst/include/nimble/dynamicRegistrations.h
+++ b/packages/nimble/inst/include/nimble/dynamicRegistrations.h
@@ -133,6 +133,22 @@ R_CallMethodDef CallEntries[] = {
   FUN(OptimResultNimbleList_castPtrPtrToNamedObjectsPtrSEXP, 1),
   FUN(OptimResultNimbleList_castDerivedPtrPtrToPairOfPtrsSEXP, 1),
   
+  FUN(new_OptimControlNimbleList, 0),
+  FUN(OptimControlNimbleList_castPtrPtrToNamedObjectsPtrSEXP, 1),
+  FUN(OptimControlNimbleList_castDerivedPtrPtrToPairOfPtrsSEXP, 1),
+
+  FUN(new_NIMBLE_ADCLASS, 0),
+  FUN(NIMBLE_ADCLASS_castPtrPtrToNamedObjectsPtrSEXP, 1),
+  FUN(NIMBLE_ADCLASS_castDerivedPtrPtrToPairOfPtrsSEXP, 1),
+
+  FUN(new_waicList, 0),
+  FUN(waicList_castPtrPtrToNamedObjectsPtrSEXP, 1),
+  FUN(waicList_castDerivedPtrPtrToPairOfPtrsSEXP, 1),
+  
+  FUN(new_waicDetailsList, 0),
+  FUN(waicDetailsList_castPtrPtrToNamedObjectsPtrSEXP, 1),
+  FUN(waicDetailsList_castDerivedPtrPtrToPairOfPtrsSEXP, 1),
+
   {NULL, NULL, 0}
 };
 

--- a/packages/nimble/tests/testthat/test-nimbleList.R
+++ b/packages/nimble/tests/testthat/test-nimbleList.R
@@ -1146,7 +1146,6 @@ test_that("nimbleList test 25: return object (from C++) is nimbleList", {
 ########
 ## Test #2 for eigen() function.  Use eigen() to specify a nl element.
 ########
-
 test_that("nimbleList test 26: return object (from C++) is nimbleList", {
     nlTestFunc26 <- nimbleFunction(
         setup = function(){


### PR DESCRIPTION
When one nimbleList contains another, and the contained nimbleList is a predefined, the dll in which we look for SEXP-functions for accessing the C++ objects is the wrong dll.  It is the on-the-fly dll instead of the sessionSpecificDLL.  This problem is OS-specific and occurs on Mac but not Linux.  It has not been checked on Windows yet.  I added a fix that checks for the predefined status when generating the active binding code for the (nested) nimbleList interface class.  I also added some of the predefined entries to dynamicRegistrations.h, which was a step missing in the instructions for updating predefined nimbleLists.  Let's see if this passes tests, but note that due to which tests were run on which OS, this was not actually failing tests in the first place.