### PR TITLE
 add `--preclean` to `R CMD SHLIB`

### DIFF
--- a/packages/nimble/LICENSE
+++ b/packages/nimble/LICENSE
@@ -1,3 +1,3 @@
-YEAR: 2023
+YEAR: 2024
 COPYRIGHT HOLDER: Perry de Valpine, Christopher Paciorek, Daniel Turek, Clifford Anderson-Bergman, Nick Michaud, Fritz Obermeyer, Claudia Wehrhahn Cortes, Abel Rodriguez, Sally Paganin, Wei Zhang, Duncan Temple Lang
 ORGANIZATION: University of California

--- a/packages/nimble/R/cppDefs_cppProject.R
+++ b/packages/nimble/R/cppDefs_cppProject.R
@@ -205,7 +205,7 @@ cppProjectClass <- setRefClass('cppProjectClass',
                                        ssdSHLIBcmd <- normalizePath(file.path(R.home('bin'), 'R'),
                                                                           winslash = "\\", mustWork=FALSE)
                                        ssdSHLIBargs <- paste('CMD SHLIB',
-                                                             ifelse(nimbleOptions()precleanCompilation, '--preclean', ''),
+                                                             ifelse(nimbleOptions()$precleanCompilation, '--preclean', ''),
                                                              cppName, '-o', basename(ssDllName))
 
                                        logFile <- paste0(dllName, ".log")
@@ -279,7 +279,7 @@ cppProjectClass <- setRefClass('cppProjectClass',
                                        }
                                        SHLIBcmd <- normalizePath(file.path(R.home('bin'), 'R'), winslash = "\\", mustWork=FALSE)
                                        SHLIBargs <- paste('CMD SHLIB',
-                                                          ifelse(nimbleOptions()precleanCompilation, '--preclean', ''),
+                                                          ifelse(nimbleOptions()$precleanCompilation, '--preclean', ''),
                                                           paste(c(mainfiles, includes), collapse = ' '), '-o', basename(outputSOfile))
 
                                        cur = getwd()

--- a/packages/nimble/R/cppDefs_cppProject.R
+++ b/packages/nimble/R/cppDefs_cppProject.R
@@ -204,7 +204,9 @@ cppProjectClass <- setRefClass('cppProjectClass',
                                        ssDllName <- normalizePath(file.path(dirName, paste0(dllName, .Platform$dynlib.ext)), winslash = "\\", mustWork=FALSE)
                                        ssdSHLIBcmd <- normalizePath(file.path(R.home('bin'), 'R'),
                                                                           winslash = "\\", mustWork=FALSE)
-                                       ssdSHLIBargs <- paste('CMD SHLIB', cppName, '-o', basename(ssDllName))
+                                       ssdSHLIBargs <- paste('CMD SHLIB',
+                                                             ifelse(nimbleOptions()precleanCompilation, '--preclean', ''),
+                                                             cppName, '-o', basename(ssDllName))
 
                                        logFile <- paste0(dllName, ".log")
                                        errorFile <- paste0(dllName, ".err")
@@ -276,7 +278,9 @@ cppProjectClass <- setRefClass('cppProjectClass',
                                            includes <- c(includes, Oincludes) ## normal operation will have Oincludes.
                                        }
                                        SHLIBcmd <- normalizePath(file.path(R.home('bin'), 'R'), winslash = "\\", mustWork=FALSE)
-                                       SHLIBargs <- paste('CMD SHLIB', paste(c(mainfiles, includes), collapse = ' '), '-o', basename(outputSOfile))
+                                       SHLIBargs <- paste('CMD SHLIB',
+                                                          ifelse(nimbleOptions()precleanCompilation, '--preclean', ''),
+                                                          paste(c(mainfiles, includes), collapse = ' '), '-o', basename(outputSOfile))
 
                                        cur = getwd()
                                        setwd(dirName)

--- a/packages/nimble/R/options.R
+++ b/packages/nimble/R/options.R
@@ -52,6 +52,7 @@ nimbleUserNamespace <- as.environment(list(sessionSpecificDll = NULL))
         checkModel = FALSE,
         checkNimbleFunction = TRUE,
         checkDuplicateNodeDefinitions = TRUE,
+        precleanCompilation = TRUE,
         verbose = TRUE,
         verboseErrors = FALSE,
 


### PR DESCRIPTION
This should clear out old files from previous compilation and address the apparent time stamp issue in R CMD SHLIB's use of `make`.

Fixes #1368 