### PR TITLE
fix besselK to have standard `toEigenize`

### DIFF
--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -539,7 +539,7 @@ sizeRecyclingRuleBesselK <- function(code, symTab, typeEnv) { ## also need an en
     code$sizeExprs <- newSizeExprs
     code$type <- 'double' ## will need to look up from a list
     code$nDim <- 1
-    code$toEigenize <- TRUE
+    code$toEigenize <- 'yes'
     return(asserts)
 }
 


### PR DESCRIPTION
@perrydv wanted to look at this, in part to figure out why it hasn't caused a problem already.