### PR TITLE
modelValuesAccessorVector setup template matches modelValues

### DIFF
--- a/packages/nimble/R/nimbleFunction_keywordProcessing.R
+++ b/packages/nimble/R/nimbleFunction_keywordProcessing.R
@@ -1238,13 +1238,13 @@ copierVector_setupCodeTemplate <- setupCodeTemplateClass(
     
 
 modelValuesAccessorVector_setupCodeTemplate <- setupCodeTemplateClass(
-	#Note to programmer: required fields of argList are model, nodes and logProb
+	#Note to programmer: required fields of argList are modelValues, nodes and logProb
 
-    makeName = function(argList) {Rname2CppName(paste(deparse(argList$model), deparse(argList$nodes), 'access_logProb', deparse(argList$logProb), 'LPO', deparse(argList$logProbOnly), deparse(argList$row), sep = '_'))},
+    makeName = function(argList) {Rname2CppName(paste(deparse(argList[['modelValues']]), deparse(argList$nodes), 'access_logProb', deparse(argList$logProb), 'LPO', deparse(argList$logProbOnly), deparse(argList$row), sep = '_'))},
     codeTemplate = quote( ACCESSNAME <- nimble:::modelValuesAccessorVector(MODEL, NODES, logProb = LOGPROB, logProbOnly = LOGPROBONLY) ),
 	makeCodeSubList = function(resultName, argList) {
         list(ACCESSNAME = as.name(resultName),
-             MODEL = argList$model,
+             MODEL = argList[['modelValues']],
              NODES = argList$nodes,
              LOGPROB = argList$logProb,
              LOGPROBONLY = argList$logProbOnly)


### PR DESCRIPTION
@perrydv as best I see this fixes a small typo in the `modelValuesAccessorVector_setupCodeTemplate`, which defines the setup code for copy operations to/from modelValues objects.  I believe this was a harmless partial matching, which as-written matches the correct modelValues object because of the same prefix "model".  This PR corrects the partial match typo, and also enforces exact matching by now using `LIST[["VAR"]]` syntax.

That said, @perrydv you should definitely look at this, and confirm this makes sense.