### PR TITLE
trap non-existent run/methods in nimbleFunction()

### DIFF
--- a/packages/nimble/R/MCEM_build.R
+++ b/packages/nimble/R/MCEM_build.R
@@ -87,18 +87,17 @@ calc_E_llk_gen = nimbleFunction(
 
 
 ## helper function to extract ranges of nodes to be maximized
-getMCEMRanges <- nimbleFunction(name = 'getMCEMRanges',
- setup = function(model, maxNodes, buffer){
+getMCEMRanges <- function(model, maxNodes, buffer) {
     low_limits = rep(-Inf, length(maxNodes) ) 
     hi_limits  = rep(Inf,  length(maxNodes) )
     nodes <- model$expandNodeNames(maxNodes)
     for(i in seq_along(nodes)) {
-      low_limits[i] = model$getBound(nodes[i], 'lower') + abs(buffer)
-      hi_limits[i]  = model$getBound(nodes[i], 'upper')  - abs(buffer)
+        low_limits[i] = model$getBound(nodes[i], 'lower') + abs(buffer)
+        hi_limits[i]  = model$getBound(nodes[i], 'upper')  - abs(buffer)
     }
     return(list(low_limits, hi_limits))
-  }
-)
+}
+
 
 #' Builds an MCEM algorithm from a given NIMBLE model
 #' 

--- a/packages/nimble/R/nimbleFunction_core.R
+++ b/packages/nimble/R/nimbleFunction_core.R
@@ -81,6 +81,9 @@ nimbleFunction <- function(setup         = NULL,
                            where         = getNimbleFunctionEnvironment()
                            ) {
     force(where) # so that we can get to namespace where a nf is defined by using topenv(parent.frame(2)) in getNimbleFunctionEnvironment()
+
+    if(missing(run) && missing(methods))
+        stop("nimbleFunction: either 'run' function or 'methods' must be provided.")
     if(is.logical(setup)) if(setup) setup <- function() {} else setup <- NULL
 
     if(is.null(setup)) {


### PR DESCRIPTION
This addresses NCT issue 374, where a user mistakenly left out the run function by doing

```
a <- nimbleFunction(run <- function(){})
```

@danielturek @perrydv let me know if you can think of any cases where creating a nimbleFunction with only setup code is something we want to allow.