### PR TITLE
avoid wrapping CRP cluster parameters when joint sampling

### DIFF
--- a/UserManual/src/chapter_MCMC.Rmd
+++ b/UserManual/src/chapter_MCMC.Rmd
@@ -508,6 +508,7 @@ It is often important to provide valid and reasonable initial values to an MCMC,
 Not doing so can cause slow convergence or even failure of an MCMC algorithm (e.g., if the values the model is initialized with are not valid). When starting an MCMC, when NIMBLE encounters a missing parameter value, it simulates from the prior distribution. NIMBLE can be more sensitive to missing or bad starting values than some MCMC packages.
 
 The following cases are particularly important to consider when initializing:
+
   - In a model with flat priors (i.e., using `x~dflat()` or `x~dhalfflat()`), NIMBLE cannot generate initial values from those priors.
   - In a model with diffuse priors, initializing from the prior can give unreasonable/extreme initial values. 
   - In a model with stochastic indices (e.g., `x[idx[i]]` with `idx[i]` unknown), those indices should have (valid) initial values.

--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -482,19 +482,19 @@ For internal use.  Adds default MCMC samplers to the specified nodes.
                                 }
 
                                 samplers <- getSamplers(clusterNodes)
-                                removeSamplers(clusterNodes)
                                 for(i in seq_along(samplers)) {
                                     node <- samplers[[i]]$target
                                     ## getSamplers() returns samplers in order of configuration not in order of input.
                                     clusterID <- which(clusterNodes == node)
-                                    if(length(clusterID) != 1)
-                                        stop("Cannot determine wrapped sampler for cluster parameter ", node, ".")
-                                    controlCRP <- controlDefaultsArg
-                                    controlCRP$wrapped_type <- samplers[[i]]$name
-                                    controlCRP$wrapped_conf <- samplers[[i]]
-                                    controlCRP$dcrpNode <- dcrpNode[[k]]
-                                    controlCRP$clusterID <- clusterNodeInfo[[k]]$clusterIDs[[idx]][clusterID]
-                                    addSampler(target = node, type = 'CRP_cluster_wrapper', control = controlCRP)
+                                    if(length(clusterID) ==1) {  # Joint sampling on multiple nodes won't use wrapping.
+                                        removeSamplers(node)
+                                        controlCRP <- controlDefaultsArg
+                                        controlCRP$wrapped_type <- samplers[[i]]$name
+                                        controlCRP$wrapped_conf <- samplers[[i]]
+                                        controlCRP$dcrpNode <- dcrpNode[[k]]
+                                        controlCRP$clusterID <- clusterNodeInfo[[k]]$clusterIDs[[idx]][clusterID]
+                                        addSampler(target = node, type = 'CRP_cluster_wrapper', control = controlCRP)
+                                    }
                                 }
                             }
                         }

--- a/packages/nimble/tests/testthat/test-bnp.R
+++ b/packages/nimble/tests/testthat/test-bnp.R
@@ -5160,9 +5160,6 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
 
 
   ## clusters not indep, with mv declaration - not allowed
-  ## errors when trying to wrap sampler because there is only
-  ## one cluster node. Might want have configureMCMC
-  ## give up on wrapping and then have error occur in buildMCMC().
   code <- nimbleCode({
       for(i in 1:4) 
           y[i] ~ dnorm(thetaTilde[xi[i]], 1)
@@ -5172,8 +5169,8 @@ test_that("Testing handling (including error detection) with non-standard CRP mo
   data = list(y = rnorm(4))
   inits = list(xi = rep(1,4), iden = diag(4))
   model <- nimbleModel(code, data = data, inits = inits)
-  expect_error(conf <- configureMCMC(model, print = FALSE),
-               "Cannot determine wrapped sampler for cluster parameter")
+  conf <- configureMCMC(model, print = FALSE)
+  expect_error(mcmc <- buildMCMC(conf), "must be part of conditionally independent nodes")
 
   ## clusters indep G0 but not IID
   code <- nimbleCode({


### PR DESCRIPTION
This came up for HMC. If we assign an HMC (joint) sampler to parameters for multiple cluster nodes, the current handling of wrapping the cluster parameters to only sample if there are members of the cluster fails.

This simply does not do the wrapping if the target involves multiple nodes.