### PR TITLE
replace-ptr_fun

### DIFF
--- a/packages/nimble/R/genCpp_generateCpp.R
+++ b/packages/nimble/R/genCpp_generateCpp.R
@@ -413,7 +413,7 @@ cppOutputEigExternalUnaryFunction <- function(code, symTab) {
     }
     paste0(
       '(', nimGenerateCpp(code$args[[1]], symTab),
-      ').unaryExpr(std::ptr_fun<',info2,', ',info3,'>(', info1, '))'
+      ').unaryExpr(std::function< ', info3,'(',info2,') >( static_cast<',info3 ,' (*)(' ,info2 , ')>(&', info1, ')))'
     )
 }
 
@@ -439,7 +439,7 @@ cppOutputEigMemberFunctionNoTranslate_specialAD <- function(code, symTab) {
         return(cppOutputEigMemberFunctionNoTranslate(code, symTab))
     paste0(
         '(', nimGenerateCpp(code$args[[1]], symTab),
-        ').unaryExpr(std::ptr_fun<CppAD::AD<double>, CppAD::AD<double> >(nimDerivs_fabs))')
+        ').unaryExpr(std::function<CppAD::AD<double>(CppAD::AD<double>) >( static_cast<CppAD::AD<double> (*)(CppAD::AD<double>) >(&nimDerivs_fabs)))')
 }
 
 cppOutputMemberFunctionDeref <- function(code, symTab) {

--- a/packages/nimble/inst/CppCode/nimDerivs_atomic_classes_temp.cpp
+++ b/packages/nimble/inst/CppCode/nimDerivs_atomic_classes_temp.cpp
@@ -325,7 +325,7 @@ bool atomic_lgamma_class::forward(
     std::cout<<"atomic info:"<<CppAD::local::atomic_index_info_vec_manager_nimble<double>::manage()<<"\n";
   }
      if((order_low <= 0) && (order_up >= 0)) {
-       taylor_y[0] = nimDerivs_lgammafn_base(taylor_x[0], baseOrder, verbose); // This puts it in the new tape being recorded
+       taylor_y[0] = nimDerivs_lgammafn(taylor_x[0], baseOrder, verbose); // This puts it in the new tape being recorded
 	  if(verbose) {
 	    std::cout<<"taylor_y[0] "<<CppAD::Value(taylor_y[0])<<" ";
 	  }
@@ -335,7 +335,7 @@ bool atomic_lgamma_class::forward(
      
      CppAD::AD<double> fprime;
      if((order_low <= 2) && (order_up >= 1)) {
-       fprime = nimDerivs_lgammafn_base(taylor_x[0], baseOrder+1, verbose);
+       fprime = nimDerivs_lgammafn(taylor_x[0], baseOrder+1, verbose);
 	  if(verbose) std::cout<<"fprime "<<CppAD::Value(fprime)<<" ";
      }
      if((order_low <= 1) && (order_up >= 1)) {
@@ -343,7 +343,7 @@ bool atomic_lgamma_class::forward(
 	  if(verbose) std::cout<<"taylor_x[1] "<<CppAD::Value(taylor_x[1])<<" taylor_y[1] "<<CppAD::Value(taylor_y[1])<<" ";
      }
      if((order_low <= 2) && (order_up >= 2)) {
-       taylor_y[2] = 0.5 * (nimDerivs_lgammafn_base(taylor_x[0], baseOrder+2, verbose) * taylor_x[1] * taylor_x[1] +
+       taylor_y[2] = 0.5 * (nimDerivs_lgammafn(taylor_x[0], baseOrder+2, verbose) * taylor_x[1] * taylor_x[1] + 
 			       fprime * 2 * taylor_x[2]);
 	  if(verbose) std::cout<<"taylor_x[2] "<<CppAD::Value(taylor_x[2])<<" taylor_y[2] "<<CppAD::Value(taylor_y[2])<<" ";
      }
@@ -368,11 +368,11 @@ bool atomic_lgamma_class::reverse(
 
   partial_x[0] = CppAD::AD<double>(0);
      if(order_up >= 1) partial_x[1] = CppAD::AD<double>(0);
-     CppAD::AD<double> fprime = nimDerivs_lgammafn_base(taylor_x[0], baseOrder+1, verbose);
+     CppAD::AD<double> fprime = nimDerivs_lgammafn(taylor_x[0], baseOrder+1, verbose);
      if(verbose) std::cout<<"fprime "<<CppAD::Value(fprime)<<" ";
      if(order_up >= 1) {
 	  partial_x[1] += partial_y[1] * fprime;
-	  partial_x[0] += partial_y[1] * nimDerivs_lgammafn_base(taylor_x[0], baseOrder+2, verbose) * taylor_x[1];
+	  partial_x[0] += partial_y[1] * nimDerivs_lgammafn(taylor_x[0], baseOrder+2, verbose) * taylor_x[1];
 	  if(verbose) std::cout<<"partial_x[1] "<<CppAD::Value(partial_x[1])<<" first step of partial_x[0] "<<CppAD::Value(partial_x[0])<<" ";
      }
      partial_x[0] += partial_y[0] * fprime;
@@ -383,7 +383,7 @@ bool atomic_lgamma_class::reverse(
      return true;
 }
 
-CppAD::AD<double> nimDerivs_lgammafn_base(CppAD::AD<double> x, int baseOrder, bool verbose) {
+CppAD::AD<double> nimDerivs_lgammafn(CppAD::AD<double> x, int baseOrder, bool verbose) {
   if(verbose) {
     return nimDerivs_lgammafn_verbose(x, baseOrder);
   }
@@ -422,7 +422,7 @@ CppAD::AD<double> nimDerivs_lgammafn_base(CppAD::AD<double> x, int baseOrder, bo
 }
 
 CppAD::AD<double> nimDerivs_lgammafn(CppAD::AD<double> x) {
-  return nimDerivs_lgammafn_base(x, 0); // a relic of a problem with default value when writing this previously using templates.
+  return nimDerivs_lgammafn(x, 0); // a relic of a problem with default value when writing this previously using templates.
 }
 
 /***************************************/
@@ -513,7 +513,7 @@ bool atomic_gammafn_class::forward(
   }
   CppAD::AD<double> lgamma_prime;
   if((order_low <= 2) && (order_up >= 1)) {
-    lgamma_prime = nimDerivs_lgammafn_base(taylor_x[0], 1);
+    lgamma_prime = nimDerivs_lgammafn(taylor_x[0], 1);
   }
   if((order_low <= 1) && (order_up >= 1)) {
     taylor_y[1] = lgamma_prime * taylor_y[0] * taylor_x[1];
@@ -521,7 +521,7 @@ bool atomic_gammafn_class::forward(
   }
   if((order_low <= 2) && (order_up >= 2)) {
     taylor_y[2] = 0.5 * taylor_y[0] *
-      ((nimDerivs_lgammafn_base(taylor_x[0], 2) + lgamma_prime*lgamma_prime) * taylor_x[1] * taylor_x[1] +
+      ((nimDerivs_lgammafn(taylor_x[0], 2) + lgamma_prime*lgamma_prime) * taylor_x[1] * taylor_x[1] + 
        lgamma_prime * 2 * taylor_x[2]);
     if(verbose) std::cout<<"taylor_x[2] "<<CppAD::Value(taylor_x[2])<<" taylor_y[2] "<<CppAD::Value(taylor_y[2])<<" ";
   }
@@ -541,12 +541,12 @@ bool atomic_gammafn_class::reverse(
   bool verbose = false;
   partial_x[0] = CppAD::AD<double>(0);
   if(order_up >= 1) partial_x[1] = CppAD::AD<double>(0);
-  CppAD::AD<double> lgamma_prime = nimDerivs_lgammafn_base(taylor_x[0], 1);
+  CppAD::AD<double> lgamma_prime = nimDerivs_lgammafn(taylor_x[0], 1);
   CppAD::AD<double>  fprime = lgamma_prime * taylor_y[0];
   if(verbose) std::cout<<"fprime "<<CppAD::Value(fprime)<<" ";
   if(order_up >= 1) {
     partial_x[1] += partial_y[1] * fprime;
-    CppAD::AD<double> fprimeprime = (nimDerivs_lgammafn_base(taylor_x[0], 2) + lgamma_prime * lgamma_prime) * taylor_y[0];
+    CppAD::AD<double> fprimeprime = (nimDerivs_lgammafn(taylor_x[0], 2) + lgamma_prime * lgamma_prime) * taylor_y[0];
     partial_x[0] += partial_y[1] * fprimeprime * taylor_x[1];
     if(verbose) std::cout<<"partial_x[1] "<<CppAD::Value(partial_x[1])<<" first step of partial_x[0] "<<CppAD::Value(partial_x[0])<<" ";
   }

--- a/packages/nimble/inst/include/nimble/Utils.h
+++ b/packages/nimble/inst/include/nimble/Utils.h
@@ -171,16 +171,27 @@ static inline bool isTRUE(bool x) {return(x);}
 
 double pow_int(double a, double b);
 
+// All the nimDerivs_FOO functions
+// were templated, but in a rush we
+// had to change some generated code to
+// std::function< CppAD::AD<double>(CppAD::AD<double) >( nimDerivs_FOO )
+// That does not do template type inference. And there are cases
+// where nimDerivs_FOO is not a template.
+// Quick solution is to remove the templating here, since
+// in practice T is always CppAD::AD<double>, and get that
+// hard-wired in.  There is an #undef at the end.
+#define T CppAD::AD<double>
+
 // needed for link functions
 double ilogit(double x);
-template<class T>
-T nimDerivs_ilogit(T x){
+//template<class T>
+inline T nimDerivs_ilogit(T x){
   return(1./(1. + exp(-x)));
 }
 
 double icloglog(double x);
-template<class T>
-T nimDerivs_icloglog(T x){
+//template<class T>
+inline T nimDerivs_icloglog(T x){
   return(1.-exp(-exp(x)));
 }
 
@@ -189,14 +200,14 @@ double probit(double x);
 
 //double abs(double x);
 double cloglog(double x);
-template<class T>
-T nimDerivs_cloglog(T x){
+//template<class T>
+inline T nimDerivs_cloglog(T x){
   return(log(-log(T(1) - x)));
 }
 
 int nimEquals(double x1, double x2);
-template<class T>
-T nimDerivs_nimEquals(T x1, T x2){
+//template<class T>
+inline T nimDerivs_nimEquals(T x1, T x2){
   return(CondExpEq(x1, x2, T(1), T(0))); 
 }
 
@@ -205,80 +216,80 @@ double lfactorial(double x);
 double factorial(double x);
 //double loggam(double x);
 double logit(double x);
-template<class T>
-T nimDerivs_logit(T x) {
+//template<class T>
+inline T nimDerivs_logit(T x) {
   return(log(x / (T(1)-x)));
 }
 
 double nimRound(double x);
 double pairmax(double x1, double x2);
-template<class T>
-T nimDerivs_pairmax(T x1, T x2) {
+//template<class T>
+inline T nimDerivs_pairmax(T x1, T x2) {
   return(CondExpGt(x1, x2, x1, x2));
 }
 
 double pairmin(double x1, double x2);
-template<class T>
-T nimDerivs_pairmin(T x1, T x2) {
+//template<class T>
+inline T nimDerivs_pairmin(T x1, T x2) {
   return(CondExpLt(x1, x2, x1, x2));
 }
 
 //double phi(double x);
 int nimStep(double x); 
-template<class T>
-T nimDerivs_nimStep(T x){
+//template<class T>
+inline T nimDerivs_nimStep(T x){
 	return(CondExpGe(x, T(0), T(1), T(0)));
 } 
 
 double cube(double x);
-template<class T>
-T nimDerivs_cube(T x){
+//template<class T>
+inline T nimDerivs_cube(T x){
 	return(x*x*x);
 }
 
 double inprod(double v1, double v2);
-template<class T>
-T nimDerivs_inprod(T v1, T v2) {
+//template<class T>
+inline T nimDerivs_inprod(T v1, T v2) {
   return(v1*v2);
 }
 
-template<class T>
-T nimDerivs_atan(T x) {
+//template<class T>
+inline T nimDerivs_atan(T x) {
   return(CppAD::atan(x));
 }
 
-template<class T>
-T nimDerivs_cosh(T x) {
+//template<class T>
+inline T nimDerivs_cosh(T x) {
   return(CppAD::cosh(x));
 }
 
-template<class T>
-T nimDerivs_sinh(T x) {
+//template<class T>
+inline T nimDerivs_sinh(T x) {
   return(CppAD::sinh(x));
 }
 
-template<class T>
-T nimDerivs_tanh(T x) {
+//template<class T>
+inline T nimDerivs_tanh(T x) {
   return(CppAD::tanh(x));
 }
 
-template<class T>
-T nimDerivs_acosh(T x) {
+//template<class T>
+inline T nimDerivs_acosh(T x) {
   return(CppAD::acosh(x));
 }
 
-template<class T>
-T nimDerivs_asinh(T x) {
+//template<class T>
+inline T nimDerivs_asinh(T x) {
   return(CppAD::asinh(x));
 }
 
-template<class T>
-T nimDerivs_atanh(T x) {
+//template<class T>
+inline T nimDerivs_atanh(T x) {
   return(CppAD::atanh(x));
 }
 
-template<class T>
-T nimDerivs_log1p(T x) {
+//template<class T>
+inline T nimDerivs_log1p(T x) {
   return(CppAD::log1p(x));
 }
 
@@ -287,4 +298,7 @@ inline double nimble_NaN() {
     ? std::numeric_limits<double>::quiet_NaN()
     : (0./0.);
 }
+
+#undef T
+
 #endif

--- a/packages/nimble/inst/include/nimble/nimDerivs_atomic_classes.h
+++ b/packages/nimble/inst/include/nimble/nimDerivs_atomic_classes.h
@@ -20,7 +20,7 @@
 #include "nimDerivs_atomic_cache.h"
 #include "nimDerivs_atomic_probit.h"
 
-CppAD::AD<double> nimDerivs_lgammafn(CppAD::AD<double> x, int baseOrder, bool verbose = FALSE);
+CppAD::AD<double> nimDerivs_lgammafn_base(CppAD::AD<double> x, int baseOrder, bool verbose = FALSE);
 CppAD::AD<double> nimDerivs_lgammafn(CppAD::AD<double> x);
 
 class atomic_lgamma_class : public unary_atomic_class<double> {

--- a/packages/nimble/inst/include/nimble/nimDerivs_dists.h
+++ b/packages/nimble/inst/include/nimble/nimDerivs_dists.h
@@ -1031,7 +1031,7 @@ Type nimDerivs_nimArr_ddirch_logFixed(NimArr<1, Type> &x, NimArr<1, Type> &alpha
 /* The CondExp expressions may slow down CppAD tapes.*/
 //template<class Type>
 #define Type CppAD::AD<double>
-Type nimDerivs_pow(Type x, Type y) {
+inline Type nimDerivs_pow(Type x, Type y) {
 
   /* We experimented with CppAD conditionals but still had cases that 
      crashed or had constants baked into tapes when they shouldn't be
@@ -1055,13 +1055,13 @@ Type nimDerivs_pow(Type x, Type y) {
 
 // This may not longer ever be used from nimble-generated code.
 //template<class Type>
-Type nimDerivs_pow(Type x, int y) {
+inline Type nimDerivs_pow(Type x, int y) {
   Type outVal = nimDerivs_pow_int(x, y);
   return(outVal);
 }
 
 //template<class Type>
-Type nimDerivs_pow(Type x, double y) {
+inline Type nimDerivs_pow(Type x, double y) {
   Type outVal;
   if(fabs(y - round(y)) < 1e-8) // allows binary rounding error on computed indices
     outVal = nimDerivs_pow_int(x, round(y));
@@ -1087,19 +1087,19 @@ Type nimDerivs_pow(Type x, double y) {
 /* which is necessary because otherwise Eigen circumvents regular call to fabs. */
 #define T CppAD::AD<double>
 //template<class T>
-T nimDerivs_fabs(T x) {
+inline T nimDerivs_fabs(T x) {
   return fabs(x);
 }
 
 /* lfactorial */
 //template<class T>
-T nimDerivs_lfactorial(T x) {
+inline T nimDerivs_lfactorial(T x) {
   return nimDerivs_lgammafn(x + 1.);
 }
 
 /* factorial */
 //template<class Type>
-Type nimDerivs_factorial(Type x) {
+inline Type nimDerivs_factorial(Type x) {
   return nimDerivs_gammafn(x + 1.); // Even R does not restrict to x >= 0
 }
 #undef Type

--- a/packages/nimble/inst/include/nimble/nimDerivs_dists.h
+++ b/packages/nimble/inst/include/nimble/nimDerivs_dists.h
@@ -1029,7 +1029,8 @@ Type nimDerivs_nimArr_ddirch_logFixed(NimArr<1, Type> &x, NimArr<1, Type> &alpha
 /* If x > 0, do simple x^y.*/
 /* Otherwise, if y is not an integer, return NaN */
 /* The CondExp expressions may slow down CppAD tapes.*/
-template<class Type> 
+//template<class Type>
+#define Type CppAD::AD<double>
 Type nimDerivs_pow(Type x, Type y) {
 
   /* We experimented with CppAD conditionals but still had cases that 
@@ -1053,13 +1054,13 @@ Type nimDerivs_pow(Type x, Type y) {
 }
 
 // This may not longer ever be used from nimble-generated code.
-template<class Type> 
+//template<class Type>
 Type nimDerivs_pow(Type x, int y) {
   Type outVal = nimDerivs_pow_int(x, y);
   return(outVal);
 }
 
-template<class Type> 
+//template<class Type>
 Type nimDerivs_pow(Type x, double y) {
   Type outVal;
   if(fabs(y - round(y)) < 1e-8) // allows binary rounding error on computed indices
@@ -1084,22 +1085,25 @@ Type nimDerivs_pow(Type x, double y) {
 
 /* This seems necessary for use in Eigen unaryExpr via ptr_fun */
 /* which is necessary because otherwise Eigen circumvents regular call to fabs. */
-template<class T>
+#define T CppAD::AD<double>
+//template<class T>
 T nimDerivs_fabs(T x) {
   return fabs(x);
 }
 
 /* lfactorial */
-template<class T>
+//template<class T>
 T nimDerivs_lfactorial(T x) {
   return nimDerivs_lgammafn(x + 1.);
 }
 
 /* factorial */
-template<class Type> 
+//template<class Type>
 Type nimDerivs_factorial(Type x) {
   return nimDerivs_gammafn(x + 1.); // Even R does not restrict to x >= 0
 }
+#undef Type
+#undef T
 
 /* /\* gammafn *\/ */
 /* template<class Type> */


### PR DESCRIPTION
Do not merge.
Attempt to remove std::ptr_fun<> usages (deprecates) and replace with std::function<>.
There may be some special cases to clean up.