### PR TITLE
fix issue 1285

### DIFF
--- a/packages/nimble/DESCRIPTION
+++ b/packages/nimble/DESCRIPTION
@@ -40,6 +40,7 @@ Imports:
 Suggests:
     testthat
 URL: https://r-nimble.org, https://github.com/nimble-dev/nimble
+BugReports: https://github.com/nimble-dev/nimble/issues
 SystemRequirements: GNU make
 License: BSD_3_clause + file LICENSE | GPL (>= 2)
 Copyright: See COPYRIGHTS file.

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -2148,7 +2148,7 @@ modelDefClass$methods(genExpandedNodeAndParentNames3 = function(debug = FALSE) {
 
                 BUGSdecl$replacementsEnv[['logProbIDs']] <- newLogProbNames
                 BUGSdecl$replacementsEnv[[lhsVar]] <- vars2LogProbName[[lhsVar]]
-                eval(forCode, envir = BUGSdecl$replacementsEnv, silent = TRUE)
+                result <- try(eval(forCode, envir = BUGSdecl$replacementsEnv), silent = TRUE)
                 if(is(result, 'try-error')) {
                     msg <- paste0("Cannot process code `", safeDeparse(forCode), "`.")
                     varsFound <- all.vars(forCode) %in% ls(BUGSdecl$replacementsEnv)

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -2070,7 +2070,16 @@ modelDefClass$methods(genExpandedNodeAndParentNames3 = function(debug = FALSE) {
                 ## make a line of code to evaluate in the replacementsEnv
                 forCode <- substitute( for(iAns in 1:OUTPUTSIZE) ASSIGNCODE <- origIDs[iAns], list(OUTPUTSIZE = BUGSdecl$outputSize, ASSIGNCODE = IDassignCode) )
                 BUGSdecl$replacementsEnv[[lhsVar]] <- vars_2_nodeOrigID[[lhsVar]]
-                eval(forCode, envir = BUGSdecl$replacementsEnv)
+                result <- try(eval(forCode, envir = BUGSdecl$replacementsEnv), silent = TRUE)
+                if(is(result, 'try-error')) {
+                    msg <- paste0("Cannot process code `", safeDeparse(forCode), "`.")
+                    varsFound <- all.vars(forCode) %in% ls(BUGSdecl$replacementsEnv)
+                    if(!all(varsFound))
+                        msg <- paste0(msg, " Missing variable(s): `",
+                                     paste0(all.vars(forCode)[!varsFound], collapse = "`, "),
+                                     "`.")
+                    stop(msg)                
+                }
                 vars_2_nodeOrigID[[lhsVar]] <- BUGSdecl$replacementsEnv[[lhsVar]]
                 rm(list = lhsVar, envir = BUGSdecl$replacementsEnv)
             } else {
@@ -2139,7 +2148,16 @@ modelDefClass$methods(genExpandedNodeAndParentNames3 = function(debug = FALSE) {
 
                 BUGSdecl$replacementsEnv[['logProbIDs']] <- newLogProbNames
                 BUGSdecl$replacementsEnv[[lhsVar]] <- vars2LogProbName[[lhsVar]]
-                eval(forCode, envir = BUGSdecl$replacementsEnv)
+                eval(forCode, envir = BUGSdecl$replacementsEnv, silent = TRUE)
+                if(is(result, 'try-error')) {
+                    msg <- paste0("Cannot process code `", safeDeparse(forCode), "`.")
+                    varsFound <- all.vars(forCode) %in% ls(BUGSdecl$replacementsEnv)
+                    if(!all(varsFound))
+                        msg <- paste0(msg, " Missing variable(s): `",
+                                     paste0(all.vars(forCode)[!varsFound], collapse = "`, "),
+                                     "`.")
+                    stop(msg)                
+                }
                 vars2LogProbName[[lhsVar]] <- BUGSdecl$replacementsEnv[[lhsVar]]
                 rm(list = c(lhsVar, 'logProbIDs'), envir = BUGSdecl$replacementsEnv)
             } else {

--- a/packages/nimble/R/genCpp_operatorLists.R
+++ b/packages/nimble/R/genCpp_operatorLists.R
@@ -86,7 +86,7 @@ reductionUnaryOperatorsEither <- c(reductionUnaryDoubleOperatorsEither,
 reductionUnaryOperatorsArray <- c('sd','var')
 reductionUnaryOperators <- c(reductionUnaryOperatorsEither,
                              reductionUnaryOperatorsArray)
-matrixSquareReductionOperators <- c('det','logdet','trace')
+matrixSquareReductionOperators <- c('det','logdet')
 reductionBinaryOperatorsEither <- c('inprod')
 reductionBinaryOperators <- reductionBinaryOperatorsEither
 


### PR DESCRIPTION
This catches a case (see issue #1285)  where in `genExpandedNodeAndParentNames3` the for loop code has variables not present in `BUGSdecl$replacementsEnv`.