### PR TITLE
change `|` to `||` to avoid error on M2 Mac

### DIFF
--- a/packages/nimble/LICENSE
+++ b/packages/nimble/LICENSE
@@ -1,3 +1,3 @@
-YEAR: 2023
+YEAR: 2024
 COPYRIGHT HOLDER: Perry de Valpine, Christopher Paciorek, Daniel Turek, Clifford Anderson-Bergman, Nick Michaud, Fritz Obermeyer, Claudia Wehrhahn Cortes, Abel Rodriguez, Sally Paganin, Wei Zhang, Duncan Temple Lang
 ORGANIZATION: University of California

--- a/packages/nimble/inst/include/nimble/nimbleEigenNimArr.h
+++ b/packages/nimble/inst/include/nimble/nimbleEigenNimArr.h
@@ -224,7 +224,7 @@ template<typename NimArrOutput, typename NimArrInput>
     }
     sizeToCopy = totSize;
   }
-  if(input.isMap() | (output.getNimType() != input.getNimType())) { 
+  if(input.isMap() || (output.getNimType() != input.getNimType())) { 
     for(int i = 0; i < sizeToCopy; i++) output.valueNoMap(i) = input[i];
     if(sizeToCopy < totSize) {
       if(recycle) {


### PR DESCRIPTION
This fixes issue #1372 