### PR TITLE
lift nimNewArr if LHS of <- is not just a name

### DIFF
--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -967,15 +967,32 @@ sizeNimArrayGeneral <- function(code, symTab, typeEnv) {
                 asserts <- c(asserts, sizeInsertIntermediate(code, 1, symTab, typeEnv))
     }
 
-    if(!useNewMatrix) 
-        if(inherits(code$caller, 'exprClass'))
-            if(!(code$caller$name %in% assignmentOperators)) {
-                if(!is.null(code$caller$name)) {
-                    asserts <- c(asserts, sizeInsertIntermediate(code$caller, code$callerArgID, symTab, typeEnv))
-                }
-            } else
-                typeEnv$.ensureNimbleBlocks <- TRUE
-    
+    ## if(!useNewMatrix)
+    ##     if(inherits(code$caller, 'exprClass'))
+    ##         if(!(code$caller$name %in% assignmentOperators)) {
+    ##             if(!is.null(code$caller$name)) {
+    ##                 asserts <- c(asserts, sizeInsertIntermediate(code$caller, code$callerArgID, symTab, typeEnv))
+    ##             }
+    ##         } else
+    ##             typeEnv$.ensureNimbleBlocks <- TRUE
+
+    if(!useNewMatrix)
+      if(inherits(code$caller, 'exprClass')) {
+        liftNewArr <- FALSE
+        if(!is.null(code$caller$name)) {
+          if(!(code$caller$name %in% assignmentOperators)) {
+            liftNewArr <- TRUE
+          } else {
+            if(!isTRUE(code$caller$args[[1]]$isName))
+              liftNewArr <- TRUE
+          }
+        }
+        if(liftNewArr)
+          asserts <- c(asserts, sizeInsertIntermediate(code$caller, code$callerArgID, symTab, typeEnv))
+        else
+          typeEnv$.ensureNimbleBlocks <- TRUE
+      }
+
     return(asserts)
 }
 


### PR DESCRIPTION
Fixes #1234 

This fixes cases like

```
a[1:4] <- numeric(2)
```

by lifting the new vector (in general array) before assigning into the block of a. The issue is that the LHS is a block, not a full object. The fix is a small change in a heavily used piece of size processing, so the test suite will be important.