### PR TITLE
registerDistributions type-checking allows default value for x arg

### DIFF
--- a/packages/nimble/R/distributions_processInputList.R
+++ b/packages/nimble/R/distributions_processInputList.R
@@ -307,6 +307,9 @@ checkDistributionFunctions <- function(distributionInput, userEnv) {
         rrcf <- get(simulateName, pos = userEnv)
         dtype <- environment(drcf)$nfMethodRCobject$argInfo[['x']]
         rtype <- environment(rrcf)$nfMethodRCobject$returnType
+        ## remove possible 'default' specification from dtype
+        ## must occur before type() vs type(0) check (immediately below)
+        dtype$default <- NULL
         ## Deal with type() vs type(0) ambiguity.
         if(length(dtype) == 1)
             dtype <- substitute(x(0), list(x = dtype[[1]]))


### PR DESCRIPTION
Modified the type-checking in `registerDistributions`, to allow a default value for the `x` argument of user-defined distributions.  For example, the following is now ok:

```
ddist <- nimbleFunction(
    run = function(x = double(default = 0), log = integer(default = 1)) {
        returnType(double())
        return(0)
    }
)
```

This should never affect model calculations, but does result in a user-defined density function (in the R environment) which has a default value for the `x` argument.

