### PR TITLE
warn if indexing in model code uses vars from user environment rather than `constants`

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -327,7 +327,7 @@ modelDefClass$methods(assignBUGScode = function(code) {
 })
 modelDefClass$methods(assignConstants = function(constants) {
     ## uses 'constants' argument, sets fields: constantsEnv, constantsList, constantsNamesList
-    constantsEnv <<- new.env()
+    constantsEnv <<- new.env(parent = baseenv())  # baseenv() prevents lookup in user env (see issue 468)
     if(length(constants) > 0) {
         if(!is.list(constants) || is.null(names(constants)))   stop('constants argument must be a named list')
         list2env(constants, constantsEnv)

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -327,7 +327,7 @@ modelDefClass$methods(assignBUGScode = function(code) {
 })
 modelDefClass$methods(assignConstants = function(constants) {
     ## uses 'constants' argument, sets fields: constantsEnv, constantsList, constantsNamesList
-    constantsEnv <<- new.env(parent = baseenv())  # baseenv() prevents lookup in user env (see issue 468)
+    constantsEnv <<- new.env() 
     if(length(constants) > 0) {
         if(!is.list(constants) || is.null(names(constants)))   stop('constants argument must be a named list')
         list2env(constants, constantsEnv)
@@ -1461,6 +1461,10 @@ determineContextSize <- function(context, useContext = rep(TRUE, length(context$
     test <- try(eval(innerLoopCode, evalEnv))
     if(is(test, 'try-error'))
         stop("Could not evaluate loop syntax: is indexing information provided via 'constants'?")
+    wh <- which(!all.vars(innerLoopCode) %in% c(ls(evalEnv), context$indexVarNames))
+    if(length(wh))
+        messageIfVerbose("  [Warning] Indexing information for ", paste(all.vars(innerLoopCode)[wh], collapse = ", "),
+                " not provided in `constants`.\n            Information has been found in the user's environment,\n            but we recommend all indexing information be provided via `constants`.")
     ans <- evalEnv$iAns
     rm(list = c('iAns', context$indexVarNames[useContext]), envir = evalEnv)
     return(ans)

--- a/packages/nimble/tests/testthat/test-models.R
+++ b/packages/nimble/tests/testthat/test-models.R
@@ -1016,6 +1016,7 @@ test_that("Warning printed when indexing info in user environment.", {
             y[i] ~ dnorm(0,1)
     })
     N <- 3
+    temporarilyAssignInGlobalEnv(N)
     expect_message(m <- nimbleModel(code, constants = list(foo=3)),
                    "Information has been found in the user's environment")
 })

--- a/packages/nimble/tests/testthat/test-models.R
+++ b/packages/nimble/tests/testthat/test-models.R
@@ -1010,5 +1010,16 @@ test_that("Example of splitVertices bug from Issue 1268 works.", {
   expect_no_error(Rmodel <- nimbleModel(code, constants = list(index=c(1,1))))
 })
 
+test_that("Warning printed when indexing info in user environment.", {
+    code <- nimbleCode({
+        for(i in 1:N)
+            y[i] ~ dnorm(0,1)
+    })
+    N <- 3
+    expect_message(m <- nimbleModel(code, constants = list(foo=3)),
+                   "Information has been found in the user's environment")
+})
+
+
 options(warn = RwarnLevel)
 nimbleOptions(verbose = nimbleVerboseSetting)


### PR DESCRIPTION
Fixes NCT issue 468.