### PR TITLE
fixed multiple warnings of MCMC unsampled nodes

### DIFF
--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -96,7 +96,8 @@
 #' @export
 buildMCMC <- nimbleFunction(
     name = 'MCMC',
-    setup = function(conf, print = getNimbleOption('verbose'), ...) {
+    setup = function(conf, print, ...) {
+        if(missing(print)) print <- getNimbleOption('verbose')  ## default value defined by getNimbleOption has to be here, inside the setup function code
         dotdotdotArgNames <- names(list(...))
         if(inherits(conf, 'MCMCconf') && ('enableWAIC' %in% dotdotdotArgNames || 'controlWAIC' %in% dotdotdotArgNames))
             stop("buildMCMC: 'enableWAIC' and 'controlWAIC' can only be given as arguments when running 'buildMCMC' directly on a model object, not on an MCMC configuration object. Instead pass these argument(s) directly to 'configureMCMC'.")

--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -107,6 +107,10 @@ buildMCMC <- nimbleFunction(
             if(print)   conf$show(includeConfGetUnsampledNodes = FALSE)
         } else {
             if(!inherits(conf, 'MCMCconf')) stop('conf must either be a nimbleModel or a MCMCconf object (created by configureMCMC(...) )')
+            if(getNimbleOption('MCMCwarnUnsampledStochasticNodes')) {
+                conf$setUnsampledNodes()
+                conf$warnUnsampledNodes()
+            }
         }
         
         enableWAIC <- conf$enableWAIC

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -1213,15 +1213,18 @@ Details: See the initialize() function
             return(unsampledNodes)
         },
         
-        warnUnsampledNodes = function() {
+        warnUnsampledNodes = function(includeConfGetUnsampledNodes = TRUE) {
             if(length(unsampledNodes)) {
                 numUnsampled <- length(unsampledNodes)
                 sTag <- if(numUnsampled > 1) 's' else ''
-                messageIfVerbose('  [Warning] No samplers assigned for ', numUnsampled, ' node', sTag, ', use conf$getUnsampledNodes() for node name', sTag, '.')
+                msg <- paste0('  [Warning] No samplers assigned for ', numUnsampled, ' node', sTag)
+                if(includeConfGetUnsampledNodes)   msg <- paste0(msg, ', use conf$getUnsampledNodes() for node name', sTag)
+                msg <- paste0(msg, '.')
+                messageIfVerbose(msg)
             }
         },
 
-        printComments = function() {
+        printComments = function(...) {
             setUnsampledNodes()
             anyComments <-
                 length(postPredSamplerDownstreamNodes) ||
@@ -1229,16 +1232,16 @@ Details: See the initialize() function
             if(anyComments) {
                 cat('===== Comments =====\n')
                 if(length(postPredSamplerDownstreamNodes))   message('  [Note] Additional downstream predictive nodes are also being sampled by posterior_predictive sampler.')
-                if(getNimbleOption('MCMCwarnUnsampledStochasticNodes'))   warnUnsampledNodes()
+                if(getNimbleOption('MCMCwarnUnsampledStochasticNodes'))   warnUnsampledNodes(...)
             }
         },
 
-        show = function() {
+        show = function(...) {
             cat('===== Monitors =====\n')
             printMonitors()
             cat('===== Samplers =====\n')
             if(length(samplerConfs)) printSamplers(byType = TRUE) else cat('(no samplers assigned)\n')
-            printComments()
+            printComments(...)
         }
     )
 )


### PR DESCRIPTION
This fixes the problem of outputting multiple (2) warnings about unsampled nodes, which would occur when using:
```
buildMCMC(model, nodes = only_some_of_model_nodes)
```

Opening PR to trigger testing.