### PR TITLE
use `inherits` in `nf_preProcessMemberDataObj`

### DIFF
--- a/packages/nimble/R/nimbleFunction_core.R
+++ b/packages/nimble/R/nimbleFunction_core.R
@@ -348,7 +348,7 @@ nf_getNamesFromSetupOutputDeclaration <- function(setupOutputsDeclaration) {
 ## needs to be exported as otherwise use of nimble::: in `nf_createGeneratorFunctionDef()` gives R CMD check NOTE
 #' @export
 nf_preProcessMemberDataObject <- function(obj) {
-    if(is(obj, 'CmodelBaseClass')) {
+    if(inherits(obj, 'CmodelBaseClass')) {
         warning('This nimbleFunction was passed a *compiled* model object.\nInstead, the corresponding *uncompiled* model object was used.', call. = FALSE)
         return(obj$Rmodel)
     }


### PR DESCRIPTION
Using `inherits` is faster than `is` in general, I believe.

Using it in `nf_preProcessMemberDataObj` can give a surprisingly large (20%) speedup in a case where we are building many simple samplers. In code below `buildMCMC` takes 28 sec when using `inherits` and 36 sec when using `is`.

```
n <- 10000
code <- nimbleCode({
    for(i in 1:n) {
        y[i]~dpois(mu[i])
        mu[i]~dnorm(mu0,sd=sigma)
    }
    mu0 ~ dnorm(0,sd=10)
    sigma ~ dunif(0, 10)
})

m <- nimbleModel(code, data = list(y = rpois(n,1)), constants = list(n=n))
system.time(conf <- configureMCMC(m, useConjugacy=FALSE))
system.time(mcmc <- buildMCMC(conf))
```