### PR TITLE
add name mangling of . to nf names

### DIFF
--- a/packages/nimble/R/all_utils.R
+++ b/packages/nimble/R/all_utils.R
@@ -24,6 +24,7 @@ labelFunctionMetaCreator <- function() {
                 nextIndex <<- 1
                 return(invisible(NULL))
             }
+            envName <- gsub("\\.", "_dot_", envName)
             lead <- paste(lead, envName , sep = '_')
             ans <- paste0(lead, nextIndex - 1 + (1:count))
             nextIndex <<- nextIndex + count

--- a/packages/nimble/inst/NEWS.md
+++ b/packages/nimble/inst/NEWS.md
@@ -7,6 +7,9 @@
 
 ## DEVELOPER LEVEL CHANGES
 
+- Fix error with name mangling affecting packages that use nimble
+  and have dot(s) in the package name (issue #1332)
+  
 - Make change to `nimble-package` documentation to use `"_PACKAGE"`
 instead of `@docType` per CRAN request (issue #1359).
 


### PR DESCRIPTION
Fixes issue #1332 , which affects packages that depend on nimble and have dots in name of package.