### PR TITLE
detect invalid variable names in nfcode

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -20,6 +20,10 @@ graphNode <- setRefClass(
     )
 )
 
+reservedKeywords <- c("Values", "NimArr")  # These prevent compilation. Not clear without further investigation why othe class names in `include/nimble` do not.
+## Add C++ keywords (from https://en.cppreference.com/w/cpp/keyword).
+reservedKeywords <- c("reservedKeywords", "alignas", "alignof", "and", "and_eq", "asm", "atomic_cancel", "atomic_commit", "atomic_noexcept", "auto", "bitand", "bitor", "bool", "break", "case", "catch", "char", "char8_t", "char16_t", "char32_t", "class", "compl", "concept", "const", "consteval", "constexpr", "constinit", "const_cast", "continue", "co_await", "co_return", "co_yield", "decltype", "default", "delete", "do", "double", "dynamic_cast", "else", "enum", "explicit", "export", "extern", "false", "float", "for", "friend", "goto", "if", "inline", "int", "long", "mutable", "namespace", "new", "noexcept", "not", "not_eq", "nullptr", "operator", "or", "or_eq", "private", "protected", "public", "reflexpr", "register", "reinterpret_cast", "requires", "return", "short", "signed", "sizeof ", "static", "static_assert", "static_cast", "struct ", "switch", "synchronized", "template", "this", "thread_local", "throw", "true", "try", "typedef", "typeid", "typename", "union", "unsigned", "using ", "virtual", "void", "volatile", "wchar_t", "while", "xor", "xor_eq")
+
 #' Class for NIMBLE model definition
 #'
 #' Class for NIMBLE model definition that is not usually needed directly by a user.
@@ -139,6 +143,7 @@ modelDefClass$methods(setupModel = function(code, constants, dimensions, inits, 
     checkUnusedConstants(code, constants)          ## Need to do check before we process if-then-else, or constants used for if-then-else would be flagged.
     code <- codeProcessIfThenElse(code, constants, userEnv) ## evaluate definition-time if-then-else
     if(nimbleOptions("enableModelMacros")) code <- codeProcessModelMacros(code)
+    checkReservedVarNames(code) 
     setModelValuesClassName()         ## uses 'name' field to set field: modelValuesClassName
     assignBUGScode(code)              ## uses 'code' argument, assigns field: BUGScode.  puts codes through nf_changeNimKeywords
     assignConstants(constants)        ## uses 'constants' argument, sets fields: constantsEnv, constantsList, constantsNamesList
@@ -303,6 +308,14 @@ codeProcessModelMacros <- function(code,
     }
     code
 }
+
+checkReservedVarNames <- function(code) {
+    nms <- all.names(code)
+    wh <- which(nms %in% reservedKeywords)
+    if(length(wh))
+        stop("Found variable name that conflicts with C++ keywords: ", paste0(nms[wh], collapse = ", "), ". Please use a different name.")
+}
+
 
 modelDefClass$methods(checkUnusedConstants = function(code, constants) {
     constantsEnv <<- new.env()

--- a/packages/nimble/tests/testthat/test-models.R
+++ b/packages/nimble/tests/testthat/test-models.R
@@ -1010,5 +1010,12 @@ test_that("Example of splitVertices bug from Issue 1268 works.", {
   expect_no_error(Rmodel <- nimbleModel(code, constants = list(index=c(1,1))))
 })
 
+test_that("Reserved keywords as model vars are trapped.", {
+    code <- nimbleCode({
+        double ~ dnorm(0,1)
+    })
+    expect_error(m <- nimbleModel(code), info = "Found variable names that conflict")
+})
+
 options(warn = RwarnLevel)
 nimbleOptions(verbose = nimbleVerboseSetting)


### PR DESCRIPTION
Fixes #1335 , a longstanding issue that certain variable names conflict with C++ keywords but this is not error-trapped and C++ compilation fails.