### PR TITLE
Clean up use of offset argument in SEXP_2_int

### DIFF
--- a/packages/nimble/inst/CppCode/RcppUtils.cpp
+++ b/packages/nimble/inst/CppCode/RcppUtils.cpp
@@ -232,7 +232,7 @@ vector<int> SEXP_2_vectorInt( SEXP Sn, int offset ) {
   return(ans);
 }
 
-int SEXP_2_int(SEXP Sn, int i, int offset ) {
+int SEXP_2_int(SEXP Sn, int i ) {
   if(!(Rf_isNumeric(Sn) || Rf_isLogical(Sn))) PRINTF("Error: SEXP_2_int called for SEXP that is not numeric or logical\n");
   if(LENGTH(Sn) <= i) PRINTF("Error: SEXP_2_int called for element %i% >= length of %i.\n", i, LENGTH(Sn));
   if(Rf_isInteger(Sn) || Rf_isLogical(Sn)) {
@@ -242,7 +242,7 @@ int SEXP_2_int(SEXP Sn, int i, int offset ) {
       return(LOGICAL(Sn)[i]);
   } else {
     if(Rf_isReal(Sn)) {
-      double ans = REAL(Sn)[i] + offset;
+      double ans = REAL(Sn)[i];
       if(ans != floor(ans)) PRINTF("Warning from SEXP_2_int: input element is a real with a non-integer value\n");
       return(static_cast<int>(ans));
     } else {

--- a/packages/nimble/inst/CppCode/accessorClasses.cpp
+++ b/packages/nimble/inst/CppCode/accessorClasses.cpp
@@ -858,7 +858,7 @@ SEXP mapInfo2Rlist(const mapInfoClass &input) {
 SEXP varAndIndices2mapParts(SEXP SvarAndIndicesExtPtr, SEXP Ssizes, SEXP SnDim) {
   varAndIndicesClass *varAndIndicesPtr = static_cast<varAndIndicesClass *>(R_ExternalPtrAddr(SvarAndIndicesExtPtr));
   vector<int> sizes(SEXP_2_vectorInt(Ssizes, 0));
-  int nDim(SEXP_2_int(SnDim, 0, 0));
+  int nDim(SEXP_2_int(SnDim, 0));
   mapInfoClass output;
   varAndIndices2mapParts(*varAndIndicesPtr, nDim, sizes, output);
   return(mapInfo2Rlist(output));
@@ -869,7 +869,7 @@ SEXP var2mapParts(SEXP Sinput, SEXP Ssizes, SEXP SnDim) {
   varAndIndicesClass varAndIndices;
   parseVarAndInds(input, varAndIndices);
   vector<int> sizes(SEXP_2_vectorInt(Ssizes, 0));
-  int nDim(SEXP_2_int(SnDim, 0, 0));
+  int nDim(SEXP_2_int(SnDim, 0));
   mapInfoClass output;
   varAndIndices2mapParts(varAndIndices, nDim, sizes, output);
   return(mapInfo2Rlist(output));

--- a/packages/nimble/inst/CppCode/eigenUsingClasses.cpp
+++ b/packages/nimble/inst/CppCode/eigenUsingClasses.cpp
@@ -179,7 +179,7 @@ SEXP C_nimSvd(SEXP S_x, SEXP S_vectors, SEXP returnList) {
   if(!Rf_isMatrix(S_x))
     RBREAK("Error (C_nimSvd): 'x' must be a matrix.\n");
   NimArr<2, double> x;
-  int vectors = SEXP_2_int(S_vectors, 0, 0);
+  int vectors = SEXP_2_int(S_vectors, 0);
   SEXP_2_NimArr<2>(S_x, x);
   Eigen::Map<Eigen::MatrixXd> Eig_x(x.getPtr(), x.dim()[0], x.dim()[1]); 
   EIGEN_SVDCLASS_R C_svdClass = *EIGEN_SVD_R(Eig_x, vectors);

--- a/packages/nimble/inst/CppCode/nimbleGraph.cpp
+++ b/packages/nimble/inst/CppCode/nimbleGraph.cpp
@@ -147,7 +147,7 @@ SEXP C_getParents(SEXP SgraphExtPtr, SEXP Snodes, SEXP Somit, SEXP Sdownstream, 
 
 SEXP C_getDependencyPathCountOneNode(SEXP SgraphExtPtr, SEXP Snode) {
   nimbleGraph *graphPtr = static_cast<nimbleGraph *>(R_ExternalPtrAddr(SgraphExtPtr));
-  int node = SEXP_2_int(Snode, 0, -1); // subtract 1 index for C
+  int node = SEXP_2_int(Snode, 0)-1; // subtract 1 index for C
   int result = graphPtr->getDependencyPathCountOneNode(node);
   return(int_2_SEXP(result)); 
 }

--- a/packages/nimble/inst/include/nimble/RcppUtils.h
+++ b/packages/nimble/inst/include/nimble/RcppUtils.h
@@ -72,9 +72,8 @@ SEXP vectorInt_2_SEXP(const vector<int> &v);
 SEXP vectorInt_2_SEXP(const vector<int> &v, int offset);
 
 vector<int> SEXP_2_vectorInt(SEXP Sn, int offset = 0); /* Sn can be numeric or integer from R */ 
-/* Offset is added to every value, so if the vectors are indices, offset = -1 is useful */
 /* If Sn is numeric but not integer, a warning is issued if it contains non-integers */
-int SEXP_2_int(SEXP Sn, int i = 0, int offset = 0);
+int SEXP_2_int(SEXP Sn, int i = 0);
 SEXP int_2_SEXP(int i);
 bool SEXP_2_bool(SEXP Sn, int i = 0);
 SEXP bool_2_SEXP(bool ind);


### PR DESCRIPTION
Issue #1218 raised the issue that the offset argument was applied only for one type of input.

It turns out that offset is only non-zero (-1) when called from one pathway for graphs.  This PR removes offset as a general argument to SEXP_2_int and instead does the -1 step in the one place where it is used.