### PR TITLE
check for risky aliasing with nimbleFunction and nimbleList objects

### DIFF
--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -1817,7 +1817,7 @@ sizeAssignAfterRecursing <- function(code, symTab, typeEnv, NoEigenizeMap = FALS
         RHStype <- RHS$type
         RHSsizeExprs <- RHS$sizeExprs
     } else {
-        if(is.numeric(RHS) | is.logical(RHS)) {
+        if(is.numeric(RHS) || is.logical(RHS)) {
             RHSname = ''
             RHSnDim <- 0
             RHStype <- sizeProc_storage_mode(RHS)
@@ -1833,7 +1833,7 @@ sizeAssignAfterRecursing <- function(code, symTab, typeEnv, NoEigenizeMap = FALS
             stop(exprClassProcessingErrorMsg(code, "In sizeAssignAfterRecursing: don't know what to do with a provided expression."), call. = FALSE)
         }
     }
-    if(is.null(RHStype) | length(RHStype)==0) {
+    if(is.null(RHStype) || length(RHStype)==0) {
         stop(exprClassProcessingErrorMsg(code, paste0("In sizeAssignAfterRecursing: '", RHSname, "' is not available or its output type is unknown.")), call. = FALSE)
     }
     if(LHS$isName) {
@@ -1904,7 +1904,7 @@ sizeAssignAfterRecursing <- function(code, symTab, typeEnv, NoEigenizeMap = FALS
     ## update size info in typeEnv
     assert <- NULL
 
-    if((LHS$name == 'values' | LHS$name == 'valuesIndexRange') && length(LHS$args) %in% c(1,2)) { ## It is values(model_values_accessor[, index]) <- STUFF
+    if((LHS$name == 'values' || LHS$name == 'valuesIndexRange') && length(LHS$args) %in% c(1,2)) { ## It is values(model_values_accessor[, index]) <- STUFF
         # triggered when we have simple assignment into values() without indexing of values()
         if(is.numeric(RHS)) stop(exprClassProcessingErrorMsg(code, paste0('In sizeAssignAfterRecursing: Cannot assign into values() from numeric.')), call. = FALSE)
         code$name <- if(LHS$name == 'values') 'setValues' else 'setValuesIndexRange' 
@@ -1928,7 +1928,7 @@ sizeAssignAfterRecursing <- function(code, symTab, typeEnv, NoEigenizeMap = FALS
         code$toEigenize <-if(inherits(RHS, 'exprClass')) {
             if(RHS$toEigenize == 'no') 'no' else {
                 if(RHS$toEigenize == 'unknown') 'no' else {
-                    if(RHS$toEigenize != 'yes' & (!(LHS$name %in% c('eigenBlock', 'diagonal', 'coeffSetter'))) & (RHS$nDim == 0 | RHS$isName | (RHS$name == 'map' & NoEigenizeMap))) 'no' ## if it is scalar or is just a name or a map, we will do it via NimArr operator= .  Used to have "| RHS$name == 'map'", but this allowed X[1:3] <- X[2:4], which requires eigen, with eval triggered, to get right
+                    if(RHS$toEigenize != 'yes' && (!(LHS$name %in% c('eigenBlock', 'diagonal', 'coeffSetter'))) && (RHS$isName || RHS$nDim == 0 || (RHS$name == 'map' && NoEigenizeMap))) 'no' ## if it is scalar or is just a name or a map, we will do it via NimArr operator= .  Used to have "| RHS$name == 'map'", but this allowed X[1:3] <- X[2:4], which requires eigen, with eval triggered, to get right
                     else 'yes' ## if it is 'maybe' and non-scalar and not just a name, default to 'yes'
                 }
             }
@@ -1949,7 +1949,7 @@ sizeAssignAfterRecursing <- function(code, symTab, typeEnv, NoEigenizeMap = FALS
         }
         if(RHSnDim > 0) {
             if(!(RHS$name %in% setSizeNotNeededOperators)) {
-                if(LHS$isName | LHS$name == "nfVar") {
+                if(LHS$isName || LHS$name == "nfVar") {
                     assert <- substitute(setSize(LHS), list(LHS = nimbleGeneralParseDeparse(LHS)))
                     for(i in seq_along(RHSsizeExprs)) {
                         test <- try(assert[[i + 2]] <- RHS$sizeExprs[[i]])
@@ -1969,7 +1969,7 @@ sizeAssignAfterRecursing <- function(code, symTab, typeEnv, NoEigenizeMap = FALS
                                     newExpr$sizeExprs <- RHS$sizeExprs 
                                     newExpr$type <- LHS$type
                                     newExpr$nDim <- RHS$nDim
-                                    if(!is.numeric(LHS$sizeExprs[[1]]) | !is.numeric(RHS$sizeExprs[[2]])) {
+                                    if(!is.numeric(LHS$sizeExprs[[1]]) || !is.numeric(RHS$sizeExprs[[2]])) {
                                         assertMessage <- paste0("Run-time size error: expected ", deparse(LHS$sizeExprs[[1]]), " == ", deparse(RHS$sizeExprs[[2]]))
                                         thisAssert <- identityAssert(LHS$sizeExprs[[1]], RHS$sizeExprs[[2]], assertMessage)
                                         if(!is.null(thisAssert)) assert[[length(assert) + 1]] <- thisAssert 

--- a/packages/nimble/R/nimbleFunction_keywordProcessing.R
+++ b/packages/nimble/R/nimbleFunction_keywordProcessing.R
@@ -533,7 +533,7 @@ doubleBracket_keywordInfo <- keywordInfoClass(
           #  myNimbleList[['myVar']]
           nl_charName <- as.character(callerCode)
           nl_fieldName <-as.character(code[[3]])
-          newRunCode <- substitute(nlVar(NIMBLELIST, VARNAME), list(NIMBLELIST = as.name(nl_charName), VARNAME = nl_fieldName))
+          newRunCode <- substitute(nfVar(NIMBLELIST, VARNAME), list(NIMBLELIST = as.name(nl_charName), VARNAME = nl_fieldName))
           return(newRunCode)
         }
         if(class == 'symbolModel'){

--- a/packages/nimble/tests/testthat/test-nimbleList.R
+++ b/packages/nimble/tests/testthat/test-nimbleList.R
@@ -1346,6 +1346,49 @@ test_that("nimbleList test use of [[", {
     expect_identical(is.nl(CnimbleList), TRUE)
 })
 
+test_that("Assignment of list object to list object works (Issue 1246) a", {
+  nl <- nimbleList(A = double(1))
+  temporarilyAssignInGlobalEnv(nl)
+
+  foo <- nimbleFunction(
+    setup <- function(A) {
+      my_nl <- nl$new()
+      my_nl$A <- A
+    },
+    run = function() {
+      my_nl$A <<- my_nl$A[1:3]
+      return(my_nl$A)
+      returnType(double(1))
+    }
+  )
+
+  foo1 <- foo(as.numeric(1:10))
+  cfoo <- compileNimble(foo1)
+  expect_equal(cfoo$run(), 1:3)
+})
+
+test_that("Assignment of list object to list object works (Issue 1246) b", {
+  nl <- nimbleList(A = double(1))
+  temporarilyAssignInGlobalEnv(nl)
+
+  foo <- nimbleFunction(
+    setup <- function(A) {
+      my_nl <- nl$new()
+      my_nl$A <- A
+      my_nl2 <- my_nl
+    },
+    run = function() {
+      my_nl2$A <<- my_nl$A[1:3]
+      return(my_nl$A)
+      returnType(double(1))
+    }
+  )
+
+  foo1 <- foo(as.numeric(1:10))
+  cfoo <- compileNimble(foo1)
+  expect_equal(cfoo$run(), 1:3)
+})
+
 options(warn = RwarnLevel)
 nimbleOptions(verbose = nimbleVerboseSetting)
 


### PR DESCRIPTION
Fixes #1246 

This fix puts a check in assignment operations for aliasing like `nf$a <- nf$a[1:3]`.

Because the changes will touch compiler processing of any assignment operation, the test suite will be important.  Let's see what happens.