### PR TITLE
remove cxx11 stuff from Linux/Mac files

### DIFF
--- a/packages/nimble/configure
+++ b/packages/nimble/configure
@@ -2114,11 +2114,14 @@ if test -n "$EIGEN_DIR" && ! test "${EIGEN_DIR}" = "" ; then
    export CPPFLAGS="-I${EIGEN_DIR}"
 fi
 
+CXX=`"${R_HOME}/bin/R" CMD config CXX`
+if test -z "$CXX"; then
+  as_fn_error $? "No C++ compiler is available" "$LINENO" 5
+fi
+CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
+CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 
-CXX11=`"${R_HOME}/bin/R" CMD config CXX11`
-CXX11STD=`"${R_HOME}/bin/R" CMD config CXX11STD`
-CXX="${CXX11} ${CXX11STD}"
-CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXX11FLAGS`
+
 ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'
 ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'

--- a/packages/nimble/configure.ac
+++ b/packages/nimble/configure.ac
@@ -123,13 +123,21 @@ if test -n "$EIGEN_DIR" && ! test "${EIGEN_DIR}" = "" ; then
    export CPPFLAGS="-I${EIGEN_DIR}"
 fi
 
+dnl Next set of lines from https://cran.r-project.org/doc/manuals/r-release/R-exts.html in light of new CRAN policy to not hard code CXX11
+CXX=`"${R_HOME}/bin/R" CMD config CXX`
+if test -z "$CXX"; then
+  AC_MSG_ERROR([No C++ compiler is available])
+fi
+CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
+CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 
 dnl Next 5 lines are from from https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Using-C_002b_002b11-code, but with CXX11 modified to CXX1X per output of R CMD config
 dnl 2018-07-25: now modified to CXX11 as that seems to be standard on more recent R versions
-CXX11=`"${R_HOME}/bin/R" CMD config CXX11`
-CXX11STD=`"${R_HOME}/bin/R" CMD config CXX11STD`
-CXX="${CXX11} ${CXX11STD}"
-CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXX11FLAGS`
+dnl CXX11=`"${R_HOME}/bin/R" CMD config CXX11`
+dnl CXX11STD=`"${R_HOME}/bin/R" CMD config CXX11STD`
+dnl CXX="${CXX11} ${CXX11STD}"
+dnl CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXX11FLAGS`
+
 AC_LANG(C++)
 dnl 2018-07-25: moved next line from early in this file because it seems to trigger various configure checks based on g++ even when R is configured to use clang; see issue 766
 dnl however note that having it here seems extraneous as it produces same configure file without it

--- a/packages/nimble/inst/make/Makevars.in
+++ b/packages/nimble/inst/make/Makevars.in
@@ -19,6 +19,6 @@ ifndef NIMBLE_LIB_DIR
 NIMBLE_LIB_DIR=@NIMBLE_LIB_DIR@
 endif
 
-PKG_CPPFLAGS= -DR_NO_REMAP $(CPPAD_INC) $(EIGEN_INC) -DEIGEN_MPL2_ONLY=1 -I"$(NIMBLE_INC_DIR)" -Wno-misleading-indentation -Wno-ignored-attributes -Wno-deprecated-declarations -std=c++11
+PKG_CPPFLAGS= -DR_NO_REMAP $(CPPAD_INC) $(EIGEN_INC) -DEIGEN_MPL2_ONLY=1 -I"$(NIMBLE_INC_DIR)" -Wno-misleading-indentation -Wno-ignored-attributes -Wno-deprecated-declarations
 PKG_LIBS=-L"$(NIMBLE_LIB_DIR)" -lnimble  $(LAPACK_LIBS) $(BLAS_LIBS) 
 

--- a/packages/nimble/inst/make/Makevars_lib.in
+++ b/packages/nimble/inst/make/Makevars_lib.in
@@ -30,6 +30,6 @@ ifndef RPATH
 RPATH=@RPATH@
 endif
 
-PKG_CPPFLAGS= -DR_NO_REMAP $(EIGEN_INC) $(CPPAD_INC) -DEIGEN_MPL2_ONLY=1 -I"$(NIMBLE_INC_DIR)" -Wno-misleading-indentation -Wno-ignored-attributes -Wno-deprecated-declarations -std=c++11
+PKG_CPPFLAGS= -DR_NO_REMAP $(EIGEN_INC) $(CPPAD_INC) -DEIGEN_MPL2_ONLY=1 -I"$(NIMBLE_INC_DIR)" -Wno-misleading-indentation -Wno-ignored-attributes -Wno-deprecated-declarations
 NIMBLE_LIB_DIR="$(NIMBLE_DIR)/CppCode"
 PKG_LIBS=-L"$(NIMBLE_LIB_DIR)"  -lnimble $(RPATH) $(LAPACK_LIBS) $(BLAS_LIBS) 

--- a/run_tests.R
+++ b/run_tests.R
@@ -48,8 +48,9 @@ if (length(grep('^-', argv, invert = TRUE))) {
         'test-ADdists.R',
         'test-ADfunctions.R',
         'test-ADmodels.R',
-        'test-ADmodels-bigmv.R')
-        ## 'test-benchmarks.R')  # some issue with version conflicts causing tensorflow to fail on Travis with errors such as 'nimble-tensorflow_11_20_18_17_45.so: undefined symbol: TF_DeleteImportGraphDefOptions'
+        'test-ADmodels-bigmv.R',
+        'test-ADlaplace.R')  ## temporary
+         ## 'test-benchmarks.R')  # some issue with version conflicts causing tensorflow to fail on Travis with errors such as 'nimble-tensorflow_11_20_18_17_45.so: undefined symbol: TF_DeleteImportGraphDefOptions'
     cat('SKIPPING', omitlist, sep = '\n  ')
     allTests <- setdiff(allTests, omitlist)
     smcTests <- 'test-filtering.R'


### PR DESCRIPTION
This tests whether removal of cxx11 stuff from non-Windows-specific configuration files (`configure{,.ac}, inst/make/Makevars*in` causes problems. This includes removing hard-coded `-std=c++11`.

Initial basic testing indicates things are fine.

Note that I've temporarily removed `test-ADlaplace.R` from GHA testing so that the rest of the tests in that set run.