### PR TITLE
ensure stoch_ind_set is not used in a nested way

### DIFF
--- a/packages/nimble/R/cppDefs_nimbleFunction.R
+++ b/packages/nimble/R/cppDefs_nimbleFunction.R
@@ -762,8 +762,11 @@ modifyForAD_indexingBracket <- function(code, symTab, workEnv) {
   if(!isTRUE(workEnv$.anyAD)) return(invisible(NULL))
   if(is.null(code$type)) return(invisible(NULL)) # arises from constructions like setMap that lack type annotation
   if(length(code$args) > 4) return(invisible(NULL)) # 4D or higher is not handled, assumed to be static indexing
-  if(isTRUE(workEnv$onLHS)) code$name <- "stoch_ind_set"
-  else code$name <- "stoch_ind_get"
+  newName <- "stoch_ind_get"
+  if(isTRUE(workEnv$onLHS))
+    if(code$caller$name %in% assignmentOperators)
+      newName <- "stoch_ind_set"
+  code$name <- newName
   invisible(NULL)
 }
 


### PR DESCRIPTION
fixes #1403 

The problem was that `stoch_ind_set` was being inserted in nested indexing on the LHS. I added a check that it should only be inserted if the caller is an assignment operator, meaning the `[` is the top level of the LHS. I hope this is general enough.