### PR TITLE
trap list-like syntax errors in nimbleFunction run code

### DIFF
--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -1135,7 +1135,7 @@ sizeNFvar <- function(code, symTab, typeEnv) {
     ## nl in nlEigenReferenceList
 
     if(!(isSymFunc || isSymList))
-        stop(exprClassProcessingErrorMsg(code, 'In sizeNFvar: First argument is not a nimbleFunction or a nimbleList. List-like syntax with `[[` and `$` in nimbleFunction run code can only be done with a nimbleFunction or nimbleList.'), call. = FALSE)
+        stop(exprClassProcessingErrorMsg(code, 'In sizeNFvar: First argument is not a nimbleFunction or a nimbleList.\nList-like syntax with `[[` and `$` in nimbleFunction run code can only be done with a nimbleFunction or nimbleList.'), call. = FALSE)
     nfProc <- if(isSymFunc) symbolObject$nfProc else symbolObject$nlProc
     
     if(is.null(nfProc)) {

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -1135,7 +1135,7 @@ sizeNFvar <- function(code, symTab, typeEnv) {
     ## nl in nlEigenReferenceList
 
     if(!(isSymFunc || isSymList))
-        stop(exprClassProcessingErrorMsg(code, 'In sizeNFvar: First argument is not a nimbleFunction or a nimbleList'), call. = FALSE)
+        stop(exprClassProcessingErrorMsg(code, 'In sizeNFvar: First argument is not a nimbleFunction or a nimbleList. List-like syntax with `[[` and `$` in nimbleFunction run code can only be done with a nimbleFunction or nimbleList.'), call. = FALSE)
     nfProc <- if(isSymFunc) symbolObject$nfProc else symbolObject$nlProc
     
     if(is.null(nfProc)) {

--- a/packages/nimble/R/nimbleFunction_keywordProcessing.R
+++ b/packages/nimble/R/nimbleFunction_keywordProcessing.R
@@ -1311,6 +1311,8 @@ matchAndFill.call <- function(def, call){
 determineNdimsFromNfproc <- function(modelExpr, varOrNodeExpr, nfProc) {
     allNDims <- lapply(nfProc$instances, function(x) {
         model <- eval(modelExpr, envir = x)
+        if(length(varOrNodeExpr) > 1)
+            stop("One must request a node from a model using syntax like `model[[node]]` and not syntax such as `model[[nodes[i]]]`. For the latter case use `values()` instead.")
         if(!exists(as.character(varOrNodeExpr), x, inherits = FALSE) ) {
             stop(paste0('Problem accessing node or variable ', deparse(varOrNodeExpr), '.'), call. = FALSE)
         }

--- a/packages/nimble/R/nimbleFunction_keywordProcessing.R
+++ b/packages/nimble/R/nimbleFunction_keywordProcessing.R
@@ -516,6 +516,7 @@ nimCopy_keywordInfo <- keywordInfoClass(
 doubleBracket_keywordInfo <- keywordInfoClass(
 	keyword = '[[', 
     processor = function(code, nfProc){
+        callerCode <- code[[2]]
         if(is.null(nfProc)) stop("No allowed use of [[ in a nimbleFunction without setup code.")
         possibleObjects <- c('symbolModel', 'symbolNimPtrList', 'symbolNimbleFunctionList', 'symbolNimbleList')
         class = symTypeFromSymTab(code[[2]], nfProc$setupSymTab, options = possibleObjects)

--- a/packages/nimble/tests/testthat/test-nimbleList.R
+++ b/packages/nimble/tests/testthat/test-nimbleList.R
@@ -1324,7 +1324,6 @@ test_that("nimbleList test use of [[", {
             doubleVector <- numeric(2, 1)
             newList1 <- testListDef1$new(nlVector = doubleVector, nlMatrix = doubleMatrix)
             newList1[['nlScalar']] <- doubleScalar
-            newList1[[nm]] <- doubleScalar
             returnType(testListDef1())
             return(newList1)
         }

--- a/packages/nimble/tests/testthat/test-nimbleList.R
+++ b/packages/nimble/tests/testthat/test-nimbleList.R
@@ -1311,5 +1311,44 @@ test_that("nimSvd Model Test 1", {
     expect_identical(Rmodel2$calculate(), Cmodel2$calculate())
 })
 
+test_that("nimbleList test use of [[", {
+    testListDef1 <- nimbleList(nlScalar = double(0), nlVector = double(1), nlMatrix = double(2))
+    temporarilyAssignInGlobalEnv(testListDef1)
+    
+    nlTestFunc1 <- nimbleFunction(
+        setup = function(){
+            doubleMatrix <- diag(1)
+        },
+        run = function(){
+            doubleScalar <- 1
+            doubleVector <- numeric(2, 1)
+            newList1 <- testListDef1$new(nlVector = doubleVector, nlMatrix = doubleMatrix)
+            newList1[['nlScalar']] <- doubleScalar
+            newList1[[nm]] <- doubleScalar
+            returnType(testListDef1())
+            return(newList1)
+        }
+    )
+    
+    testInst <- nlTestFunc1()
+    RnimbleList <- testInst$run()
+    CtestInst <- compileNimble(testInst, control = list(debug =  F))
+    CnimbleList <- CtestInst$run()
+
+    ## test for correct values of R nimbleList
+    expect_identical(RnimbleList$nlScalar, 1)
+    expect_identical(RnimbleList$nlVector, c(1, 1))
+    expect_identical(RnimbleList$nlMatrix, diag(1))
+    ## test for identical values of R and C nimbleLists
+    expect_identical(RnimbleList$nlScalar, CnimbleList$nlScalar)
+    expect_identical(RnimbleList$nlVector, CnimbleList$nlVector)
+    expect_identical(RnimbleList$nlMatrix, CnimbleList$nlMatrix)
+    expect_identical(nimble:::is.nl(RnimbleList), TRUE)
+    expect_identical(is.nl(CnimbleList), TRUE)
+})
+
 options(warn = RwarnLevel)
 nimbleOptions(verbose = nimbleVerboseSetting)
+
+
+


### PR DESCRIPTION
This address issues #1237  and #1252 , by

- fixing a bug in handling `nimbleList[['foo']]` syntax
- adding a test for the former case
- error trapping `model[[nodes[i]]]`

Do not merge until deciding on the question of whether to enhance the `sizeNFvar` error message to be discussed in issue #1237.