### PR TITLE
Fix `setData`

### DIFF
--- a/UserManual/src/chapter_BuildingModels.Rmd
+++ b/UserManual/src/chapter_BuildingModels.Rmd
@@ -74,7 +74,7 @@ which case NIMBLE handles values for stochastic nodes as data and
 everything else as constants.
 
 Values for nodes that appear only on the right-hand side of BUGS
-declarations (e.g., covariates/predictors) can be provided as constants or as data or initial values. There is no real difference between providing as data or initial values and the values can be added after building a model via `setInits` or `setData`. 
+declarations (e.g., covariates/predictors) can be provided as constants or as data or initial values. There is no real difference between providing as data or initial values and the values can be added after building a model via `setInits` or `setData`. However if provided as data, calls to `setInits` will not overwrite those values (thought direct assignment of values will overwrite those values). 
 
 #### Providing (or changing) data and initial values for an existing model
 
@@ -96,7 +96,10 @@ by using the `resetData` method, e.g. `pump$resetData()`.
 
 Data nodes cannot be deterministic, and using `setData` on
 deterministic nodes (or passing values for deterministic nodes
-via the `data` argument to `nimbleModel`) will produce an error.
+via the `data` argument to `nimbleModel`) will not flag those
+nodes as containing data. It will set the values of those nodes,
+but that will presumably be overwritten as soon as the nodes
+are deterministically calculated.
 
 To change data values without any modification of which nodes are
 flagged as containing data, simply use R's usual assignment syntax

--- a/install_revDeps.R
+++ b/install_revDeps.R
@@ -8,7 +8,7 @@ revDeps <- c(
 ## Note that if don't specify repos, the RStudio repo seems to install from
 ## Linux binary (that is what the .tar.gz is?) and doesn't install tests.
 for (package in revDeps) {
-        install.packages(package, type = 'source', INSTALL_opts = '--install-tests', repos = 'https://cran.us.r-project.org')
+        install.packages(package, type = 'source', INSTALL_opts = '--install-tests', repos = 'https://cran.r-project.org')
     }
 print(list.files(system.file('tests','testthat', package='nimbleSMC')))
 print(list.files(system.file('', package='nimbleSMC')))

--- a/packages/nimble/R/MCMC_utils.R
+++ b/packages/nimble/R/MCMC_utils.R
@@ -371,9 +371,9 @@ mcmc_checkWAICmonitors_conditional <- function(model, monitors, dataNodes) {
     }
 }
 
-## Used through version 0.10.0 and likely to be used in some form once we re-introduce mWAIC
+## Used through version 0.10.0.
 mcmc_checkWAICmonitors <- function(model, monitors, dataNodes) {
-    monitoredDetermNodes <- model$expandNodeNames(monitors)[model$isDeterm(model$expandNodeNames(monitors))]
+    monitoredDetermNodes <- model$expandNodeNames(monitors)[model$isDeterm(model$expandNodeNames(monitors), includeRHSonly = TRUE)]
     if(length(monitoredDetermNodes) > 0) {
         monitors <- monitors[- which(monitors %in% model$getVarNames(nodes = monitoredDetermNodes))]
     }

--- a/packages/nimble/R/parameterTransform.R
+++ b/packages/nimble/R/parameterTransform.R
@@ -81,10 +81,10 @@ parameterTransform <- nimbleFunction(
         nodesExpanded <- model$expandNodeNames(nodes)
         allowDeterm <- if(!is.null(control$allowDeterm)) control$allowDeterm else FALSE
         if(!allowDeterm){
-          if(any(model$isDeterm(nodesExpanded)))   stop(paste0('parameterTransform cannot operate on deterministic nodes: ',        paste0(nodesExpanded[model$isDeterm(nodesExpanded)],   collapse = ', ')))
+          if(any(model$isDeterm(nodesExpanded, includeRHSonly = TRUE)))   stop(paste0('parameterTransform cannot operate on deterministic nodes: ',        paste0(nodesExpanded[model$isDeterm(nodesExpanded, includeRHSonly = TRUE)],   collapse = ', ')))
           if(any(model$isDiscrete(nodesExpanded))) stop(paste0('parameterTransform cannot operate on discrete-valued nodes: ',      paste0(nodesExpanded[model$isDiscrete(nodesExpanded)], collapse = ', ')))
         } else {
-          boolDeterm <- model$isDeterm(nodesExpanded)
+          boolDeterm <- model$isDeterm(nodesExpanded, includeRHSonly = TRUE)
           nodesExpandedNotDeterm <- nodesExpanded[!boolDeterm]
           if(any(model$isDiscrete(nodesExpandedNotDeterm))) stop(paste0('parameterTransform cannot operate on discrete-valued nodes: ',      paste0(nodesExpanded[model$isDiscrete(nodesExpandedNotDeterm)], collapse = ', ')))
         }

--- a/packages/nimble/tests/testthat/test-misc.R
+++ b/packages/nimble/tests/testthat/test-misc.R
@@ -329,7 +329,7 @@ test_that("setInits works in complicated case", {
                      constants = list(f = c(1, 2),
                                       n = 3),
                      data = data,
-                     inits = inits), "Ignoring non-NA values in inits")
+                     inits = inits), "Ignoring non-NA values in `inits`")
 
     ## This model defines x[1, 1], x[1, 2], x[1, 3], x[2, 2], and x[2, 3]. 
     ## x[2,1] is not a node in the model.
@@ -344,8 +344,35 @@ test_that("setInits works in complicated case", {
     ##[1,]  100  100    5
     ##[2,]    2    4    6
     expect_equal(m$x, matrix(c(100, 2, 100, 4, 5, 6), nrow = 2))
+    expect_identical(m$isDataEnv$'x', matrix(c(TRUE,FALSE,TRUE,FALSE,FALSE,FALSE),2))
+    expect_length(m$isData('x[2,1]'), 0)
 }
 )
+
+test_that("error trapping bad dimension size in setInits", {
+    code <- nimbleCode({
+        for(i in 1:3)
+            for(j in 1:3)
+                y[i,j]~dnorm(0,1)
+    })
+    m <- nimbleModel(code)
+    expect_message(m$setInits(list(y = rnorm(3))), "Incorrect size or dimension of initial value")
+
+    code <- nimbleCode({
+        for(i in 1:3)
+            for(j in 1:3)
+                y[i,j]~dnorm(0,1)
+    })
+    m <- nimbleModel(code, data = list(y = matrix(rnorm(9),3)))
+    expect_message(m$setInits(list(y = rnorm(3))), "Incorrect size or dimension of initial value")
+    
+    code <- nimbleCode({
+        for(i in 1:3)
+            for(j in 1:3)
+                y[i,j]~dnorm(0,1)
+    })
+    expect_error(m <- nimbleModel(code, inits = list(y = rnorm(3))), "inconsistent dimensionality")
+})
 
 test_that("missing return statement is trapped",
 {

--- a/packages/nimble/tests/testthat/test-models.R
+++ b/packages/nimble/tests/testthat/test-models.R
@@ -341,7 +341,7 @@ test_that("test of distinguishing lumped data and constants:", {
         beta ~ dnorm(0, 1)
     })
     m <- nimbleModel(code, data = list(y = c(1, 2), x = c(1, 5)))
-    expect_equal(m$isData('x'), c(FALSE, FALSE), info = "'x' not set as data in fourth test")
+    expect_equal(m$isData('x'), c(TRUE, TRUE), info = "'x' not set as data in fourth test")
     expect_equal('x' %in% m$getVarNames(), TRUE, info = "'x' is not set as variable in fourth test")
     expect_equal(sum(c("x[1]", "x[2]") %in% m$getNodeNames()), 0, info = "'x[1]' appears incorrectly in nodes in fourth test")
 
@@ -421,7 +421,7 @@ test_that("test of the handling of missing covariates:", {
     })
     m <- nimbleModel(code, data = list(y = c(1, 2), x = c(1, NA)))
     expect_equal('x' %in% m$getVarNames(), TRUE, info = "'x' is not set as variable in second test")
-    expect_equal(m$isData('x'), c(FALSE, FALSE), info = "'x' data flags are not set correctly in second test")
+    expect_equal(m$isData('x'), c(TRUE, FALSE), info = "'x' data flags are not set correctly in second test")
     expect_equal(sum(c("x[1]", "x[2]") %in% m$getNodeNames()), 0, info = "'x' appears incorrectly in nodes in second test")
 
     code <- nimbleCode({
@@ -432,7 +432,7 @@ test_that("test of the handling of missing covariates:", {
     })
     m <- nimbleModel(code, data = list(y = c(1, 2)), constants = list(x = c(1, NA)))
     expect_equal('x' %in% m$getVarNames(), TRUE, info = "'x' is not set as variable in second test")
-    expect_equal(m$isData('x'), c(FALSE, FALSE), info = "'x' data flags are not set correctly in second test")
+    expect_equal(m$isData('x'), c(TRUE, FALSE), info = "'x' data flags are not set correctly in second test")
     expect_equal(sum("x[1]" %in% m$getNodeNames()), 0, info = "'x[1]' appears incorrectly in nodes in second test")
     expect_equal(sum("x[2]" %in% m$getNodeNames()), 1, info = "'x[2]' does not appears in nodes in second test")
 
@@ -444,7 +444,7 @@ test_that("test of the handling of missing covariates:", {
     })
     m <- nimbleModel(code, data = list(y = c(1, 2), x = c(1, NA)))
     expect_equal('x' %in% m$getVarNames(), TRUE, info = "'x' is not set as variable in second test")
-    expect_equal(m$isData('x'), c(FALSE, FALSE), info = "'x' data flags are not set correctly in second test")
+    expect_equal(m$isData('x'), c(TRUE, FALSE), info = "'x' data flags are not set correctly in second test")
     expect_equal(sum("x[1]" %in% m$getNodeNames()), 0, info = "'x[1]' appears incorrectly in nodes in second test")
     expect_equal(sum("x[2]" %in% m$getNodeNames()), 1, info = "'x[2]' does not appears in nodes in second test")
 

--- a/packages/nimble/tests/testthat/test-models.R
+++ b/packages/nimble/tests/testthat/test-models.R
@@ -358,7 +358,7 @@ test_that("test of preventing overwriting of data values by inits:", {
     xVal <- c(3, NA)
     xInit <- c(4, 4)
 
-    expect_message(m <- nimbleModel(code, constants = list(x = xVal), inits = list(x = xInit)), "Ignoring non-NA values in inits for data nodes")
+    expect_message(m <- nimbleModel(code, constants = list(x = xVal), inits = list(x = xInit)), "Ignoring non-NA values in `inits` for data nodes")
     expect_equal(m$isData('x'), c(TRUE, FALSE), info = "'x' data flag is not set correctly in fourth test")
     expect_equal(m$x, c(xVal[1], xInit[2]), info = "value of 'x' not correctly set in fourth test")
     expect_equal(c('x[1]','x[2]') %in% m$getNodeNames(), c(TRUE, TRUE), info = "'x' nodes note correctly set in fourth test")
@@ -368,7 +368,7 @@ test_that("test of preventing overwriting of data values by inits:", {
         x[2] ~ dnorm(mu,1)
         mu ~ dnorm(0, 1)
     })
-    expect_message(m <- nimbleModel(code, data = list(x = xVal), inits = list(x = xInit)), "Ignoring non-NA values in inits for data nodes")
+    expect_message(m <- nimbleModel(code, data = list(x = xVal), inits = list(x = xInit)), "Ignoring non-NA values in `inits` for data nodes")
     expect_equal(m$isData('x'), c(TRUE, FALSE), info = "'x' data flag is not set correctly in fifth test")
     expect_equal(m$x, c(xVal[1], xInit[2]), info = "value of 'x' not correctly set in fifth test")
     expect_equal(c('x[1]','x[2]') %in% m$getNodeNames(), c(TRUE, TRUE), info = "'x' nodes note correctly set in fifth test")


### PR DESCRIPTION
This fixes issues #1324 and #1326 by:
- adding an includeRHSonly flag to isDeterm with default FALSE and then updating some uses of isDeterm in our codebase to set includeRHSonly to TRUE.
- not setting determ nodes as data and warning user of that situation
- fixing issue #1326 by (1) indexing into `varValue` (when checking for deterministic data) using eval with the scalar node names (similar to how `isDataFromGraphID` works) and (2) not trying to avoid RHSonly nodes as data (i.e., reverting to pre-1.0.0 behavior). 