### PR TITLE
additional catch for vector inits lists of lists

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -372,6 +372,10 @@ modelDefClass$methods(assignDimensions = function(dimensions, initsList, dataLis
         }
     }
 
+    ## update added Dec 2023, DT ... tbt earlier update in newModel method (Oct 2015)
+    ## handling for JAGS style inits (a list of lists)
+    if(length(initsList) > 0 && is.list(initsList[[1]]))   initsList <- inits[[1]]
+    ##
     # add dimensions of any *non-scalar* inits to dimensionsList
     # we'll try to be smart about this: check for duplicate names in inits and dimensions, and make sure they agree
     for(i in seq_along(initsList)) {

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -374,7 +374,7 @@ modelDefClass$methods(assignDimensions = function(dimensions, initsList, dataLis
 
     ## update added Dec 2023, DT ... tbt earlier update in newModel method (Oct 2015)
     ## handling for JAGS style inits (a list of lists)
-    if(length(initsList) > 0 && is.list(initsList[[1]]))   initsList <- inits[[1]]
+    if(length(initsList) > 0 && is.list(initsList[[1]]))   initsList <- initsList[[1]]
     ##
     # add dimensions of any *non-scalar* inits to dimensionsList
     # we'll try to be smart about this: check for duplicate names in inits and dimensions, and make sure they agree


### PR DESCRIPTION
Error fix for inits provided as a list of lists, for non-scalar inits lists.