### PR TITLE
inline many core functions

### DIFF
--- a/packages/nimble/inst/CppCode/Utils.cpp
+++ b/packages/nimble/inst/CppCode/Utils.cpp
@@ -67,29 +67,29 @@ void nimStop() {NIMERROR("");}
 
 bool nimNot(bool x) {return(!x);}
 
-double pow_int(double a, double b) {
-  return pow(a, fround(b, 0.));
-}
+// double pow_int(double a, double b) {
+//   return pow(a, fround(b, 0.));
+// }
 
-double ilogit(double x) {return(1./(1. + exp(-x)));}
+// double ilogit(double x) {return(1./(1. + exp(-x)));}
 
-double icloglog(double x) {return(1.-exp(-exp(x)));}
+// double icloglog(double x) {return(1.-exp(-exp(x)));}
 
-double iprobit(double x) {return(pnorm(x, 0., 1., 1, 0));}
+// double iprobit(double x) {return(pnorm(x, 0., 1., 1, 0));}
 
-double probit(double x) {return(qnorm(x, 0., 1., 1, 0));}
-//double abs(double x) {return(fabs(x));}
-double cloglog(double x) {return(log(-log(1.-x)));}
-int nimEquals(double x1, double x2) {return(x1 == x2 ? 1 : 0);}
-double nimbleIfElse(bool condition, double x1, double x2) {return(condition ? x1 : x2);}
-double lfactorial(double x) {return(lgammafn(x + 1));} //{return(lgamma1p(x));} not numerically equivalent to lgamma(x+1), which is what is done from R. lgamma seems to clean up numerical zeros
-double factorial(double x) {return(gammafn(1+x));}
-//double loggam(double x) {return(lgammafn(x));}
-double logit(double x) {return(log(x / (1.-x)));}
-double nimRound(double x) {return(fround(x, 0.));}
-double pairmax(double x1, double x2) {return(x1 > x2 ? x1 : x2);}
-double pairmin(double x1, double x2) {return(x1 < x2 ? x1 : x2);}
-//double phi(double x) {return(pnorm(x, 0., 1., 1, 0));}
-int nimStep(double x) { return(x >= 0 ? 1 : 0);}
-double cube(double x) {return(x*x*x);}
-double inprod(double v1, double v2) {return(v1*v2);}
+// double probit(double x) {return(qnorm(x, 0., 1., 1, 0));}
+// //double abs(double x) {return(fabs(x));}
+// double cloglog(double x) {return(log(-log(1.-x)));}
+// int nimEquals(double x1, double x2) {return(x1 == x2 ? 1 : 0);}
+// double nimbleIfElse(bool condition, double x1, double x2) {return(condition ? x1 : x2);}
+// double lfactorial(double x) {return(lgammafn(x + 1));} //{return(lgamma1p(x));} not numerically equivalent to lgamma(x+1), which is what is done from R. lgamma seems to clean up numerical zeros
+// double factorial(double x) {return(gammafn(1+x));}
+// //double loggam(double x) {return(lgammafn(x));}
+// double logit(double x) {return(log(x / (1.-x)));}
+// double nimRound(double x) {return(fround(x, 0.));}
+// double pairmax(double x1, double x2) {return(x1 > x2 ? x1 : x2);}
+// double pairmin(double x1, double x2) {return(x1 < x2 ? x1 : x2);}
+// //double phi(double x) {return(pnorm(x, 0., 1., 1, 0));}
+// int nimStep(double x) { return(x >= 0 ? 1 : 0);}
+// double cube(double x) {return(x*x*x);}
+// double inprod(double v1, double v2) {return(v1*v2);}

--- a/packages/nimble/inst/include/nimble/Utils.h
+++ b/packages/nimble/inst/include/nimble/Utils.h
@@ -169,7 +169,8 @@ bool nimNot(bool x);
 
 static inline bool isTRUE(bool x) {return(x);}
 
-double pow_int(double a, double b);
+inline double pow_int(double a, double b) {return pow(a, round(b));}
+inline double pow_int(double a, int b) {return pow(a, static_cast<double>(b));}
 
 // All the nimDerivs_FOO functions
 // were templated, but in a rush we
@@ -183,71 +184,71 @@ double pow_int(double a, double b);
 #define T CppAD::AD<double>
 
 // needed for link functions
-double ilogit(double x);
+inline double ilogit(double x) {return(1./(1. + exp(-x)));}
 //template<class T>
 inline T nimDerivs_ilogit(T x){
   return(1./(1. + exp(-x)));
 }
 
-double icloglog(double x);
+inline double icloglog(double x) {return(1.-exp(-exp(x)));}
 //template<class T>
 inline T nimDerivs_icloglog(T x){
   return(1.-exp(-exp(x)));
 }
 
-double iprobit(double x);
-double probit(double x);
+inline double iprobit(double x) {return(pnorm(x, 0., 1., 1, 0));}
+inline double probit(double x) {return(qnorm(x, 0., 1., 1, 0));}
 
 //double abs(double x);
-double cloglog(double x);
+inline double cloglog(double x) {return(log(-log(1.-x)));}
 //template<class T>
 inline T nimDerivs_cloglog(T x){
   return(log(-log(T(1) - x)));
 }
 
-int nimEquals(double x1, double x2);
+inline int nimEquals(double x1, double x2) {return(x1 == x2 ? 1 : 0);}
 //template<class T>
 inline T nimDerivs_nimEquals(T x1, T x2){
-  return(CondExpEq(x1, x2, T(1), T(0))); 
+  return(CondExpEq(x1, x2, T(1), T(0)));
 }
 
-double nimbleIfElse(bool condition, double x1, double x2);
-double lfactorial(double x);
-double factorial(double x);
+inline double nimbleIfElse(bool condition, double x1, double x2) {return(condition ? x1 : x2);}
+inline double lfactorial(double x) {return(lgammafn(x + 1));}
+inline double factorial(double x) {return(gammafn(1+x));}
 //double loggam(double x);
-double logit(double x);
+inline double logit(double x) {return(log(x / (1.-x)));}
 //template<class T>
 inline T nimDerivs_logit(T x) {
   return(log(x / (T(1)-x)));
 }
 
-double nimRound(double x);
-double pairmax(double x1, double x2);
+inline double nimRound(double x) {return(round(x));}
+inline double pairmax(double x1, double x2) {return(x1 > x2 ? x1 : x2);}
 //template<class T>
 inline T nimDerivs_pairmax(T x1, T x2) {
   return(CondExpGt(x1, x2, x1, x2));
 }
 
-double pairmin(double x1, double x2);
+inline double pairmin(double x1, double x2) {return(x1 < x2 ? x1 : x2);}
 //template<class T>
 inline T nimDerivs_pairmin(T x1, T x2) {
   return(CondExpLt(x1, x2, x1, x2));
 }
 
 //double phi(double x);
-int nimStep(double x); 
+inline int nimStep(double x) { return(x >= 0 ? 1 : 0);}
 //template<class T>
 inline T nimDerivs_nimStep(T x){
 	return(CondExpGe(x, T(0), T(1), T(0)));
-} 
+}
 
-double cube(double x);
+inline double cube(double x) {return(x*x*x);}
 //template<class T>
 inline T nimDerivs_cube(T x){
 	return(x*x*x);
 }
 
-double inprod(double v1, double v2);
+inline double inprod(double v1, double v2) {return(v1*v2);}
 //template<class T>
 inline T nimDerivs_inprod(T v1, T v2) {
   return(v1*v2);


### PR DESCRIPTION
This PR changes the following C++ functions in Utils.h to be inlined. That means they now use the C++ keyword `inline` (previously they called a library function that on-the-fly compilation would link to) and thus the function contents get placed directly where called and are compiled there. This reduces function call overhead and presumably allows compiler optimizations. A user shared that the new `pow_int` in version 1.0.0 introduced a surprisingly large slowdown in performance compared to previous versions, and this was traced to `pow` becoming `pow_int` in user-defined code. 

This PR inlines the following (with notes on performance [before --> after] on a mac for 10 million calls, timed in seconds):

- `pow_int` (0.201 --> 2e-6)
- `ilogit`.     (0.073 --> 2e-6)
- `logit`       (ditto)
- `cloglog`. (0.143 --> 2e-6)
- `icloglog` (0.146 --> 2e-6)
- `iprobit` (little difference because the cost is in pnorm)
- `probit`. (little difference because the cost is in qnorm)
- `nimEquals`
- `nimbleIfElse`
- `lfactorial` (little difference because the cost is in lgamma)
- `factorial`. (little difference because the cost is in gamma)
- `nimRound`
- `pairmax` in overloaded (double, double) case
- `pairmin` (ditto)
- `nimStep`
- `cube`
- `inprod` in overloaded (double, double) case (should be rare)

Cases without notes went from about 0.03-->2e-6, and that 0.03 might be just the baseline cost of packing up function calls.

All of these seem fast before or after the changes (these are cumulative times for *10 million* calls). Yet, the `pow_int` was the source of a serious slowdown, so perhaps the overhead and costs compound in more complex compiled situations using lots of memory etc. The benchmarks I ran were isolated and had nothing else going on.