### PR TITLE
Fix splitVertices to address issue #1268

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -1679,7 +1679,8 @@ splitVertices <- function(var2vertexID, unrolledBUGSindices, indexExprs = NULL, 
     if(all(is.na(var2vertexID)))
         currentVertexCounts <- rep(0, maxVertexID)
     else
-        currentVertexCounts <- tabulate(var2vertexID, max(max(var2vertexID, na.rm = TRUE), maxVertexID))
+      currentVertexCounts <- tabulate(var2vertexID, max(max(var2vertexID, na.rm = TRUE), maxVertexID))
+     if(nextVertexID > length(currentVertexCounts)) currentVertexCounts <- append(currentVertexCounts, rep(0, length(currentVertexCounts) - maxVertexID))
     ## 5. Set up initial table of vertexIDcounts
 
     ## 6. All scalar case: iterate or vectorize via cbind and put new vertexIDs over -1s
@@ -1734,7 +1735,8 @@ splitVertices <- function(var2vertexID, unrolledBUGSindices, indexExprs = NULL, 
                         varIndicesToUse[ , !dynamicIndices] <- tmp[ , (numDynamicIndices+1):ncol(varIndicesToUse)]
                 }
             }
-        
+
+      #  varIndicesToUse <- unique(varIndicesToUse)
         ## parentIndexNamePieces Should there be a unique in one of the next lines? Or varIndicesToUse <- unique(varIndicesToUse).
         ## OR use a !duplicated construction in boolUseUnrolledRow <- rep(TRUE, nrow(unrolledBUGSindices)) above
         currentVertexIDs <- var2vertexID[varIndicesToUse]
@@ -1743,6 +1745,7 @@ splitVertices <- function(var2vertexID, unrolledBUGSindices, indexExprs = NULL, 
         if(numNewVertexIDs > 0) {
             var2vertexID[varIndicesToUse][needsVertexID] <- nextVertexID - 1 + 1:numNewVertexIDs
             nextVertexID <- nextVertexID + numNewVertexIDs
+            if(nextVertexID > length(currentVertexCounts)) currentVertexCounts <- append(currentVertexCounts, rep(0, length(currentVertexCounts) - maxVertexID))
         }
         ## Still need to look for splits on other existing vertexIDs
         oldIndices <- !needsVertexID
@@ -1755,6 +1758,7 @@ splitVertices <- function(var2vertexID, unrolledBUGSindices, indexExprs = NULL, 
         if(numNeedSplit > 0) {
             var2vertexID[varIndicesToUse][ oldIndices][needsSplit] <- nextVertexID - 1 + 1:numNeedSplit
             nextVertexID <- nextVertexID + numNeedSplit
+            if(nextVertexID > length(currentVertexCounts)) currentVertexCounts <- append(currentVertexCounts, rep(0, length(currentVertexCounts) - maxVertexID))
         }
         ## This can result in skips, e.g. if a previous BUGSdecl labeled a vector with a new vectorID, and that now gets split in scalar vectorID labels
         ## Then the earlier vectorID will be gone forever
@@ -1780,11 +1784,14 @@ splitVertices <- function(var2vertexID, unrolledBUGSindices, indexExprs = NULL, 
             currentVertexIDblock <- eval(accessExpr)
             uniqueCurrentVertexIDs <- unique(c(currentVertexIDblock))
             if(length(uniqueCurrentVertexIDs)==1) { ## current block has only 1 ID
-                if( is.na(uniqueCurrentVertexIDs[1]) |      ## It's all unassigned OR
+                if( is.na(uniqueCurrentVertexIDs[1]) ||      ## It's all unassigned OR
                    currentVertexCounts[ uniqueCurrentVertexIDs[1] ] != length(currentVertexIDblock) ) { ## It does not fully cover  existing vertexID
                     if(!is.na(uniqueCurrentVertexIDs[1])) currentVertexCounts[ uniqueCurrentVertexIDs[1] ] <- currentVertexCounts[ uniqueCurrentVertexIDs[1] ] - sum(currentVertexIDblock == uniqueCurrentVertexIDs[1])
                     eval(assignExprNextVID) ## var2vertexID[ all indexing stuff ] <- nextVertexID
+             #       updatedVertexIDblock <- eval(accessExpr)
+             #       currentVertexCounts[nextVertexID] <- currentVertexCounts[nextVertexID] + sum(updatedVertexIDblock == nextVertexID) ## should be all of the elements, so summing the size of the block
                     nextVertexID <- nextVertexID + 1
+                    if(nextVertexID > length(currentVertexCounts)) currentVertexCounts <- append(currentVertexCounts, rep(0, length(currentVertexCounts) - maxVertexID))
                 }
             } else { ## need to iterate through IDs
                 for(VID in uniqueCurrentVertexIDs) {
@@ -1793,6 +1800,7 @@ splitVertices <- function(var2vertexID, unrolledBUGSindices, indexExprs = NULL, 
                         currentVertexIDblock[ boolIsNA ] <- nextVertexID
                         currentVertexCounts[nextVertexID] <- currentVertexCounts[nextVertexID] + sum(boolIsNA)
                         nextVertexID <- nextVertexID + 1
+                        if(nextVertexID > length(currentVertexCounts)) currentVertexCounts <- append(currentVertexCounts, rep(0, length(currentVertexCounts) - maxVertexID))
                     } else {
                         boolWithinBlock <- currentVertexIDblock == VID
                         numWithinBlock <- sum(boolWithinBlock, na.rm = TRUE)
@@ -1801,6 +1809,7 @@ splitVertices <- function(var2vertexID, unrolledBUGSindices, indexExprs = NULL, 
                             currentVertexCounts[VID] <- currentVertexCounts[VID] - numWithinBlock
                             currentVertexCounts[nextVertexID] <- currentVertexCounts[nextVertexID] + numWithinBlock
                             nextVertexID <- nextVertexID + 1
+                            if(nextVertexID > length(currentVertexCounts)) currentVertexCounts <- append(currentVertexCounts, rep(0, length(currentVertexCounts) - maxVertexID))
                         }
                     }
                 }
@@ -1809,7 +1818,6 @@ splitVertices <- function(var2vertexID, unrolledBUGSindices, indexExprs = NULL, 
         }
     }
     list(var2vertexID = var2vertexID, nextVertexID = nextVertexID)
-    
 }
 
 collectInferredVertexEdges <- function(var2nodeID, var2vertexID) {

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -1680,7 +1680,8 @@ splitVertices <- function(var2vertexID, unrolledBUGSindices, indexExprs = NULL, 
         currentVertexCounts <- rep(0, maxVertexID)
     else
       currentVertexCounts <- tabulate(var2vertexID, max(max(var2vertexID, na.rm = TRUE), maxVertexID))
-     if(nextVertexID > length(currentVertexCounts)) currentVertexCounts <- append(currentVertexCounts, rep(0, length(currentVertexCounts) - maxVertexID))
+    if(nextVertexID > length(currentVertexCounts))
+      currentVertexCounts <- append(currentVertexCounts, rep(0, nextVertexID - length(currentVertexCounts)))
     ## 5. Set up initial table of vertexIDcounts
 
     ## 6. All scalar case: iterate or vectorize via cbind and put new vertexIDs over -1s
@@ -1745,7 +1746,8 @@ splitVertices <- function(var2vertexID, unrolledBUGSindices, indexExprs = NULL, 
         if(numNewVertexIDs > 0) {
             var2vertexID[varIndicesToUse][needsVertexID] <- nextVertexID - 1 + 1:numNewVertexIDs
             nextVertexID <- nextVertexID + numNewVertexIDs
-            if(nextVertexID > length(currentVertexCounts)) currentVertexCounts <- append(currentVertexCounts, rep(0, length(currentVertexCounts) - maxVertexID))
+            if(nextVertexID > length(currentVertexCounts))
+              currentVertexCounts <- append(currentVertexCounts, rep(0, nextVertexID - length(currentVertexCounts)))
         }
         ## Still need to look for splits on other existing vertexIDs
         oldIndices <- !needsVertexID
@@ -1758,7 +1760,8 @@ splitVertices <- function(var2vertexID, unrolledBUGSindices, indexExprs = NULL, 
         if(numNeedSplit > 0) {
             var2vertexID[varIndicesToUse][ oldIndices][needsSplit] <- nextVertexID - 1 + 1:numNeedSplit
             nextVertexID <- nextVertexID + numNeedSplit
-            if(nextVertexID > length(currentVertexCounts)) currentVertexCounts <- append(currentVertexCounts, rep(0, length(currentVertexCounts) - maxVertexID))
+            if(nextVertexID > length(currentVertexCounts))
+               currentVertexCounts <- append(currentVertexCounts, rep(0, nextVertexID - length(currentVertexCounts)))
         }
         ## This can result in skips, e.g. if a previous BUGSdecl labeled a vector with a new vectorID, and that now gets split in scalar vectorID labels
         ## Then the earlier vectorID will be gone forever
@@ -1791,7 +1794,8 @@ splitVertices <- function(var2vertexID, unrolledBUGSindices, indexExprs = NULL, 
              #       updatedVertexIDblock <- eval(accessExpr)
              #       currentVertexCounts[nextVertexID] <- currentVertexCounts[nextVertexID] + sum(updatedVertexIDblock == nextVertexID) ## should be all of the elements, so summing the size of the block
                     nextVertexID <- nextVertexID + 1
-                    if(nextVertexID > length(currentVertexCounts)) currentVertexCounts <- append(currentVertexCounts, rep(0, length(currentVertexCounts) - maxVertexID))
+                    if(nextVertexID > length(currentVertexCounts))
+                       currentVertexCounts <- append(currentVertexCounts, rep(0, nextVertexID - length(currentVertexCounts)))
                 }
             } else { ## need to iterate through IDs
                 for(VID in uniqueCurrentVertexIDs) {
@@ -1800,7 +1804,8 @@ splitVertices <- function(var2vertexID, unrolledBUGSindices, indexExprs = NULL, 
                         currentVertexIDblock[ boolIsNA ] <- nextVertexID
                         currentVertexCounts[nextVertexID] <- currentVertexCounts[nextVertexID] + sum(boolIsNA)
                         nextVertexID <- nextVertexID + 1
-                        if(nextVertexID > length(currentVertexCounts)) currentVertexCounts <- append(currentVertexCounts, rep(0, length(currentVertexCounts) - maxVertexID))
+                        if(nextVertexID > length(currentVertexCounts))
+                           currentVertexCounts <- append(currentVertexCounts, rep(0, nextVertexID - length(currentVertexCounts)))
                     } else {
                         boolWithinBlock <- currentVertexIDblock == VID
                         numWithinBlock <- sum(boolWithinBlock, na.rm = TRUE)
@@ -1809,7 +1814,8 @@ splitVertices <- function(var2vertexID, unrolledBUGSindices, indexExprs = NULL, 
                             currentVertexCounts[VID] <- currentVertexCounts[VID] - numWithinBlock
                             currentVertexCounts[nextVertexID] <- currentVertexCounts[nextVertexID] + numWithinBlock
                             nextVertexID <- nextVertexID + 1
-                            if(nextVertexID > length(currentVertexCounts)) currentVertexCounts <- append(currentVertexCounts, rep(0, length(currentVertexCounts) - maxVertexID))
+                            if(nextVertexID > length(currentVertexCounts))
+                                 currentVertexCounts <- append(currentVertexCounts, rep(0, nextVertexID - length(currentVertexCounts)))
                         }
                     }
                 }

--- a/packages/nimble/tests/testthat/test-models.R
+++ b/packages/nimble/tests/testthat/test-models.R
@@ -996,6 +996,19 @@ test_that("bad size or dimension of initial values", {
 
 })
 
+test_that("Example of splitVertices bug from Issue 1268 works.", {
+  code <- nimbleCode({
+    for (i in 1:2) {
+      for (j in 1:2){
+        b[i,j] <- X[i, index[j]]
+      }
+    }
+    for (i in 1:2) {
+      y[i] <- sum(a[1:2, index[i]])
+    }
+  })
+  expect_no_error(Rmodel <- nimbleModel(code, constants = list(index=c(1,1))))
+})
 
 options(warn = RwarnLevel)
 nimbleOptions(verbose = nimbleVerboseSetting)


### PR DESCRIPTION
Issue #1268 gives a corner case where `splitVertices` breaks, resulting in failure to build a very simple model.

The cases covered by `splitVertices` are quite varied, and the code is not simple, and it has not had problems in a long time, and we have a longer-term development effort to renovate how we handle graphical model relationships.  For these reasons, the intention here is as simple a fix as possible.

The details are as follows.  There is a `maxVertexID` determined early on in model building that attempts to be an upper bound on the possible number of graph vertices (i.e. nodes) needed for a model.  A vector of that length is then used to track how many scalar elements correspond to each vertex.  It turns out sometimes `splitVertices` results in skipping vertex IDs, with the result that a vertexID could end up larger than the `maxVertexID`, but it would be rare for it to happen (as in Issue #1268).  The `maxVertexID` logic wasn't wrong, but to strictly ensure that no vertexID is larger than it, we would have to go in and handle any cases where skipping occurs so that it would never occur.  This would be a pain and involve careful rethinking that would not be productive for code that is on the way out anyway.  Instead I have made a proposed fix that simply checks if an indexID gets larger than what is already being tracked and extends the tracking vector if necessary.  I think this is a minimal fix and we will see what testing turns up. 

Note that in any case, the vertexIDs at issue are only temporary, as they are before topological sorting, so any skipped indices do get cleaned up at a later stage of model building.

I also have a slightly more involved additional fix that could reduce some of the index-skipping behavior, and I might like to see if it passes tests, but even if it does there might be a case for omitting it to stick to the absolute simplest fix right now, even inelegant as it is.
