### PR TITLE
threshold dependency path counting used on conjugacy checking

### DIFF
--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -781,7 +781,7 @@ Details: This provides a fairly raw representation of the graph (model) structur
                                       }
                                   },
 
-                                  getDependencyPathCountOneNode = function(node) {
+                                  getDependencyPathCountOneNode = function(node, max = .Machine$integer.max) {
                                       if(length(node) > 1)
                                           stop("getDependencyPathCountOneNode: argument 'node' should provide a single node.")
                                       if(is.character(node)) {
@@ -789,7 +789,7 @@ Details: This provides a fairly raw representation of the graph (model) structur
                                       }
                                       if(!is.numeric(node))
                                           stop("getDependencyPathCountOneNode: argument 'node' should be a character node name or a numeric node ID.")
-                                      modelDef$maps$nimbleGraph$getDependencyPathCountOneNode(node = node)
+                                      modelDef$maps$nimbleGraph$getDependencyPathCountOneNode(node = node, max = max)
                                   },
 getDependencyPaths = function(node) {
     if(length(node) > 1)

--- a/packages/nimble/R/BUGS_nimbleGraph.R
+++ b/packages/nimble/R/BUGS_nimbleGraph.R
@@ -62,10 +62,10 @@ nimbleGraphClass <- setRefClass(
                 startDown,
                 unknownAsGiven)
         },
-        getDependencyPathCountOneNode = function(node) {
+        getDependencyPathCountOneNode = function(node, max = .Machine$integer.max) {
             if(length(node) > 1)
                 stop("getDependencyPathCountOneNode: argument 'node' should provide a single node.")
-            .Call(C_getDependencyPathCountOneNode, graphExtPtr, node)
+            .Call(C_getDependencyPathCountOneNode, graphExtPtr, node, max)
         },
         getDependencyPaths = function(node) {
             if(length(node) > 1)

--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -230,14 +230,14 @@ conjugacyRelationshipsClass <- setRefClass(
                 ## We only need check until we get to as many paths as `sumNumDeps`.
                 ## This also avoids integer overflow that can occur with recursive indexing.
                 for(nodeID in nodeIDsFromOneDecl) {
-                    numPaths <- model$getDependencyPathCountOneNode(nodeID, max = sumNumDeps)
+                    numPaths <- model$getDependencyPathCountOneNode(nodeID, max = sumNumDeps + 1)
                     if(numPaths > maxNumPaths)
                         maxNumPaths <- numPaths
-                    if(maxNumPaths >= sumNumDeps)
+                    if(maxNumPaths > sumNumDeps)
                         break
                 }
 
-                if(maxNumPaths >= sumNumDeps) {
+                if(maxNumPaths > sumNumDeps) {
                     # max(numPaths) is reasonable guess at number of unique (by node) paths (though it overestimates number of unique (by declaration ID) paths; if we have to evaluate conjugacy for more paths than we would by simply looking at all pairs of target-dependent nodes, then just use node pairs
                     # note that it's not clear what criterion to use here since computational time is combination of time for finding all paths and then for evaluating conjugacy for unique (by declaration ID) paths, but the hope is to make a crude cut here that avoids path calculations when there would be a lot of them
                     ansList[[length(ansList)+1]] <- lapply(seq_along(nodeIDsFromOneDecl),

--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -223,11 +223,20 @@ conjugacyRelationshipsClass <- setRefClass(
                 #    if(not conj) next
 
                 # now try to guess if finding paths will be more intensive than simply looking at target-dependent pairs, to avoid path finding when there is nested structure such as stickbreaking
-                numPaths <- sapply(nodeIDsFromOneDecl, model$getDependencyPathCountOneNode)
+
                 deps <- lapply(nodeIDsFromOneDecl, function(x) model$getDependencies(x, stochOnly = TRUE, self = FALSE))
                 numDeps <- sapply(deps, length)
+                sumNumDeps <- sum(numDeps)
+                maxNumPaths <- 0
+                for(nodeID in nodeIDsFromOneDecl) {
+                    numPaths <- model$getDependencyPathCountOneNode(nodeID, max = sumNumDeps)
+                    if(numPaths > maxNumPaths)
+                        maxNumPaths <- numPaths
+                    if(maxNumPaths >= sumNumDeps)
+                        break
+                }
 
-                if(max(numPaths) > sum(numDeps)) {
+                if(maxNumPaths >= sum(numDeps)) {
                     # max(numPaths) is reasonable guess at number of unique (by node) paths (though it overestimates number of unique (by declaration ID) paths; if we have to evaluate conjugacy for more paths than we would by simply looking at all pairs of target-dependent nodes, then just use node pairs
                     # note that it's not clear what criterion to use here since computational time is combination of time for finding all paths and then for evaluating conjugacy for unique (by declaration ID) paths, but the hope is to make a crude cut here that avoids path calculations when there would be a lot of them
                     ansList[[length(ansList)+1]] <- lapply(seq_along(nodeIDsFromOneDecl),

--- a/packages/nimble/R/MCMC_conjugacy.R
+++ b/packages/nimble/R/MCMC_conjugacy.R
@@ -223,11 +223,12 @@ conjugacyRelationshipsClass <- setRefClass(
                 #    if(not conj) next
 
                 # now try to guess if finding paths will be more intensive than simply looking at target-dependent pairs, to avoid path finding when there is nested structure such as stickbreaking
-
                 deps <- lapply(nodeIDsFromOneDecl, function(x) model$getDependencies(x, stochOnly = TRUE, self = FALSE))
                 numDeps <- sapply(deps, length)
                 sumNumDeps <- sum(numDeps)
                 maxNumPaths <- 0
+                ## We only need check until we get to as many paths as `sumNumDeps`.
+                ## This also avoids integer overflow that can occur with recursive indexing.
                 for(nodeID in nodeIDsFromOneDecl) {
                     numPaths <- model$getDependencyPathCountOneNode(nodeID, max = sumNumDeps)
                     if(numPaths > maxNumPaths)
@@ -236,7 +237,7 @@ conjugacyRelationshipsClass <- setRefClass(
                         break
                 }
 
-                if(maxNumPaths >= sum(numDeps)) {
+                if(maxNumPaths >= sumNumDeps) {
                     # max(numPaths) is reasonable guess at number of unique (by node) paths (though it overestimates number of unique (by declaration ID) paths; if we have to evaluate conjugacy for more paths than we would by simply looking at all pairs of target-dependent nodes, then just use node pairs
                     # note that it's not clear what criterion to use here since computational time is combination of time for finding all paths and then for evaluating conjugacy for unique (by declaration ID) paths, but the hope is to make a crude cut here that avoids path calculations when there would be a lot of them
                     ansList[[length(ansList)+1]] <- lapply(seq_along(nodeIDsFromOneDecl),

--- a/packages/nimble/inst/CppCode/nimbleGraph.cpp
+++ b/packages/nimble/inst/CppCode/nimbleGraph.cpp
@@ -304,7 +304,7 @@ bool nimbleGraph::anyStochParentsOneNode(vector<int> &anyStochParents,  int Cgra
 int nimbleGraph::getDependencyPathCountOneNode(const int Cnode, const int max) {
   int result(0);
   int i(0);
-  int tmp;
+  int currentCount;
   graphNode *thisGraphNode;
   graphNode *thisChildNode;
 
@@ -325,14 +325,20 @@ int nimbleGraph::getDependencyPathCountOneNode(const int Cnode, const int max) {
 #ifdef _DEBUG_GETPATHS
       PRINTF("node %i has child %i\n", Cnode, thisChildNode->CgraphID);
 #endif
+      // Formulation here with checks compared to `max` will avoid overflow.
       if(thisChildNode->type == STOCH) {
+        if(max - result <= 1) {
+          thisGraphNode->numPaths = max;
+          return(max);
+        }
         result++;
-        if(result >= max)
-          return(result);
       } else {
-        tmp = getDependencyPathCountOneNode(thisChildNode->CgraphID);
-        if(tmp >= max - result)   // this check will avoid overflow, if max is integer max
-          return(max)
+        currentCount = getDependencyPathCountOneNode(thisChildNode->CgraphID, max);
+        if(max - result <= currentCount) {   
+          thisGraphNode->numPaths = max;
+          return(max);
+        } 
+        result += currentCount;
       }
     }
   }

--- a/packages/nimble/inst/include/nimble/nimbleGraph.h
+++ b/packages/nimble/inst/include/nimble/nimbleGraph.h
@@ -72,7 +72,7 @@ public:
   void getDependenciesOneNode(vector<int> &deps, vector<int> &tempDeps, int CgraphID, bool downstream, unsigned int recursionDepth, bool followLHSinferred = true);
   vector<int> getParents(const vector<int> &Cnodes, const vector<int> &Comit, bool upstream, bool oneStep);
   void getParentsOneNode(vector<int> &deps, vector<int> &tempDeps, int CgraphID, bool upstream, unsigned int recursionDepth, bool recurse = true, bool followLHSinferred = true);
-  int getDependencyPathCountOneNode(const int Cnode);
+  int getDependencyPathCountOneNode(const int Cnode, const int max);
   
   vector<vector<int> > getAllCondIndSets(const vector<int> &Cnodes,
                                          const vector<int> &CgivenNodes,
@@ -106,7 +106,7 @@ extern "C" {
   SEXP C_anyStochParents(SEXP SextPtr);
   SEXP C_getDependencies(SEXP SextPtr, SEXP Snodes, SEXP Somit, SEXP Sdownstream);
   SEXP C_getParents(SEXP SextPtr, SEXP Snodes, SEXP Somit, SEXP upstream, SEXP SoneStep);
-  SEXP C_getDependencyPathCountOneNode(SEXP SgraphExtPtr, SEXP Snode);
+  SEXP C_getDependencyPathCountOneNode(SEXP SgraphExtPtr, SEXP Snode, SEXP Smax);
   SEXP C_getConditionallyIndependentSets(SEXP SgraphExtPtr,
                                          SEXP Snodes,
                                          SEXP SgivenNodes,

--- a/packages/nimble/src/nimble.cpp
+++ b/packages/nimble/src/nimble.cpp
@@ -71,7 +71,7 @@ R_CallMethodDef CallEntries[] = {
  FUN(C_getParents, 5),
  FUN(C_getConditionallyIndependentSets, 7),
  FUN(C_getDependencyPaths, 2), 
- FUN(C_getDependencyPathCountOneNode, 2), 
+ FUN(C_getDependencyPathCountOneNode, 3), 
  {NULL, NULL, 0}
 };
 

--- a/packages/nimble/tests/testthat/test-ADmodels.R
+++ b/packages/nimble/tests/testthat/test-ADmodels.R
@@ -508,6 +508,7 @@ model$setData('y')
 newDist <- as.matrix(dist(runif(n)))
 relTolTmp <- relTol
 relTolTmp[1] <- 1e-14
+relTolTmp[4] <- 1e-3
 
 ## 361 sec.
 test_ADModelCalculate(model, newUpdateNodes = list(dist = newDist), useParamTransform = TRUE,


### PR DESCRIPTION
  Modify getDependencyPathCountOneNode to have a max count  and use this to reduce computation in `checkConjugacy_new`. This fixes issue #1321 

