### PR TITLE
enable AD for CAR models

### DIFF
--- a/packages/nimble/LICENSE
+++ b/packages/nimble/LICENSE
@@ -1,3 +1,3 @@
-YEAR: 2023
+YEAR: 2024
 COPYRIGHT HOLDER: Perry de Valpine, Christopher Paciorek, Daniel Turek, Clifford Anderson-Bergman, Nick Michaud, Fritz Obermeyer, Claudia Wehrhahn Cortes, Abel Rodriguez, Sally Paganin, Wei Zhang, Duncan Temple Lang
 ORGANIZATION: University of California

--- a/packages/nimble/R/CAR.R
+++ b/packages/nimble/R/CAR.R
@@ -23,7 +23,7 @@ CAR_convertWeightMatrix <- function(weightMatrix) {
 #' 
 #' Two alternate representations are handled:
 #'
-#' A single matrix argument will be interpreted as a matrix of symmetric unnormalized weights;
+#' A single matrix argument will be interpreted as a matrix of symmetric unnormalized weights.
 #'
 #' Two lists will be interpreted as (the first) a list of numeric vectors
 #' specifying the adjacency (neighboring) indices of each CAR process component,

--- a/packages/nimble/R/CAR.R
+++ b/packages/nimble/R/CAR.R
@@ -234,8 +234,8 @@ CAR_calcNumIslands <- nimbleFunction(
     run = function(adj_in = double(1), num_in = double(1)) {
         N <- dim(num_in)[1]
         L <- dim(adj_in)[1]
-        adj <- nimInteger(L)
-        num <- nimInteger(N)
+        adj <- nimInteger(L, init = FALSE)
+        num <- nimInteger(N, init = FALSE)
         for(i in 1:L)
             adj[i] <- ADbreak(adj_in[i])
         for(i in 1:N)
@@ -250,8 +250,8 @@ CAR_calcNumIslands <- nimbleFunction(
                 if(nNeighbors > 0) {
                     adjStartInd <- 1L
                     if(i > 1) adjStartInd <- adjStartInd + sum(num[1:(i-1)])
-                    indToVisit <- nimInteger(nNeighbors)
-                    indToVisit[1:nNeighbors] <- adj[adjStartInd:(adjStartInd+nNeighbors-1)]
+                    indToVisit <- nimInteger(nNeighbors,
+                                             value = adj[adjStartInd:(adjStartInd+nNeighbors-1)])
                     lengthIndToVisit <- nNeighbors
                     l <- 1L
                     while(l <= lengthIndToVisit) {
@@ -312,7 +312,7 @@ CAR_calcC <- nimbleFunction(
     run = function(adj = double(1), num_in = double(1)) {
         N <- dim(num_in)[1]
         L <- dim(adj)[1]
-        num <- nimInteger(N)
+        num <- nimInteger(N, init = FALSE)
         for(i in 1:N)
             num[i] <- ADbreak(num_in[i])
         C <- rep(0, length = L)
@@ -343,13 +343,13 @@ CAR_calcCmatrix <- nimbleFunction(
     run = function(C = double(1), adj_in = double(1), num_in = double(1)) {
         N <- dim(num_in)[1]
         L <- dim(adj_in)[1]
-        adj <- nimInteger(L)
-        num <- nimInteger(N)
+        adj <- nimInteger(L, init = FALSE)
+        num <- nimInteger(N, init = FALSE)
         for(i in 1:L)
             adj[i] <- ADbreak(adj_in[i])
         for(i in 1:N)
             num[i] <- ADbreak(num_in[i])
-        Cmatrix <- array(0, dim = c(N, N))
+        Cmatrix <- nimMatrix(value = 0, nrow = N, ncol = N)
         count <- 1L
         for(i in 1:N) {
             if(num[i] > 0) {
@@ -468,7 +468,7 @@ CAR_calcEVs2 <- nimbleFunction(
         C <- CAR_calcC(adj, num)
         Cmatrix_out <- CAR_calcCmatrix(C, adj, num)
         ## Need to make sure Cmatrix not tracked or have issue with conversion of CppAD double in call to nimEigen.
-        Cmatrix <- nimMatrix(nrow = N, ncol = N)
+        Cmatrix <- nimMatrix(nrow = N, ncol = N, init = FALSE)
         for(i in 1:N)  
             for(j in 1:N)
                 Cmatrix[i,j] <- ADbreak(Cmatrix_out[i,j])
@@ -501,7 +501,7 @@ CAR_calcEVs3 <- nimbleFunction(
     run = function(C = double(1), adj = double(1), num = double(1)) {
         N <- dim(num)[1]
         Cmatrix_out <- CAR_calcCmatrix(C, adj, num)
-        Cmatrix <- nimMatrix(nrow = N, ncol = N)
+        Cmatrix <- nimMatrix(nrow = N, ncol = N, init = FALSE)
         for(i in 1:N)  
             for(j in 1:N)
                 Cmatrix[i,j] <- ADbreak(Cmatrix_out[i,j])

--- a/packages/nimble/R/CAR.R
+++ b/packages/nimble/R/CAR.R
@@ -299,7 +299,7 @@ CAR_calcM <- nimbleFunction(
         returnType(double(1))
         return(M)
     },
-    buildDerivs = list(run  = list(ignore = c("i")))
+    buildDerivs = list(run  = list(ignore = c("i","M")))
 )
 
 
@@ -507,7 +507,7 @@ CAR_calcEVs3 <- nimbleFunction(
                 Cmatrix[i,j] <- ADbreak(Cmatrix_out[i,j])
         evs <- nimEigen(Cmatrix, only.values = TRUE)$values
         ## NaN eigenvalues occur when Cmatrix is singular.
-        tmp <- numNumeric(N)
+        tmp <- nimNumeric(N)
         for(i in 1:N)
             tmp[i] <- ADbreak(evs[i])
         if(any_nan(tmp)) {

--- a/packages/nimble/R/CAR.R
+++ b/packages/nimble/R/CAR.R
@@ -329,7 +329,7 @@ CAR_calcC <- nimbleFunction(
         returnType(double(1))
         return(C)
     },
-    buildDerivs = list(run  = list(ignore = c("i","j")))
+    buildDerivs = list(run  = list(ignore = c("i", "j")))
 )
 
 
@@ -349,7 +349,6 @@ CAR_calcCmatrix <- nimbleFunction(
             adj[i] <- ADbreak(adj_in[i])
         for(i in 1:N)
             num[i] <- ADbreak(num_in[i])
-       
         Cmatrix <- array(0, dim = c(N, N))
         count <- 1L
         for(i in 1:N) {
@@ -513,7 +512,7 @@ CAR_calcEVs3 <- nimbleFunction(
             tmp[i] <- ADbreak(evs[i])
         if(any_nan(tmp)) {
             for(i in 1:N) {
-                tmpi <- tmp[i]
+                tmpi <- tmp[i]  # o.w. lifted node is CppAD double.
                 if(is.nan(tmpi)) evs[i] <- 0
             }
         }

--- a/packages/nimble/R/CAR.R
+++ b/packages/nimble/R/CAR.R
@@ -234,12 +234,12 @@ CAR_calcNumIslands <- nimbleFunction(
     run = function(adj_in = double(1), num_in = double(1)) {
         N <- dim(num_in)[1]
         L <- dim(adj_in)[1]
-        adj = nimInteger(L)
-        num = nimInteger(N)
+        adj <- nimInteger(L)
+        num <- nimInteger(N)
         for(i in 1:L)
-            adj[i] = ADbreak(adj_in[i])
+            adj[i] <- ADbreak(adj_in[i])
         for(i in 1:N)
-            num[i] = ADbreak(num_in[i])
+            num[i] <- ADbreak(num_in[i])
         numIslands <- 0L
         visited <- rep(0L, N)
         for(i in 1:N) {
@@ -293,12 +293,13 @@ CAR_calcM <- nimbleFunction(
         M <- rep(-1234, length = N)   ## Mi = -1234 indicates M was auto-generated, and region i has 0 neighbors
         for(i in 1:N) {
             if(num[i] > 0) {
-                M[i] <- 1/num[i]
+                M[i] <- ADbreak(1/num[i])
             }
         }
         returnType(double(1))
         return(M)
-    }
+    },
+    buildDerivs = list(run  = list(ignore = c("i")))
 )
 
 
@@ -308,11 +309,14 @@ CAR_calcM <- nimbleFunction(
 ## @author Daniel Turek
 CAR_calcC <- nimbleFunction(
     name = 'CAR_calcC',
-    run = function(adj = double(1), num = double(1)) {
-        N <- dim(num)[1]
+    run = function(adj = double(1), num_in = double(1)) {
+        N <- dim(num_in)[1]
         L <- dim(adj)[1]
+        num <- nimInteger(N)
+        for(i in 1:N)
+            num[i] <- ADbreak(num_in[i])
         C <- rep(0, length = L)
-        count <- 1
+        count <- 1L
         for(i in 1:N) {
             if(num[i] > 0) {
                 for(j in 1:num[i]) {
@@ -324,7 +328,8 @@ CAR_calcC <- nimbleFunction(
         if(count != L+1)   stop('dcar distribution internal error')
         returnType(double(1))
         return(C)
-    }
+    },
+    buildDerivs = list(run  = list(ignore = c("i","j")))
 )
 
 
@@ -335,15 +340,22 @@ CAR_calcC <- nimbleFunction(
 ## @author Daniel Turek
 CAR_calcCmatrix <- nimbleFunction(
     name = 'CAR_calcCmatrix',
-    run = function(C = double(1), adj = double(1), num = double(1)) {
-        N <- dim(num)[1]
-        L <- dim(adj)[1]
+    run = function(C = double(1), adj_in = double(1), num_in = double(1)) {
+        N <- dim(num_in)[1]
+        L <- dim(adj_in)[1]
+        adj <- nimInteger(L)
+        num <- nimInteger(N)
+        for(i in 1:L)
+            adj[i] <- ADbreak(adj_in[i])
+        for(i in 1:N)
+            num[i] <- ADbreak(num_in[i])
+       
         Cmatrix <- array(0, dim = c(N, N))
-        count <- 1
+        count <- 1L
         for(i in 1:N) {
             if(num[i] > 0) {
                 for(j in 1:num[i]) {
-                    Cmatrix[i, adj[count]] <- C[count]
+                    Cmatrix[i, adj[count]] <- ADbreak(C[count])
                     count <- count + 1
                 }
             }
@@ -351,7 +363,8 @@ CAR_calcCmatrix <- nimbleFunction(
         if(count != L+1)   stop('dcar distribution internal error')
         returnType(double(2))
         return(Cmatrix)
-    }
+    },
+    buildDerivs = list(run  = list(ignore = c("i", "j")))
 )
 
 
@@ -452,20 +465,30 @@ carMaxBound <- nimbleFunction(
 CAR_calcEVs2 <- nimbleFunction(
     name = 'CAR_calcEVs2',
     run = function(adj = double(1), num = double(1)) {
+        N <- dim(num)[1]
         C <- CAR_calcC(adj, num)
-        Cmatrix <- CAR_calcCmatrix(C, adj, num)
+        Cmatrix_out <- CAR_calcCmatrix(C, adj, num)
+        ## Need to make sure Cmatrix not tracked or have issue with conversion of CppAD double in call to nimEigen.
+        Cmatrix <- nimMatrix(nrow = N, ncol = N)
+        for(i in 1:N)  
+            for(j in 1:N)
+                Cmatrix[i,j] <- ADbreak(Cmatrix_out[i,j])
         evs <- nimEigen(Cmatrix, only.values = TRUE)$values
-        ## new code below, to replace NaN eigenvalues of Cmatrix with 0,
-        ## which occurs when Cmatrix is singular
-        ## -DT June 2020
-        if(any_nan(evs)) {
-            for(i in 1:length(evs)) {
-                if(is.nan(evs[i])) evs[i] <- 0
+        ## NaN eigenvalues occur when Cmatrix is singular.
+        ## Need to make sure arg of `any_nan` and `is.nan` are not CppAD types.
+        tmp <- nimNumeric(N)
+        for(i in 1:N)
+            tmp[i] <- ADbreak(evs[i])
+        if(any_nan(tmp)) {
+            for(i in 1:N) {
+                tmpi <- tmp[i]  # o.w. lifted node is CppAD double.
+                if(is.nan(tmpi)) evs[i] <- 0
             }
         }
         returnType(double(1))
         return(evs)
-    }
+    },
+    buildDerivs = list(run  = list(ignore = c("i", "j", "tmp", "tmpi", "Cmatrix")))
 )
 
 
@@ -477,19 +500,27 @@ CAR_calcEVs2 <- nimbleFunction(
 CAR_calcEVs3 <- nimbleFunction(
     name = 'CAR_calcEVs3',
     run = function(C = double(1), adj = double(1), num = double(1)) {
-        Cmatrix <- CAR_calcCmatrix(C, adj, num)
+        N <- dim(num)[1]
+        Cmatrix_out <- CAR_calcCmatrix(C, adj, num)
+        Cmatrix <- nimMatrix(nrow = N, ncol = N)
+        for(i in 1:N)  
+            for(j in 1:N)
+                Cmatrix[i,j] <- ADbreak(Cmatrix_out[i,j])
         evs <- nimEigen(Cmatrix, only.values = TRUE)$values
-        ## new code below, to replace NaN eigenvalues of Cmatrix with 0,
-        ## which occurs when Cmatrix is singular
-        ## -DT June 2020
-        if(any_nan(evs)) {
-            for(i in 1:length(evs)) {
-                if(is.nan(evs[i])) evs[i] <- 0
+        ## NaN eigenvalues occur when Cmatrix is singular.
+        tmp <- numNumeric(N)
+        for(i in 1:N)
+            tmp[i] <- ADbreak(evs[i])
+        if(any_nan(tmp)) {
+            for(i in 1:N) {
+                tmpi <- tmp[i]
+                if(is.nan(tmpi)) evs[i] <- 0
             }
         }
         returnType(double(1))
         return(evs)
-    }
+    },
+    buildDerivs = list(run  = list(ignore = c("i", "tmp", "tmpi", "Cmatrix")))
 )
 
 

--- a/packages/nimble/R/CAR.R
+++ b/packages/nimble/R/CAR.R
@@ -231,22 +231,29 @@ CAR_proper_processParams <- function(model, target, C, adj, num, M) {
 #' @export
 CAR_calcNumIslands <- nimbleFunction(
     name = 'CAR_calcNumIslands',
-    run = function(adj = double(1), num = double(1)) {
-        N <- dim(num)[1]
-        numIslands <- 0
-        visited <- rep(0, N)
+    run = function(adj_in = double(1), num_in = double(1)) {
+        N <- dim(num_in)[1]
+        L <- dim(adj_in)[1]
+        adj = nimInteger(L)
+        num = nimInteger(N)
+        for(i in 1:L)
+            adj[i] = ADbreak(adj_in[i])
+        for(i in 1:N)
+            num[i] = ADbreak(num_in[i])
+        numIslands <- 0L
+        visited <- rep(0L, N)
         for(i in 1:N) {
             if(visited[i] == 0) {
                 visited[i] <- 1
                 numIslands <- numIslands + 1
                 nNeighbors <- num[i]
                 if(nNeighbors > 0) {
-                    adjStartInd <- 1
+                    adjStartInd <- 1L
                     if(i > 1) adjStartInd <- adjStartInd + sum(num[1:(i-1)])
-                    indToVisit <- numeric(nNeighbors)
+                    indToVisit <- nimInteger(nNeighbors)
                     indToVisit[1:nNeighbors] <- adj[adjStartInd:(adjStartInd+nNeighbors-1)]
                     lengthIndToVisit <- nNeighbors
-                    l <- 1
+                    l <- 1L
                     while(l <= lengthIndToVisit) {
                         nextInd <- indToVisit[l]
                         if(visited[nextInd] == 0) {
@@ -254,7 +261,7 @@ CAR_calcNumIslands <- nimbleFunction(
                             newNneighbors <- num[nextInd]
                             if(newNneighbors > 0) {
                                 newIndToVisit <- numeric(newNneighbors)
-                                adjStartInd <- 1
+                                adjStartInd <- 1L
                                 if(nextInd > 1) adjStartInd <- adjStartInd + sum(num[1:(nextInd-1)])
                                 new_indToVisit <- c(indToVisit, adj[adjStartInd:(adjStartInd+newNneighbors-1)])
                                 new_lengthIndToVisit <- lengthIndToVisit + newNneighbors
@@ -269,7 +276,8 @@ CAR_calcNumIslands <- nimbleFunction(
         }
         returnType(double())
         return(numIslands)
-    }
+    },
+    buildDerivs = list(run  = list(ignore = c("i")))
 )
 
 

--- a/packages/nimble/R/CAR.R
+++ b/packages/nimble/R/CAR.R
@@ -299,7 +299,7 @@ CAR_calcM <- nimbleFunction(
         returnType(double(1))
         return(M)
     },
-    buildDerivs = list(run  = list(ignore = c("i","M")))
+    buildDerivs = list(run  = list(ignore = c("i")))
 )
 
 

--- a/packages/nimble/R/RCfunction_core.R
+++ b/packages/nimble/R/RCfunction_core.R
@@ -69,7 +69,7 @@ fxnsNotAllowedInAD <- c(
   paste0('r', c('cat', 'interval', 'car_normal', 'car_proper',
                 'dirch','mnorm_chol','multi','mvt_chol','lkj_corr_cholesky','wish_chol',
                 'invwish_chol')),
-  paste0('nimArr_d', c('cat', 'dcar_normal', 'dcar_proper', 'interval')),
+  paste0('nimArr_d', c('cat', 'car_normal', 'car_proper', 'interval')),
   paste0('nimArr_r', c('mnorm_chol','mvt_chol', 'lkj_corr_cholesky','wish_chol',
                        'invwish_chol', 'car_normal','car_proper','multi','dirch') ),
   'getLogProb',

--- a/packages/nimble/R/RCfunction_core.R
+++ b/packages/nimble/R/RCfunction_core.R
@@ -43,7 +43,7 @@ nimKeyWords <- list(copy = 'nimCopy',
                     derivs = 'nimDerivs')
 
 distsNotAllowedInAD <- c(
-  paste0('d', c('cat', 'interval', 'car_normal', 'car_proper', 'constraint'))
+  paste0('d', c('cat', 'interval', 'constraint'))
 )
 
 fxnsNotAllowedInAD <- c(

--- a/packages/nimble/R/distributions_implementations.R
+++ b/packages/nimble/R/distributions_implementations.R
@@ -1047,7 +1047,6 @@ rcar_normal <- function(n = 1, adj, weights = adj/adj, num, tau, c = CAR_calcNum
 #' @name CAR-Proper
 #'
 #' @param x vector of values.
-#' @param n number of observations.
 #' @param mu vector of the same length as \code{x}, specifying the mean for each spatial location.
 #' @param C vector of the same length as \code{adj}, giving the weights associated with each pair of neighboring locations.  See \sQuote{Details}.
 #' @param adj vector of indices of the adjacent locations (neighbors) of each spatial location.  This is a sparse representation of the full adjacency matrix.

--- a/packages/nimble/R/genCpp_operatorLists.R
+++ b/packages/nimble/R/genCpp_operatorLists.R
@@ -340,6 +340,7 @@ nimDerivsPrependTypeOperators <- c("dnorm", "dpois", "dgamma", "dinvgamma", "dsq
                                    "dt_nonstandard", "nimArr_dmulti", "nimArr_dcat", "dnbinom", "dunif", "pairmax", "pairmin", 
                                    "nimArr_ddirch", "nimArr_dmvt_chol", "nimArr_dmnorm_chol", 
                                    "nimArr_dwish_chol", "nimArr_dinvwish_chol", "nimArr_dlkj_corr_cholesky",
+                                   "nimArr_dcar_normal", "nimArr_dcar_proper",
                                    "nimStep", 'ilogit', 'icloglog', 'iprobit', 'probit', 'cloglog',
                                    "nimEquals", "lgammafn", "gammafn", "lfactorial", "factorial",
                                    "logit", "floor", "ceil", "nimRound", "ftrunc",

--- a/packages/nimble/R/parameterTransform.R
+++ b/packages/nimble/R/parameterTransform.R
@@ -178,7 +178,7 @@ parameterTransform <- nimbleFunction(
                     next }
                 stop(paste0('`parameterTransform` system doesn\'t have a transformation for the bounds of node: ', node, ', which are (', bounds[1], ', ', bounds[2], ')'))
             } else {   ## multivariate
-                if(dist %in% c('dmnorm', 'dmvt')) {               ## 6: multivariate {normal, t}; also set for non-scalar determ nodes when allowDeterm is TRUE
+                if(dist %in% c('dmnorm', 'dmvt', 'dcar_normal', 'dcar_proper')) {               ## 6: multivariate {normal, t}; also set for non-scalar determ nodes when allowDeterm is TRUE
                     transformType[i] <- 6L
                     d <- length(model$expandNodeNames(node, returnScalarComponents = TRUE))
                     transformData[i,NIND2] <- transformData[i,NIND1] + d - 1

--- a/packages/nimble/R/parameterTransform.R
+++ b/packages/nimble/R/parameterTransform.R
@@ -96,7 +96,7 @@ parameterTransform <- nimbleFunction(
         ## 3: scalar interval-constrained (0, 1)
         ## 4: scalar semi-interval (-Inf, b) or (a, Inf)
         ## 5: scalar interval-constrained (a, b)
-        ## 6: multivariate {normal, t}
+        ## 6: multivariate {normal, t, CAR}
         ## 7: multivariate {wishart, inverse-wishart}
         ## 8: multivariate dirichlet
         ## 9: LKJ 
@@ -178,7 +178,7 @@ parameterTransform <- nimbleFunction(
                     next }
                 stop(paste0('`parameterTransform` system doesn\'t have a transformation for the bounds of node: ', node, ', which are (', bounds[1], ', ', bounds[2], ')'))
             } else {   ## multivariate
-                if(dist %in% c('dmnorm', 'dmvt', 'dcar_normal', 'dcar_proper')) {               ## 6: multivariate {normal, t}; also set for non-scalar determ nodes when allowDeterm is TRUE
+                if(dist %in% c('dmnorm', 'dmvt', 'dcar_normal', 'dcar_proper')) {               ## 6: multivariate {normal, t, CAR}; also set for non-scalar determ nodes when allowDeterm is TRUE
                     transformType[i] <- 6L
                     d <- length(model$expandNodeNames(node, returnScalarComponents = TRUE))
                     transformData[i,NIND2] <- transformData[i,NIND1] + d - 1
@@ -233,7 +233,7 @@ parameterTransform <- nimbleFunction(
                           theseTransformed <- logit(theseValues),  ## 3: scalar interval-constrained (0, 1)
                           theseTransformed <- log(transformData[iNode,DATA2] * (theseValues - transformData[iNode,DATA1])),    ## 4: scalar semi-interval (-Inf, b) or (a, Inf)
                           theseTransformed <- logit((theseValues - transformData[iNode,DATA1]) / transformData[iNode,DATA2]),  ## 5: scalar interval-constrained (a, b)
-                          theseTransformed <- theseValues,         ## 6: multivariate {normal, t}
+                          theseTransformed <- theseValues,         ## 6: multivariate {normal, t, CAR}
                           {                                        ## 7: multivariate {wishart, inverse-wishart}
                               ## log-Cholesky transform, values are column-wise
                               dd <- transformData[iNode,DATA1]
@@ -306,7 +306,7 @@ parameterTransform <- nimbleFunction(
                           theseInvTransformed <- ilogit(theseValues),  ## 3: scalar interval-constrained (0, 1)
                           theseInvTransformed <- transformData[iNode,DATA1] + transformData[iNode,DATA2] * exp(theseValues),    ## 4: scalar semi-interval (-Inf, b) or (a, Inf)
                           theseInvTransformed <- transformData[iNode,DATA1] + transformData[iNode,DATA2] * expit(theseValues),  ## 5: scalar interval-constrained (a, b)
-                          theseInvTransformed <- theseValues,          ## 6: multivariate {normal, t}
+                          theseInvTransformed <- theseValues,          ## 6: multivariate {normal, t, CAR}
                           {                                            ## 7: multivariate {wishart, inverse-wishart}
                               dd <- transformData[iNode,DATA1]
                               cholAsMatrix <- nimArray(0, dim = c(dd, dd))
@@ -389,7 +389,7 @@ parameterTransform <- nimbleFunction(
                               x <- theseValues[1]
                               lpAdd <- log(transformData[iNode,DATA2]) - log(exp(x)+exp(-x)+2)  ## alternate: -2*log(1+exp(-x))-x)
                           },
-                          lpAdd <- 0,               ## 6: multivariate {normal, t}
+                          lpAdd <- 0,               ## 6: multivariate {normal, t, CAR}
                           {                         ## 7: multivariate {wishart, inverse-wishart}
                               dd <- transformData[iNode,DATA1]
                               lpAdd <- dd * log(2)

--- a/packages/nimble/inst/include/nimble/nimDerivs_dists.h
+++ b/packages/nimble/inst/include/nimble/nimDerivs_dists.h
@@ -1064,7 +1064,7 @@ Type nimDerivs_nimArr_dcar_normal(NimArr<1, Type> &x, NimArr<1, Type> &adj, NimA
   // where tau is precision, c = (number of islands), and N is the length of x.
   // This is the density on an N-c dimensional space, and improper on the remaining c dimensions.
   if(CppAD::Value(tau) < 0) {
-    return Type(R_NaN);
+    return CppAD::numeric_limits<Type>::quiet_NaN();
   }
   //PRINTF("c is equal to %d\n", c);
   int N = x.size();
@@ -1081,8 +1081,8 @@ Type nimDerivs_nimArr_dcar_normal(NimArr<1, Type> &x, NimArr<1, Type> &adj, NimA
       count++;
     }
   }
-  if(Type(count) != Type(L)) {
-    return Type(R_NaN);
+  if(count != L) {
+    return CppAD::numeric_limits<Type>::quiet_NaN();
   }
   lp *= Type(1/2.0);     // accounts for double-summing over all (xi,xj) pairs
   lp *= Type(-1/2.0) * tau;
@@ -1100,7 +1100,7 @@ Type nimDerivs_nimArr_dcar_normal_logFixed(NimArr<1, Type> &x, NimArr<1, Type> &
   // where tau is precision, c = (number of islands), and N is the length of x.
   // This is the density on an N-c dimensional space, and improper on the remaining c dimensions.
   if(CppAD::Value(tau) < 0) {
-    return Type(R_NaN);
+    return CppAD::numeric_limits<Type>::quiet_NaN();
   }
   //PRINTF("c is equal to %d\n", c);
   int N = x.size();
@@ -1118,7 +1118,7 @@ Type nimDerivs_nimArr_dcar_normal_logFixed(NimArr<1, Type> &x, NimArr<1, Type> &
     }
   }
   if(Type(count) != Type(L)) {
-    return Type(R_NaN);
+    return CppAD::numeric_limits<Type>::quiet_NaN();
   }
   lp *= Type(1/2.0);     // accounts for double-summing over all (xi,xj) pairs
   lp *= Type(-1/2.0) * tau;
@@ -1139,7 +1139,7 @@ Type nimDerivs_nimArr_dcar_proper(NimArr<1, Type> &x, NimArr<1, Type> &mu, NimAr
   int L = adj.size();
 
   if(CppAD::Value(tau) < 0) {
-    return Type(R_NaN);
+    return CppAD::numeric_limits<Type>::quiet_NaN();
   }
   Type lp = 0;
   Type xi, xj;
@@ -1157,7 +1157,7 @@ Type nimDerivs_nimArr_dcar_proper(NimArr<1, Type> &x, NimArr<1, Type> &mu, NimAr
     }
   }
   if(Type(count) != Type(L)) {
-    return Type(R_NaN);
+    return CppAD::numeric_limits<Type>::quiet_NaN();
   }
   lp *= Type(-1/2.0) * tau;
   // now add -1/2*log(|2*pi*Sigma|) to lp:
@@ -1181,7 +1181,7 @@ Type nimDerivs_nimArr_dcar_proper_logFixed(NimArr<1, Type> &x, NimArr<1, Type> &
   int L = adj.size();
 
   if(CppAD::Value(tau) < 0) {
-    return Type(R_NaN);
+    return CppAD::numeric_limits<Type>::quiet_NaN();
   }
   Type lp = 0;
   Type xi, xj;
@@ -1199,7 +1199,7 @@ Type nimDerivs_nimArr_dcar_proper_logFixed(NimArr<1, Type> &x, NimArr<1, Type> &
     }
   }
   if(Type(count) != Type(L)) {
-    return Type(R_NaN);
+    return CppAD::numeric_limits<Type>::quiet_NaN();
   }
   lp *= Type(-1/2.0) * tau;
   // now add -1/2*log(|2*pi*Sigma|) to lp:

--- a/packages/nimble/inst/include/nimble/nimDerivs_dists.h
+++ b/packages/nimble/inst/include/nimble/nimDerivs_dists.h
@@ -1057,7 +1057,7 @@ Type nimDerivs_nimArr_ddirch_logFixed(NimArr<1, Type> &x, NimArr<1, Type> &alpha
 // do we need `const Type &adj` because used as an index?
 //formerly did (int) adj[count]
 template<class Type>
-Type nimDerivs_nimArr_dcar_normal(NimArr<1, Type> &x, const Type &adj, NimArr<1, Type> &weights, NimArr<1, Type> &num, Type tau, Type c, Type zero_mean, Type give_log) 
+Type nimDerivs_nimArr_dcar_normal(NimArr<1, Type> &x, NimArr<1, Type> &adj, NimArr<1, Type> &weights, NimArr<1, Type> &num, Type tau, Type c, Type zero_mean, Type give_log) 
 {
   // This method implements the following density calculation:
   // p(x1, ..., xn, tau) = (tau/2/pi)^((N-c)/2) * exp(-tau/2 * sum_{i != j) w_ij (xi-xj)^2 ),
@@ -1076,7 +1076,7 @@ Type nimDerivs_nimArr_dcar_normal(NimArr<1, Type> &x, const Type &adj, NimArr<1,
   for(int i = 0; i < N; i++) {
     xi = x[i];
     for(int j = 0; j < num[i]; j++) {
-      xj = x[ adj[count] - 1 ];
+      xj = x[ CppAD::Value(adj[count]) - 1 ];
       lp += weights[count] * (xi-xj)*(xi-xj);
       count++;
     }
@@ -1093,7 +1093,7 @@ Type nimDerivs_nimArr_dcar_normal(NimArr<1, Type> &x, const Type &adj, NimArr<1,
 }
 
 template<class Type>
-Type nimDerivs_nimArr_dcar_normal_logFixed(NimArr<1, Type> &x, const Type &adj, NimArr<1, Type> &weights, NimArr<1, Type> &num, Type tau, Type c, Type zero_mean, int give_log) 
+Type nimDerivs_nimArr_dcar_normal_logFixed(NimArr<1, Type> &x, NimArr<1, Type> &adj, NimArr<1, Type> &weights, NimArr<1, Type> &num, Type tau, Type c, Type zero_mean, int give_log) 
 {
   // This method implements the following density calculation:
   // p(x1, ..., xn, tau) = (tau/2/pi)^((N-c)/2) * exp(-tau/2 * sum_{i != j) w_ij (xi-xj)^2 ),
@@ -1112,7 +1112,7 @@ Type nimDerivs_nimArr_dcar_normal_logFixed(NimArr<1, Type> &x, const Type &adj, 
   for(int i = 0; i < N; i++) {
     xi = x[i];
     for(int j = 0; j < num[i]; j++) {
-      xj = x[ adj[count] - 1 ];
+      xj = x[ CppAD::Value(adj[count]) - 1 ];
       lp += weights[count] * (xi-xj)*(xi-xj);
       count++;
     }

--- a/packages/nimble/tests/testthat/test-car.R
+++ b/packages/nimble/tests/testthat/test-car.R
@@ -325,7 +325,6 @@ test_that('CAR models compile and run when derivs enabled', {
     mcmc <- buildMCMC(conf)
     cm <- compileNimble(m)
     cmcmc <- compileNimble(mcmc,project=m)
-    out <- runMCMC(cmcmc, niter=10)
     expect_silent(out <- runMCMC(cmcmc,niter=10))
 })
 


### PR DESCRIPTION
This sets up templated versions of `dcar_normal` and `dcar_proper` for AD and enables `buildDerivs` for various auxiliary nimbleFunctions functions in `CAR.R`. In the latter case, this requires various uses of `ADbreak`, `ignore` and setting up index variables as integers.

Testing now includes tests that AD-enabled CAR models will build and basic (non-HMC) MCMC will run. Substantive HMC testing could be done in `nimbleHMC`.

@perrydv a glance over the AD-enabled code would be helpful.

@danielturek just an FYI; I'm sure you'll be happy to see this.