### PR TITLE
save userEnv in modelDef object

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -55,6 +55,7 @@ modelDefClass <- setRefClass('modelDefClass',
                                  graphNodesList = 'ANY',   ## list of graphNode objects, set in genGraphNodesList()
                                  maps = 'ANY',   ## object of mapsClass, set in buildMaps()
                                  numNodeFunctions = 'ANY',  ## FIXME: obsolete as only used in buildNodeFunctions_old()
+                                 userEnv = 'ANY',   ## userEnv argument to nimbleModel call
                                  
                                  modelClass = 'ANY',   ## custom model class
                                  modelValuesClassName = 'ANY',    ## set in setModelValuesClassName()
@@ -110,6 +111,8 @@ modelDefClass <- setRefClass('modelDefClass',
                                  genVarNames                    = function() {},
                                  buildSymbolTable               = function() {},
                                  genGraphNodesList              = function() {},
+                                 setUserEnv                     = function() {},
+                                 getUserEnv                     = function() {},
                                                                   
                                  newModel                       = function() {},
                                  fixRStudioHanging              = function() {},
@@ -216,6 +219,7 @@ modelDefClass$methods(setupModel = function(code, constants, dimensions, inits, 
     genIsDataVarInfo()                    ## only the maxs is ever used, in newModel
     genVarNames()                         ## sets varNames <<- c(names(varInfo), names(logProbVarInfo))
     warnRHSonlyDynIdx()                   ## warns user if RHS-only nodes used in indexing (inefficient)
+    setUserEnv(userEnv = userEnv)         ## set userEnv field of modelDef object
     return(NULL)        
 })
 
@@ -2998,6 +3002,14 @@ modelDefClass$methods(nodeName2LogProbName = function(nodeName){
     output <- output[!is.na(output)]
 
     return(output)
+})
+
+modelDefClass$methods(setUserEnv = function(userEnv) {
+    userEnv <<- userEnv
+})
+
+modelDefClass$methods(getUserEnv = function() {
+    return(userEnv)
 })
 
 parseEvalNumeric <- function(x, env){

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -485,18 +485,14 @@ modelDefClass$methods(checkADsupportForDistribution = function(dist, verbose = F
         dfun <- get(dist, pos = userEnv) # same way dist is looked up in prepareDistributionInput
         if(!is.rcf(dfun)) {
             if(verbose)   message("   [Warning] Could not find a valid distribution definition while trying to check derivative support for ", dist, ".")
-            supported <- FALSE
-        }
-        else {
+                supported <- FALSE
+        } else {
             dfun_buildDerivs <- environment(dfun)$nfMethodRCobject[["buildDerivs"]]
             if(isFALSE(dfun_buildDerivs) || is.null(dfun_buildDerivs)) {
                 if(verbose)   message("   [Note] Distribution ", dist, " does not appear to support derivatives. Set buildDerivs = TRUE (or to a list) in its nimbleFunction to turn on derivative support.")
                 supported <- FALSE
             }
         }
-    } else {
-        ## dist is truncated
-        supported <- FALSE
     }
     return(supported)
 })

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -113,6 +113,7 @@ modelDefClass <- setRefClass('modelDefClass',
                                  genGraphNodesList              = function() {},
                                  setUserEnv                     = function() {},
                                  getUserEnv                     = function() {},
+                                 checkADsupportForDistribution  = function() {},
                                                                   
                                  newModel                       = function() {},
                                  fixRStudioHanging              = function() {},
@@ -413,8 +414,10 @@ modelDefClass$methods(processBUGScode = function(code = NULL, contextID = 1, lin
                 checkUserDefinedDistribution(code[[i]], userEnv)
                 if(isTRUE(getNimbleOption("enableDerivs")))
                     if(isTRUE(getNimbleOption("doADerrorTraps")))
-                        if(buildDerivs)
-                            checkADsupportForDistribution(code[[i]], userEnv)
+                        if(buildDerivs) {
+                            dist <- as.character(code[[3]][[1]])
+                            checkADsupportForDistribution(dist)
+                        }
             }
             if(code[[i]][[1]] == '<-')
                 checkForDeterministicDorR(code[[i]])
@@ -476,8 +479,7 @@ modelDefClass$methods(processBUGScode = function(code = NULL, contextID = 1, lin
     lineNumber
 })
 
-checkADsupportForDistribution <- function(code, userEnv) {
-    dist <- as.character(code[[3]][[1]])
+modelDefClass$methods(checkADsupportForDistribution = function(dist) {
     supported <- TRUE
     if(!dist %in% c(distributions$namesVector, "T", "I")) {
         dfun <- get(dist, pos = userEnv) # same way dist is looked up in prepareDistributionInput

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -491,7 +491,7 @@ modelDefClass$methods(checkADsupportForDistribution = function(dist) {
                 message("   [Note] Distribution ", dist, " does not appear to support derivatives. Set buildDerivs = TRUE (or to a list) in its nimbleFunction to turn on derivative support.")
         }
     }
-}
+})
 
 
 # check if distribution is defined and if not, attempt to register it


### PR DESCRIPTION
The title says it all.

The motivation for use in `hmc_checkTarget`, to find user-defined distributions in a more robust manner.
