### PR TITLE
fixes issue 1216 by not truncating names ending in `_Vec`

### DIFF
--- a/packages/nimble/R/BUGS_utils.R
+++ b/packages/nimble/R/BUGS_utils.R
@@ -263,7 +263,10 @@ Rname2CppName <- function(rName, colonsOK = TRUE, maxLength = 250) {
     rName <- gsub('^([[:digit:]])', 'd\\1', rName)    # if begins with a digit, add 'd' in front
     rName <- sapply(rName,
                     function(x) {
-                        if(nchar(x) > maxLength && !length(grep("___TRUNC___", x))) 
+                        if(nchar(x) > maxLength &&
+                           !length(grep("___TRUNC___", x)) &&
+                           !length(grep("_Vec$", x))) ## when we add _Vec on we need it to stay on (issue #1216)
+                            ## Note this could break if a user has long syntax that ends in _Vec, but deal if it arises.
                             x <- paste0(substring(x, 1, maxLength), CppNameLabelMaker())
                         return(x)
                     })


### PR DESCRIPTION
In Rname2CppName do not truncate names ending in `_Vec` (which we have introduced during compilation).

We might want to change the compilation system to add  `___Vec___` nistead of `_Vec` to ensure that a user would never use syntax that we think is syntax we've introduced.
