### PR TITLE
handle predictive nodes in sampler_CRP

### DIFF
--- a/UserManual/src/chapter_MCMC.Rmd
+++ b/UserManual/src/chapter_MCMC.Rmd
@@ -508,6 +508,7 @@ It is often important to provide valid and reasonable initial values to an MCMC,
 Not doing so can cause slow convergence or even failure of an MCMC algorithm (e.g., if the values the model is initialized with are not valid). When starting an MCMC, when NIMBLE encounters a missing parameter value, it simulates from the prior distribution. NIMBLE can be more sensitive to missing or bad starting values than some MCMC packages.
 
 The following cases are particularly important to consider when initializing:
+
   - In a model with flat priors (i.e., using `x~dflat()` or `x~dhalfflat()`), NIMBLE cannot generate initial values from those priors.
   - In a model with diffuse priors, initializing from the prior can give unreasonable/extreme initial values. 
   - In a model with stochastic indices (e.g., `x[idx[i]]` with `idx[i]` unknown), those indices should have (valid) initial values.

--- a/packages/nimble/R/BNP_samplers.R
+++ b/packages/nimble/R/BNP_samplers.R
@@ -1321,6 +1321,12 @@ sampler_CRP <- nimbleFunction(
     if(!is.null(control$printTruncation))
       printMessage <- control$printTruncation else printMessage <- TRUE
 
+    ## Irregular association of dependencies with clusters because of
+    ## not including predictive nodes prevents CRP sampler from being set up.
+    getDependenciesIncludesPredictiveNodes_save <- getNimbleOption('getDependenciesIncludesPredictiveNodes')
+    on.exit(nimbleOptions(getDependenciesIncludesPredictiveNodes = getDependenciesIncludesPredictiveNodes_save))
+    nimbleOptions(getDependenciesIncludesPredictiveNodes = TRUE)
+    
     targetElements <- model$expandNodeNames(target, returnScalarComponents = TRUE)
     targetVar <- model$getVarNames(nodes = target)
     n <- length(targetElements)

--- a/packages/nimble/R/BNP_samplers.R
+++ b/packages/nimble/R/BNP_samplers.R
@@ -1321,12 +1321,6 @@ sampler_CRP <- nimbleFunction(
     if(!is.null(control$printTruncation))
       printMessage <- control$printTruncation else printMessage <- TRUE
 
-    ## Irregular association of dependencies with clusters because of
-    ## not including predictive nodes prevents CRP sampler from being set up.
-    getDependenciesIncludesPredictiveNodes_save <- getNimbleOption('getDependenciesIncludesPredictiveNodes')
-    on.exit(nimbleOptions(getDependenciesIncludesPredictiveNodes = getDependenciesIncludesPredictiveNodes_save))
-    nimbleOptions(getDependenciesIncludesPredictiveNodes = TRUE)
-    
     targetElements <- model$expandNodeNames(target, returnScalarComponents = TRUE)
     targetVar <- model$getVarNames(nodes = target)
     n <- length(targetElements)

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -177,9 +177,11 @@ print: A logical argument specifying whether to print the montiors and samplers.
                     for(i in crpDists) {
                         clusterNodeInfo <- findClusterNodes(model, deparse(nodeExprs[[i]]))
                         allClusterNodesVec <- unlist(clusterNodeInfo$clusterNodes)
-                        clusterNodeDeps <- model$getDependencies(allClusterNodesVec, stochOnly = TRUE, self = FALSE)
-                        if(any(clusterNodeDeps %in% model$getNodeNames(predictiveOnly = TRUE)))
-                            stop("Discovered predictive node dependencies of dCRP node. This will generally be incompatible with NIMBLE's default MCMC configuration for CRP-based models. You can proceed with sampling by setting `nimbleOptions(MCMCusePredictiveDependenciesInCalculations = TRUE)` before setting up your MCMC.")
+                        if(length(allClusterNodesVec)) {
+                            clusterNodeDeps <- model$getDependencies(allClusterNodesVec, stochOnly = TRUE, self = FALSE)
+                            if(any(clusterNodeDeps %in% model$getNodeNames(predictiveOnly = TRUE)))
+                                stop("Discovered predictive node dependencies of dCRP node. This will generally be incompatible with NIMBLE's default MCMC configuration for CRP-based models. You can proceed with sampling by setting `nimbleOptions(MCMCusePredictiveDependenciesInCalculations = TRUE)` before setting up your MCMC.")
+                        }
                     }
                 }
             }

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -169,10 +169,11 @@ print: A logical argument specifying whether to print the montiors and samplers.
             ## Conservatively insist that include any predictive nodes for CRP sampling.
             if(!getNimbleOption('MCMCusePredictiveDependenciesInCalculations')) {
                 allDists <- unlist(lapply(model$modelDef$declInfo, `[[`, 'distributionName'))
-                allDists <- allDists[!is.na(allDists)]
+                nonNAs <- !is.na(allDists)
+                allDists <- allDists[nonNAs]
                 crpDists <- which(allDists == "dCRP")
                 if(length(crpDists)) {
-                    nodeExprs <- unlist(lapply(model$modelDef$declInfo, `[[`, 'targetNodeExpr'))
+                    nodeExprs <- unlist(lapply(model$modelDef$declInfo, `[[`, 'targetNodeExpr'))[nonNAs]
                     for(i in crpDists) {
                         clusterNodeInfo <- findClusterNodes(model, deparse(nodeExprs[[i]]))
                         allClusterNodesVec <- unlist(clusterNodeInfo$clusterNodes)

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -165,6 +165,24 @@ print: A logical argument specifying whether to print the montiors and samplers.
             controlDefaults <<- list(...)
             ##namedSamplerLabelMaker <<- labelFunctionCreator('namedSampler')  ## usage long since deprecated (Dec 2020)
             for(i in seq_along(control))     controlDefaults[[names(control)[i]]] <<- control[[i]]
+
+            ## Conservatively insist that include any predictive nodes for CRP sampling.
+            if(!getNimbleOption('MCMCusePredictiveDependenciesInCalculations')) {
+                allDists <- unlist(lapply(model$modelDef$declInfo, `[[`, 'distributionName'))
+                allDists <- allDists[!is.na(allDists)]
+                crpDists <- which(allDists == "dCRP")
+                if(length(crpDists)) {
+                    nodeExprs <- unlist(lapply(model$modelDef$declInfo, `[[`, 'targetNodeExpr'))
+                    for(i in crpDists) {
+                        clusterNodeInfo <- findClusterNodes(model, deparse(nodeExprs[[i]]))
+                        allClusterNodesVec <- unlist(clusterNodeInfo$clusterNodes)
+                        clusterNodeDeps <- model$getDependencies(allClusterNodesVec, stochOnly = TRUE, self = FALSE)
+                        if(any(clusterNodeDeps %in% model$getNodeNames(predictiveOnly = TRUE)))
+                            stop("Discovered predictive node dependencies of dCRP node. This will generally be incompatible with NIMBLE's default MCMC configuration for CRP-based models. You can proceed with sampling by setting `nimbleOptions(MCMCusePredictiveDependenciesInCalculations = TRUE)` before setting up your MCMC.")
+                    }
+                }
+            }
+            
             if(missing(nodes)) {
                 nodes <- model$getNodeNames(stochOnly = TRUE, includeData = FALSE)
                 # Check of all(model$isStoch(nodes)) is not needed in this case

--- a/packages/nimble/tests/testthat/test-bnp.R
+++ b/packages/nimble/tests/testthat/test-bnp.R
@@ -2989,7 +2989,7 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
     tau ~ dnorm(muTilde[xi[1]], 1)
   })
   Inits=list(xi=rep(1, 10), muTilde=rep(0,10))
-  Data=list(y=rnorm(10,0, 1), tau=1)
+  Data=list(y=rnorm(10,0, 1))
   m <- nimbleModel(code, data=Data, inits=Inits)
   expect_error(mConf <- configureMCMC(m), "Discovered predictive node")
   nimbleOptions(MCMCusePredictiveDependenciesInCalculations = TRUE)


### PR DESCRIPTION
This sets predictive nodes to be included in dependencies for sampler_CRP, which for logistical reasons and to ensure validity of sampling, imposes some requirements in terms of the number of dependent nodes for each stochastic index being sampled. 

@danielturek a quick eye in terms of where I am setting the nimble option would be helpful.