### PR TITLE
Fix setData

### DIFF
--- a/packages/nimble/R/BNP_samplers.R
+++ b/packages/nimble/R/BNP_samplers.R
@@ -1369,7 +1369,7 @@ sampler_CRP <- nimbleFunction(
     for(varIdx in seq_along(clusterVarInfo$clusterVars)) {
         if(length(unique(clusterVarInfo$clusterNodes[[varIdx]])) != length(clusterVarInfo$clusterNodes[[varIdx]]))
             stop("sampler_CRP: cluster parameters in different clusters must be part of conditionally independent nodes.")
-        if(any(model$isDeterm(clusterVarInfo$clusterNodes[[varIdx]])))
+        if(any(model$isDeterm(clusterVarInfo$clusterNodes[[varIdx]], includeRHSonly = TRUE)))
             stop("findClusterNodes: detected that deterministic nodes are being clustered. Please use the dCRP-distributed node to cluster stochastic nodes.")
     }
     
@@ -2086,7 +2086,7 @@ checkNormalInvGammaConjugacy <- function(model, clusterVarInfo, n, gammaDist = '
     clusterNodes1 <- clusterVarInfo$clusterNodes[[1]]
     clusterNodes2 <- clusterVarInfo$clusterNodes[[2]]
 
-    if(!any(model$isDeterm(c(clusterNodes1, clusterNodes2))) &&
+    if(!any(model$isDeterm(c(clusterNodes1, clusterNodes2), includeRHSonly = TRUE)) &&
        length(clusterNodes1) == length(clusterNodes2) &&
        identical(clusterVarInfo$clusterIDs[[1]], clusterVarInfo$clusterIDs[[2]])) {
         dists <- c(model$getDistribution(clusterNodes1[1]), model$getDistribution(clusterNodes2[1]))
@@ -2180,7 +2180,7 @@ checkNormalInvWishartConjugacy <- function(model, clusterVarInfo, n, wishartDist
     clusterNodes1 <- clusterVarInfo$clusterNodes[[1]]
     clusterNodes2 <- clusterVarInfo$clusterNodes[[2]]
 
-    if(!any(model$isDeterm(c(clusterNodes1, clusterNodes2))) &&
+    if(!any(model$isDeterm(c(clusterNodes1, clusterNodes2), includeRHSonly = TRUE)) &&
        length(clusterNodes1) == length(clusterNodes2) &&
        identical(clusterVarInfo$clusterIDs[[1]], clusterVarInfo$clusterIDs[[2]])) {
         dists <- c(model$getDistribution(clusterNodes1[1]), model$getDistribution(clusterNodes2[1]))

--- a/packages/nimble/R/BUGS_model.R
+++ b/packages/nimble/R/BUGS_model.R
@@ -275,7 +275,7 @@ Details: The return value is a character vector with an element for each node in
                                   return(out)
                                 },
 
-                                isDeterm = function(nodes, nodesAlreadyExpanded = FALSE) {
+                                isDeterm = function(nodes, includeRHSonly = FALSE, nodesAlreadyExpanded = FALSE) {
                                   '
 Determines whether one or more nodes are deterministic
 
@@ -290,7 +290,9 @@ Details: The return value is a character vector with an element for each node in
                                   if(!nodesAlreadyExpanded)
                                       nodeNames <- expandNodeNames(nodes, unique = FALSE) else nodeNames <- nodes
                                   type <- getNodeType(nodeNames)
-                                  out <- type == "determ"
+                                  if(includeRHSonly) {
+                                      out <- type %in% c("determ", "RHSonly")
+                                  } else out <- type == "determ"
                                   names(out) <- nodeNames
                                   return(out)
                                 },
@@ -581,7 +583,7 @@ Arguments:
 
 ...:  Arguments may be provided as named elements with numeric values or as character names of model variables.  These may be provided in a single list, a single character vector, or as multiple arguments.  When a named element with a numeric value is provided, the size and dimension must match the corresponding model variable.  This value will be copied to the model variable and any non-NA elements will be marked as data.  When a character name is provided, the value of that variable in the model is not changed but any currently non-NA values are marked as data.  Examples: setData(\'x\', y = 1:10) will mark both x and y as data and will set the value of y to 1:10.  setData(list(\'x\', y = 1:10)) is equivalent.  setData(c(\'x\',\'y\')) or setData(\'x\',\'y\') will mark both x and y as data.
 
-Details: If a provided value (or the current value in the model when only a name is specified) contains some NA values, then the model nodes corresponding to these NAs will not have their value set, and will not be designated as \'data\'.  Only model nodes corresponding to numeric values in the argument list elements will be designated as data.  Designating a deterministic model node as \'data\' will result in an error.  Designating part of a multivariate node as \'data\' and part as non-data (NA) is allowed, but \'isData()\' will report such a node as being \'data\', calculations with the node will generally return NA, and MCMC samplers will not be assigned to such nodes.
+Details: If a provided value (or the current value in the model when only a name is specified) contains some NA values, then the model nodes corresponding to these NAs will not have their value set, and will not be designated as \'data\'.  Only model nodes corresponding to numeric values in the argument list elements will be designated as data.  Designating deterministic model nodes as \'data\' will be ignored.  Designating part of a multivariate node as \'data\' and part as non-data (NA) is allowed, but \'isData()\' will report such a node as being \'data\', calculations with the node will generally return NA, and MCMC samplers will not be assigned to such nodes.
 '
                                           ## new functionality for setData():
                                           ## ... can be a list, a character vector of variable names, or a mix of both
@@ -637,7 +639,7 @@ Details: If a provided value (or the current value in the model when only a name
                                                   if(varName == '') {
                                                       warning('setData: unnamed element provided to setData.')
                                                   } else 
-                                                      messageIfVerbose("  [Note] '", varName, "' is provided in 'data' but is not a variable in the model and is being ignored.")
+                                                      messageIfVerbose("  [Note] `", varName, "` is provided in 'data' but is not a variable in the model and is being ignored.")
                                               }
                                               ## Removing unnecessary
                                               ## elements does not
@@ -654,19 +656,30 @@ Details: If a provided value (or the current value in the model when only a name
                                           if(!(all(nimble::nimbleInternalFunctions$dimOrLength(varValue, scalarize = scalarize) == isDataVars[[varName]])))   stop(paste0('incorrect size or dim in data: ', varName))
 
                                           expandedNodeNames <- expandNodeNames(varName, returnScalarComponents = TRUE)
-                                          determElements <- .self$isDeterm(expandedNodeNames, nodesAlreadyExpanded = TRUE)
-                                          if(any(determElements))
-                                              if(any(!is.na(varValue[which(determElements)])))
-                                                  stop("setData: '", varName, "' contains deterministic nodes. Deterministic nodes cannot be specified as 'data' or 'constants'.")
-                                          
+                                          determElements <- .self$isDeterm(expandedNodeNames, includeRHSonly = FALSE, nodesAlreadyExpanded = TRUE)
+                                          if(any(determElements)) {
+                                              varValueEnv <- new.env(parent = baseenv())
+                                              varValueEnv[[varName]] <- varValue
+                                              if(any(!is.na(
+                                                       sapply(expandedNodeNames[determElements],
+                                                              function(nn)
+                                                                  return(eval(parse(text=nn, keep.source = FALSE)[[1]], envir=varValueEnv))))))
+                                                 messageIfVerbose("  [Warning] `", varName, "` contains deterministic nodes not specified as `NA`. Deterministic node values will not be flagged as 'data'.")
+                                          }
                                           .self[[varName]] <- varValue
-                                          ## Values set as NA are not flagged as data nor are RHSonly elements.
+                                          ## Values set as NA are not flagged as data.
                                           isDataVarValue <- !is.na(varValue)
-                                          isDataVarValue[!.self$isStoch(expandedNodeNames, nodesAlreadyExpanded = TRUE)] <- FALSE
                                           names(isDataVarValue) <- NULL
                                           assign(varName, isDataVarValue, envir = isDataEnv)
+
+                                          ## Nor are RHSonly or deterministic elements.
+                                          nonStochElements <- !.self$isStoch(expandedNodeNames, nodesAlreadyExpanded = TRUE)
+                                          tmp <- sapply(expandedNodeNames[nonStochElements],
+                                                 function(nn)
+                                                     eval(substitute(VALUE <- FALSE, list(VALUE = parse(text=nn, keep.source = FALSE)[[1]])),
+                                                          envir = isDataEnv))
                                       }
-                                   ##   testDataFlags()  ## this is slow for large models.  it could be re-written if we want to use it routinely
+                                      ##   testDataFlags()  ## this is slow for large models.  it could be re-written if we want to use it routinely
                                       setPredictiveNodeIDs()
                                       return(invisible(NULL))
                                   },
@@ -1066,24 +1079,27 @@ inits: A named list.  The names of list elements must correspond to model variab
                                               messageIfVerbose("  [Note] '", names(inits)[i], "' has initial values but is not a variable in the model and is being ignored.")
                                               next
                                           }
+                                          inputDim <- nimbleInternalFunctions$dimOrLength(inits[[i]])
+                                          varInfo <- .self$modelDef$varInfo[[names(inits)[i]]]
+                                          mismatch <- FALSE
+                                          if(length(inputDim) == 1 && inputDim == 1) {  # scalar could be scalar or vector of length 1
+                                              if(!(varInfo$nDim == 0 || (varInfo$nDim > 0 && identical(varInfo$maxs, rep(1, varInfo$nDim)))))
+                                                  mismatch <- TRUE
+                                          } else {
+                                              if(length(inputDim) != varInfo$nDim || any(inputDim != varInfo$maxs))
+                                                  mismatch <- TRUE
+                                          }
+                                          if(mismatch)
+                                              messageIfVerbose("  [Warning] Incorrect size or dimension of initial value for '", names(inits)[i], "'.\n         Initial value will not be used in compiled model.")
+                                          
                                           dataVals <- .self$isDataEnv[[names(inits)[[i]] ]]
                                           if(any(dataVals)) {
-                                              .self[[names(inits)[i]]][!dataVals] <- inits[[i]][!dataVals]
-                                              if(any(!is.na(inits[[i]][dataVals])))
-                                                  messageIfVerbose("  [Note] Ignoring non-NA values in inits for data nodes: ", names(inits)[[i]], ".")
+                                              currentValues <- .self[[names(inits)[i]]]
+                                              replacementByInits <- !dataVals & is.na(currentValues)
+                                              if(any(!is.na(currentValues) & !is.na(inits[[i]]) & currentValues != inits[[i]]))
+                                                  messageIfVerbose("  [Note] Ignoring non-NA values in `inits` for values specified via `data` in variables: `", names(inits)[[i]], "`.")
+                                              .self[[names(inits)[i]]][replacementByInits] <- inits[[i]][replacementByInits]
                                           } else {
-                                              inputDim <- nimbleInternalFunctions$dimOrLength(inits[[i]])
-                                              varInfo <- .self$modelDef$varInfo[[names(inits)[i]]]
-                                              mismatch <- FALSE
-                                              if(length(inputDim) == 1 && inputDim == 1) {  # scalar could be scalar or vector of length 1
-                                                  if(!(varInfo$nDim == 0 || (varInfo$nDim > 0 && identical(varInfo$maxs, rep(1, varInfo$nDim)))))
-                                                      mismatch <- TRUE
-                                              } else {
-                                                  if(length(inputDim) != varInfo$nDim || any(inputDim != varInfo$maxs))
-                                                      mismatch <- TRUE
-                                              }
-                                              if(mismatch)
-                                                  message("  [Warning] Incorrect size or dimension of initial value for '", names(inits)[i], "'.\n         Initial value will not be used in compiled model.")
                                               .self[[names(inits)[i]]] <- inits[[i]]
                                           }
                                       }

--- a/packages/nimble/R/MCMC_utils.R
+++ b/packages/nimble/R/MCMC_utils.R
@@ -371,9 +371,9 @@ mcmc_checkWAICmonitors_conditional <- function(model, monitors, dataNodes) {
     }
 }
 
-## Used through version 0.10.0 and likely to be used in some form once we re-introduce mWAIC
+## Used through version 0.10.0.
 mcmc_checkWAICmonitors <- function(model, monitors, dataNodes) {
-    monitoredDetermNodes <- model$expandNodeNames(monitors)[model$isDeterm(model$expandNodeNames(monitors))]
+    monitoredDetermNodes <- model$expandNodeNames(monitors)[model$isDeterm(model$expandNodeNames(monitors), includeRHSonly = TRUE)]
     if(length(monitoredDetermNodes) > 0) {
         monitors <- monitors[- which(monitors %in% model$getVarNames(nodes = monitoredDetermNodes))]
     }

--- a/packages/nimble/R/parameterTransform.R
+++ b/packages/nimble/R/parameterTransform.R
@@ -81,10 +81,10 @@ parameterTransform <- nimbleFunction(
         nodesExpanded <- model$expandNodeNames(nodes)
         allowDeterm <- if(!is.null(control$allowDeterm)) control$allowDeterm else FALSE
         if(!allowDeterm){
-          if(any(model$isDeterm(nodesExpanded)))   stop(paste0('parameterTransform cannot operate on deterministic nodes: ',        paste0(nodesExpanded[model$isDeterm(nodesExpanded)],   collapse = ', ')))
+          if(any(model$isDeterm(nodesExpanded, includeRHSonly = TRUE)))   stop(paste0('parameterTransform cannot operate on deterministic nodes: ',        paste0(nodesExpanded[model$isDeterm(nodesExpanded, includeRHSonly = TRUE)],   collapse = ', ')))
           if(any(model$isDiscrete(nodesExpanded))) stop(paste0('parameterTransform cannot operate on discrete-valued nodes: ',      paste0(nodesExpanded[model$isDiscrete(nodesExpanded)], collapse = ', ')))
         } else {
-          boolDeterm <- model$isDeterm(nodesExpanded)
+          boolDeterm <- model$isDeterm(nodesExpanded, includeRHSonly = TRUE)
           nodesExpandedNotDeterm <- nodesExpanded[!boolDeterm]
           if(any(model$isDiscrete(nodesExpandedNotDeterm))) stop(paste0('parameterTransform cannot operate on discrete-valued nodes: ',      paste0(nodesExpanded[model$isDiscrete(nodesExpandedNotDeterm)], collapse = ', ')))
         }


### PR DESCRIPTION
This fixes issues #1324 and #1326 by:
 - only overwriting values set by `setData` with `setInits` if the value from `setData` is NA.
 - warning users if they try to overwrite a value set by `setData` in `setInits` and the `setInits` value is different from the `setData` value and not NA.
 - adding an `includeRHSonly` flag to `isDeterm` with default `FALSE` and then updating some uses of `isDeterm` in our codebase to set `includeRHSonly` to TRUE.
 - fixing #1326 by indexing into `varValue` (when checking for deterministic data) and `isDataVarValue` (when setting data flags) using `eval` with the scalar node names (similar to how `isDataFromGraphID` works). This avoids setting the data flag to TRUE for deterministic and RHSonly elements of a variable that has data elements. Note that positions in `isDataEnv$x` can still be TRUE for positions that do not correspond to any nodes (e.g., if `x[1]` is not defined at all in the model, but the user provides a non-NA value for `x[1]` in `setData`).

Note that I have not yet added various tests, in particular the CR-type example where there are undefined nodes in a variable, such as `y[i, 3:6]` defined but `y[i, 1:2]` undefined. I will also review the changes again carefully.