### PR TITLE
error trap deterministic data nodes

### DIFF
--- a/UserManual/src/chapter_BuildingModels.Rmd
+++ b/UserManual/src/chapter_BuildingModels.Rmd
@@ -85,7 +85,7 @@ example, if `pumpData` is a named list of data values (as above),
 then `pump$setData(pumpData)` sets the named variables to the
 values in the list.
 
-`setData` does two things: it sets the values of the data nodes,
+`setData` does two things: it sets the values of the (stochastic) data nodes,
 and it flags those nodes as containing data.  nimbleFunction
 programmers can then use that information to control whether an
 algorithm should over-write data or not.  For example, NIMBLE's
@@ -93,6 +93,10 @@ algorithm should over-write data or not.  For example, NIMBLE's
 can be told to do so.  Values of data variables can be replaced, and
 the indication of which nodes should be treated as data can be reset
 by using the `resetData` method, e.g. `pump$resetData()`.
+
+Data nodes cannot be deterministic, and using `setData` on
+deterministic nodes (or passing values for deterministic nodes
+via the `data` argument to `nimbleModel`) will produce an error.
 
 To change data values without any modification of which nodes are
 flagged as containing data, simply use R's usual assignment syntax

--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -562,7 +562,7 @@ Resets the \'data\' property of ALL model nodes to FALSE.  Subsequent to this ca
 
                                   setData = function(..., warnAboutMissingNames = TRUE) {
 '
-Sets the \'data\' flag for specified nodes to TRUE, and also sets the value of these nodes to the value provided.  This is the exclusive method for specifying \'data\' nodes in a model object.  When a \'data\' argument is provided to \'nimbleModel()\', it uses this method to set the data nodes.
+Sets the \'data\' flag for specified stochastic nodes to TRUE, and also sets the value of these nodes to the value provided.  This is the exclusive method for specifying \'data\' nodes in a model object.  When a \'data\' argument is provided to \'nimbleModel()\', it uses this method to set the data nodes.
 
 Arguments:
 
@@ -606,10 +606,12 @@ Details: If a provided value (or the current value in the model when only a name
                                       origData <<- data
                                       ## argument is a named list of data values.
                                       ## all nodes specified (except with NA) are set to that value, and have isDataEnv$VAR set to TRUE
-
                                       for(iData in seq_along(data)) {
                                           varName <- dataNames[iData]
                                           varValue <- data[[varName]]
+                                          determ <- .self$isDeterm(varName)
+                                          if(any(.self$isDeterm(expandNodeNames(varName, returnScalarComponents = TRUE)) & !is.na(varValue)))
+                                              stop("setData: '", varName, "' contains deterministic nodes. Only stochastic nodes can be specified as 'data'.") 
                                           if(is.data.frame(varValue)) {
                                               if(!all(sapply(varValue, is.numeric)))
                                                   stop("setData: '", varName, "' must be numeric")
@@ -621,7 +623,7 @@ Details: If a provided value (or the current value in the model when only a name
                                               ## it is possible that the constants don't exist on LHS of BUGS decls
                                               ## and so are not variables in the model.  In that case we don't want to issue the warning.
                                               if(warnAboutMissingNames
-                                                 & nimble::nimbleOptions("verbose")) {
+                                                 && nimble::nimbleOptions("verbose")) {
                                                   if(varName == '') {
                                                       warning('setData: unnamed element provided to setData.')
                                                   } else 

--- a/packages/nimble/tests/testthat/test-setData.R
+++ b/packages/nimble/tests/testthat/test-setData.R
@@ -126,6 +126,52 @@ test_that("weird character input produces error", {
     expect_error(model$setData(c('a','d'),'b'))
 })
 
+test_that("deterministic nodes produce error", {
+    expect_error(
+        model <- nimbleModel(
+            nimbleCode({
+                for(i in 1:5) {
+                    z[i] <- mu[i]
+                }
+                z[6] ~ dnorm(0, 1)
+                y ~ dnorm(0, 1)
+            }), data = list(z = rnorm(6), y = rnorm(1))),
+        "Only stochastic nodes can be specified as 'data'."
+    )
+
+    expect_error(
+        model <- nimbleModel(
+            nimbleCode({
+                z[1:2] <- mu[1:2]
+                z[3] ~ dnorm(0, 1)
+                y ~ dnorm(0, 1)
+            }), data = list(z = rnorm(3), y = rnorm(1))),
+        "Only stochastic nodes can be specified as 'data'."
+    )
+
+    expect_message(
+        model <- nimbleModel(
+            nimbleCode({
+                z[1:2] <- mu[1:2]
+                z[3] ~ dnorm(0, 1)
+                y ~ dnorm(0, 1)
+            }), data = list(z = c(rep(NA, 2), rnorm(1)), y = rnorm(1))),
+        "Checking model sizes"
+    )
+
+    expect_message(
+        model <- nimbleModel(
+            nimbleCode({
+                for(i in 1:5) {
+                    z[i] <- mu[i]
+                }
+                z[6] ~ dnorm(0, 1)
+                y ~ dnorm(0, 1)
+            }), data = list(z = c(rep(NA, 5), rnorm(1)), y = rnorm(1))),
+        "Checking model sizes"
+    )
+})
+
 
 test_that("data frame as matrix processed correctly", {
     model <- nimbleModel(


### PR DESCRIPTION
This addresses issue #1263 by adding an error trap in `setData`.