### PR TITLE
WAIC updates

### DIFF
--- a/packages/nimble/R/MCMC_WAIC.R
+++ b/packages/nimble/R/MCMC_WAIC.R
@@ -18,7 +18,7 @@ buildDummyWAIC <- nimbleFunction(
         reset = function() {},
         updateStats = function() {},
         get = function() { return(waicNimbleList$new(WAIC = NA, lppd = NA, pWAIC = NA)); returnType(waicNimbleList()) },
-        getDetails = function(returnElements = logical(default = FALSE)) {return(waicDetailsNimbleList$new(marginal = FALSE, niterMarginal = 0, thin = FALSE, online = FALSE));  returnType(waicDetailsNimbleList()) },
+        getDetails = function(returnElements = logical(default = FALSE)) {return(waicDetailsNimbleList$new(marginal = FALSE, niterMarginal = 0, thin = FALSE, online = FALSE, nburnin_extra = 0));  returnType(waicDetailsNimbleList()) },
         calculateWAIC = function(nburnin = integer(default = 0), thin = double(default = 1)) { return(waicNimbleList$new(WAIC = NA, lppd = NA, pWAIC = NA)); returnType(waicNimbleList()) }
     )
 )
@@ -45,7 +45,7 @@ buildOfflineWAIC <- nimbleFunction(
     methods = list(
         reset = function() {},
         updateStats = function() {},
-        getDetails = function(returnElements = logical(default = FALSE)) {return(waicDetailsNimbleList$new(marginal = FALSE, niterMarginal = 0, thin = FALSE, online = FALSE));  returnType(waicDetailsNimbleList()) },
+        getDetails = function(returnElements = logical(default = FALSE)) {return(waicDetailsNimbleList$new(marginal = FALSE, niterMarginal = 0, thin = FALSE, online = FALSE, nburnin_extra = 0));  returnType(waicDetailsNimbleList()) },
         calculateWAIC = function(nburnin = integer(default = 0), thin = double(default = 1)) {
             nburninPostThinning <- ceiling(nburnin/thin)
             numMCMCSamples <- getsize(mvSamples) - nburninPostThinning
@@ -660,6 +660,9 @@ calculateWAIC <- function(mcmc, model, nburnin = 0, thin = 1) {
 #' \code{thin}: Whether WAIC was calculated based only on thinned samples.
 #' 
 #' \code{online}: Whether WAIC was calculated during MCMC sampling.
+#'
+#' \code{nburnin_extra}: Number of additional iterations discarded as burnin,
+#' in addition to original MCMC burnin.
 #' 
 #' \code{WAIC_partialMC}, \code{lppd_partialMC}, \code{pWAIC_partialMC}: The
 #' computed marginal WAIC, lppd, and pWAIC based on fewer Monte Carlo

--- a/packages/nimble/R/MCMC_WAIC.R
+++ b/packages/nimble/R/MCMC_WAIC.R
@@ -285,9 +285,9 @@ buildWAIC <- nimbleFunction(
             if(!finalized)
                 finalize()
             if(mcmcIter > 1) {
-                badpWAIC <- any( sspWAICmat[lengthConvCheck, ] / (mcmcIter-1) > 0.4 )
+                badpWAIC <- length(which( sspWAICmat[lengthConvCheck, ] / (mcmcIter-1) > 0.4 ))
                 if(badpWAIC) {  
-                    cat("  [Warning] There are individual pWAIC values that are greater than 0.4. This may indicate that the WAIC estimate is unstable (Vehtari et al., 2017), at least in cases without grouping of data nodes or multivariate data nodes.\n" )
+                    cat("  [Warning] There are ", badpWAIC, " individual pWAIC values that are greater than 0.4. This may indicate that the WAIC estimate is unstable (Vehtari et al., 2017), at least in cases without grouping of data nodes or multivariate data nodes.\n" )
                 }
             }
             output <- waicNimbleList$new()

--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -315,7 +315,7 @@ buildMCMC <- nimbleFunction(
                 return(waicFun[[1]]$getDetails(returnElements))
             } else {
                 print("WAIC details are only available when using online WAIC. Online WAIC was disabled based on the 'onlineWAIC' element of WAIC control list.")
-                return(waicDetailsNimbleList$new(marginal = FALSE, niterMarginal = 0, thin = FALSE, online = FALSE))
+                return(waicDetailsNimbleList$new(marginal = FALSE, niterMarginal = 0, thin = FALSE, online = FALSE, nburnin_extra = 0))
             }
         }
     )

--- a/packages/nimble/R/MCMC_run.R
+++ b/packages/nimble/R/MCMC_run.R
@@ -30,7 +30,7 @@
 #'
 #' @param WAIC Logical argument.  When \code{TRUE}, the WAIC (Watanabe, 2010) of the model is calculated and returned.  Note that in order for the WAIC to be calculated, the \code{mcmc} object must have also been created with the argument `enableWAIC = TRUE`.  If multiple chains are run, then a single WAIC value is calculated using the posterior samples from all chains.  Default value is \code{FALSE}.  See \code{help(waic)}.
 #'
-#' @param perChainWAIC Logical argument. When \code{TRUE} and multiple chains are run, the WAIC for each chain is returned as a means of helping assess the stability of the WAIC estimate. Default value is \code{FALSE}, corresponding to a single WAIC estimate based on all of the chains.
+#' @param perChainWAIC Logical argument. When \code{TRUE} and multiple chains are run, the WAIC for each chain is returned as a means of helping assess the stability of the WAIC estimate. Default value is \code{FALSE}.
 #'
 #' @return A list is returned with named elements depending on the arguments passed to \code{nimbleMCMC}, unless this list contains only a single element, in which case only that element is returned.  These elements may include \code{samples}, \code{summary}, and \code{WAIC}, and when the MCMC is monitoring a second set of nodes using \code{monitors2}, also \code{samples2}.  When \code{nchains = 1}, posterior samples are returned as a single matrix, and summary statistics as a single matrix.  When \code{nchains > 1}, posterior samples are returned as a list of matrices, one matrix for each chain, and summary statistics are returned as a list containing \code{nchains+1} matrices: one matrix corresponding to each chain, and the final element providing a summary of all chains, combined.  If \code{samplesAsCodaMCMC} is \code{TRUE}, then posterior samples are provided as \code{coda} \code{mcmc} and \code{mcmc.list} objects.  When \code{WAIC} is \code{TRUE}, a WAIC summary object is returned.
 #'
@@ -107,6 +107,8 @@ runMCMC <- function(mcmc,
     if(WAIC && !mcmc$enableWAIC) stop('mcmc argument must have been created with "enableWAIC = TRUE" in order to calculate WAIC.')
     if(WAIC && mcmc$enableWAIC && perChainWAIC && mcmc$onlineWAIC)
         stop('To get per-chain WAIC via runMCMC(), "mcmc" must have been configured with "online = FALSE" in the WAIC control list; see "help(WAIC)" for more information.')
+    if(mcmc$enableWAIC && !WAIC)
+        messageIfVerbose("  [Warning] To calculate WAIC, set 'WAIC = TRUE', in addition to having enabled WAIC in building the MCMC.")
     model <- if(is.Cnf(mcmc)) mcmc$Robject$model$CobjectInterface else mcmc$model
     if(!is.model(model)) stop('something went wrong')
     hasMonitors2 <- length(if(is.Cnf(mcmc)) mcmc$Robject$monitors2 else mcmc$monitors2) > 0
@@ -135,7 +137,8 @@ runMCMC <- function(mcmc,
             model$setInits(theseInits)
         }
         ##model$calculate()   # shouldn't be necessary, since mcmc$run() includes call to my_initializeModel$run()
-        mcmc$run(niter, nburnin = nburnin, thin = thinToUseVec[1], thin2 = thinToUseVec[2], progressBar = progressBar, resetWAIC = FALSE) #, samplerExecutionOrder = samplerExecutionOrderToUse)
+        mcmc$run(niter, nburnin = nburnin, thin = thinToUseVec[1], thin2 = thinToUseVec[2], progressBar = progressBar,
+                 resetWAIC = ifelse(i == 1, TRUE, FALSE)) #, samplerExecutionOrder = samplerExecutionOrderToUse)
         tmp <- as.matrix(mcmc$mvSamples)
         if(!is.null(tmp))
             samplesList[[i]] <- tmp 
@@ -151,24 +154,23 @@ runMCMC <- function(mcmc,
             ## do calculation as if a single chain.
             WAICvalue <- mcmc$getWAIC()
         } else {
-            if(nchains > 1 && perChainWAIC) {
-                WAICvalue <- rep(NA, nchains)
+            if(perChainWAIC) {
+                perChainWAICvalue <- rep(NA, nchains)
                 for(i in seq_along(samplesList)) {
                     matrix2mv(samplesList[[i]], mcmc$mvSamples)  ## transfer each set of posterior samples into mcmc$mvSamples
-                    WAICvalue[i] <- mcmc$calculateWAIC()
+                    perChainWAICvalue[i] <- mcmc$calculateWAIC()
                 }
-            } else {
-                if(nchains > 1) {
-                    samplesPerChain <- dim(samplesList[[1]])[1]
-                    posteriorSamplesMatrix <- matrix(0, nrow = samplesPerChain*nchains, ncol = dim(samplesList[[1]])[2])
-                    for(i in seq_along(samplesList)) {
-                        posteriorSamplesMatrix[((i-1)*samplesPerChain + 1):(i*samplesPerChain),] <- samplesList[[i]][,]
-                    }
-                    colnames(posteriorSamplesMatrix) <- colnames(samplesList[[1]])
-                    matrix2mv(posteriorSamplesMatrix, mcmc$mvSamples)  ## transfer all posterior samples into mcmc$mvSamples
-                }
-                WAICvalue <- mcmc$calculateWAIC()
             }
+            if(nchains > 1) {
+                samplesPerChain <- dim(samplesList[[1]])[1]
+                posteriorSamplesMatrix <- matrix(0, nrow = samplesPerChain*nchains, ncol = dim(samplesList[[1]])[2])
+                for(i in seq_along(samplesList)) {
+                    posteriorSamplesMatrix[((i-1)*samplesPerChain + 1):(i*samplesPerChain),] <- samplesList[[i]][,]
+                }
+                colnames(posteriorSamplesMatrix) <- colnames(samplesList[[1]])
+                matrix2mv(posteriorSamplesMatrix, mcmc$mvSamples)  ## transfer all posterior samples into mcmc$mvSamples
+            }
+            WAICvalue <- mcmc$calculateWAIC()
         }
     }
     if(samplesAsCodaMCMC) {
@@ -202,6 +204,7 @@ runMCMC <- function(mcmc,
                   if(hasMonitors2)   retList$samples2 <- samplesList2 }
     if(summary)   retList$summary <- summaryObject
     if(WAIC)      retList$WAIC    <- WAICvalue
+    if(perChainWAIC) retList$perChainWAIC <- perChainWAICvalue
     if(length(retList) == 1) retList <- retList[[1]]
     return(retList)
 }

--- a/packages/nimble/inst/CppCode/predefinedNimbleLists.cpp
+++ b/packages/nimble/inst/CppCode/predefinedNimbleLists.cpp
@@ -812,7 +812,7 @@ void waicDetailsNimbleList::copyFromSEXP(SEXP S_nimList_) {
   SEXP_2_NimArr<1>(S_WAIC_elements, WAIC_elements);
   SEXP_2_NimArr<1>(S_lppd_elements, lppd_elements);
   SEXP_2_NimArr<1>(S_pWAIC_elements, pWAIC_elements);
-  UNPROTECT(23);
+  UNPROTECT(25);
 }
 SEXP waicDetailsNimbleList::copyToSEXP() {
   SEXP S__dot_xData;
@@ -870,7 +870,7 @@ SEXP waicDetailsNimbleList::copyToSEXP() {
     Rf_defineVar(Rf_install("pWAIC_elements"), S_pWAIC_elements,
                  PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));
     RCopiedFlag = true;
-    UNPROTECT(23);
+    UNPROTECT(25);
   }
   return (RObjectPointer);
 }

--- a/packages/nimble/inst/CppCode/predefinedNimbleLists.cpp
+++ b/packages/nimble/inst/CppCode/predefinedNimbleLists.cpp
@@ -852,7 +852,7 @@ SEXP waicDetailsNimbleList::copyToSEXP() {
                  PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));
     Rf_defineVar(Rf_install("online"), S_online,
                  PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));
-    Rf_defineVar(Rf_install("nburnin_extra"), S_niterMarginal,
+    Rf_defineVar(Rf_install("nburnin_extra"), S_nburnin_extra,
                  PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));
     Rf_defineVar(Rf_install("WAIC_partialMC"), S_WAIC_partialMC,
                  PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));

--- a/packages/nimble/tests/testthat/test-waic.R
+++ b/packages/nimble/tests/testthat/test-waic.R
@@ -244,7 +244,7 @@ test_that("New WAIC implementation matches old implementation for conditional, u
     expect_equal(waic2$WAIC, waic1)
     expect_identical(c(waic2$WAIC, waic2$lppd, waic2$pWAIC), c(out2$WAIC$WAIC, out2$WAIC$lppd, out2$WAIC$pWAIC))
 
-    waic2full <- cmcmc$getWAICdetails(returnElements = TRUE)
+    expect_silent(waic2full <- cmcmc$getWAICdetails(returnElements = TRUE))
     expect_identical(waic2full$thin, FALSE)
     expect_identical(waic2full$online, TRUE)
     expect_identical(waic2full$marginal, FALSE)

--- a/packages/nimble/tests/testthat/test-waic.R
+++ b/packages/nimble/tests/testthat/test-waic.R
@@ -92,7 +92,7 @@ test_that("voter model WAIC is accurate", {
   Cvotermcmc <- compileNimble(votermcmc, project = voterModel)
   Cvotermcmc$run(50000)
   expect_output(waic <- Cvotermcmc$getWAIC()$WAIC,
-                 "There are individual pWAIC values that are greater than 0.4")
+                 "individual pWAIC values that are greater than 0.4")
   expect_lt(abs(waic - 87.2), 2.0)
   
   ## additional testing of validity of monitored nodes below
@@ -273,8 +273,8 @@ test_that("New WAIC implementation matches old implementation for conditional, u
     set.seed(1)
     out3 <- runMCMC(cmcmc, niter = 1000, nchains = 3, WAIC = TRUE, inits = inits, perChainWAIC = TRUE)
     waic3 <- cmcmc$calculateWAIC()
-    expect_identical(out3$WAIC[3], waic3)
-    expect_identical(out3$WAIC[1], waic1)
+    expect_identical(out3$WAIC, waic3)
+    expect_identical(out3$perChainWAIC[1], waic1)
 
 })
 
@@ -630,7 +630,7 @@ test_that("use of extra burnin of online WAIC", {
     out3 <- runMCMC(cmcmc, niter = 500, nburnin = 50)
     waic3 <- calculateWAIC(cmcmc, nburnin = 50)
 
-    expect_equal(waic1, waic2)
+    expect_gt(abs(waic1$WAIC - waic2$WAIC), .01)
     expect_equal(waic1, waic3)
 })
 


### PR DESCRIPTION
Various updates to WAIC:

1. fix bug (issue #1255) to reset WAIC when calling runMCMC mltiple times; 
2. report number of pWAIC values > 0.4 not just presence/absence; 
3. warn user if WAIC is enabled but not set to TRUE in runMCMC; 
4. provide aggregate and per-chain-waic when perChainWAIC is TRUE (not just per-chain)