### PR TITLE
protect gradient methods in nimOptim C++ from when the user-provided fn or gr modifies the input vector.

### DIFF
--- a/packages/nimble/R/cppDefs_nimbleFunction.R
+++ b/packages/nimble/R/cppDefs_nimbleFunction.R
@@ -1212,7 +1212,7 @@ makeCopyFromRobjectDef <- function(cppCopyTypes,
                             c(list('{'),
                               list(cppLiteral("SETUP_S_xData;")),
                               copyCalls,
-                              list(cppLiteral(paste0("UNPROTECT(",unprotectCount,");")))),
+                              list(cppLiteral(paste0("UNPROTECT(",unprotectCount,"+1);")))),
                             quote = TRUE
                             )
     }

--- a/packages/nimble/R/cppDefs_nimbleList.R
+++ b/packages/nimble/R/cppDefs_nimbleList.R
@@ -199,12 +199,12 @@ cppNimbleListClass <- setRefClass('cppNimbleListClass',
                                         listElementTable$addSymbol(cppSEXP(name = "S_listName"))
                                       
                                         newListLine[[1]] <- substitute({PROTECT(S_listName <- Rf_allocVector(STRSXP, 1));
-                                          SET_STRING_ELT(S_listName, 0, Rf_mkChar(LISTNAME));}, 
+                                          SET_STRING_ELT(S_listName, 0, PROTECT(Rf_mkChar(LISTNAME)));},
                                           list(LISTNAME = nimCompProc$nimbleListObj$className))
                                         newListLine[[2]] <- substitute(PROTECT(S_newNimList <- makeNewNimbleList(S_listName)),
                                                                            list())
-                                        newListLine[[3]] <- quote(cppLiteral('RObjectPointer = S_newNimList;'))
-                                        newListLine[[4]] <-   substitute(UNPROTECT(2), list())
+                                        newListLine[[3]] <- quote(cppLiteral('R_PreserveObject(RObjectPointer = S_newNimList);'))
+                                        newListLine[[4]] <-   substitute(UNPROTECT(2+1), list())
                                         allCode <- embedListInRbracket(c(newListLine))
                                         functionDefs[[paste0(name, "_createNewSEXP")]] <<- cppFunctionDef(name = "createNewSEXP",
                                                                                                     args = interfaceArgs,
@@ -231,7 +231,7 @@ cppNimbleListClass <- setRefClass('cppNimbleListClass',
                                         environmentCPPName <- Rname2CppName('S_.xData')  ## create SEXP for ref class environment 
                                         listElementTable$addSymbol(cppSEXP(name = environmentCPPName))
                                         envLine <- substitute({PROTECT(ENVNAME <- Rf_allocVector(STRSXP, 1));
-                                          SET_STRING_ELT(ENVNAME, 0, Rf_mkChar(".xData"));}, 
+                                          SET_STRING_ELT(ENVNAME, 0, PROTECT(Rf_mkChar(".xData")));},
                                           list(ENVNAME = as.name(environmentCPPName)))
                                         
                                         for(i in seq_along(elementNames)){
@@ -251,7 +251,7 @@ cppNimbleListClass <- setRefClass('cppNimbleListClass',
                                                                        list()))
                                         returnLine <- list(substitute(return(ROBJ),
                                                            list(ROBJ = as.name('RObjectPointer'))))
-                                        unprotectLine <- list(substitute(UNPROTECT(N), list(N = 2 * numElements + 1)))
+                                        unprotectLine <- list(substitute(UNPROTECT(N), list(N = 2 * numElements + 1 + 1)))
                                         allCode <- embedListInRbracket(c(conditionalClauseStart, list(envLine),  conditionalLineList,
                                                                          copyToListLines, setFlagLine, unprotectLine,
                                                                          conditionalClauseEnd, returnLine))
@@ -274,12 +274,12 @@ cppNimbleListClass <- setRefClass('cppNimbleListClass',
                                         Snames <- character(length(argNames))
                                         returnType <- "void"
                                         listElementTable <- symbolTable()
-                                        storeSexpLine <- list(quote(cppLiteral('RObjectPointer =  S_nimList_;')))
+                                        storeSexpLine <- list(quote(cppLiteral('R_PreserveObject(RObjectPointer =  S_nimList_);')))
 
                                         environmentCPPName <- Rname2CppName('S_.xData')  ## create SEXP for ref class environment 
                                         listElementTable$addSymbol(cppSEXP(name = environmentCPPName))
                                         envLine <- substitute({PROTECT(ENVNAME <- Rf_allocVector(STRSXP, 1));
-                                          SET_STRING_ELT(ENVNAME, 0, Rf_mkChar(".xData"));}, 
+                                          SET_STRING_ELT(ENVNAME, 0, PROTECT(Rf_mkChar(".xData")));},
                                           list(ENVNAME = as.name(environmentCPPName)))
 
                                         for(i in seq_along(argNames)) {
@@ -294,7 +294,7 @@ cppNimbleListClass <- setRefClass('cppNimbleListClass',
                                             copyLines <- c(copyLines, copyLine)
                                         }
                                         numArgs <- length(argNames)
-                                        unprotectLine <- substitute(UNPROTECT(N), list(N = 2 * numArgs + 1))
+                                        unprotectLine <- substitute(UNPROTECT(N), list(N = 2 * numArgs + 1 + 1))
                                         allCode <- embedListInRbracket(c(storeSexpLine, envLine, 
                                                                          copyFromListLines, copyLines,
                                                                          list(unprotectLine)))
@@ -325,7 +325,8 @@ cppNimbleListClass <- setRefClass('cppNimbleListClass',
                                                                  resetRCopiedFlagLine)
                                           }
                                         }
-                                        allCode <- embedListInRbracket(c(resetFlagLine, resetNestedFlagLines))
+                                        resetRObjLines <- list(quote(cppLiteral("if(RObjectPointer) R_ReleaseObject(RObjectPointer); RObjectPointer=NULL;")))
+                                        allCode <- embedListInRbracket(c(resetFlagLine, resetNestedFlagLines, resetRObjLines))
                                         functionDefs[[paste0(name, "_resetFlags")]] <<- cppFunctionDef(name = "resetFlags",
                                                                                                    args = interfaceArgs,
                                                                                                    code = cppCodeBlock(code = RparseTree2ExprClasses(allCode), objectDefs = listElementTable),

--- a/packages/nimble/inst/CppCode/NamedObjects.cpp
+++ b/packages/nimble/inst/CppCode/NamedObjects.cpp
@@ -103,10 +103,10 @@ SEXP getAvailableNames(SEXP Sextptr) {
     // _nimble_global_output << "starting "<<i<<"\n"; nimble_print_to_R( _nimble_global_output);
     //_nimble_global_output << iNO->first.c_str() <<" \n";
     //nimble_print_to_R( _nimble_global_output);
-    SET_STRING_ELT(Sans, i, Rf_mkChar(iNO->first.c_str()));
+    SET_STRING_ELT(Sans, i, PROTECT(Rf_mkChar(iNO->first.c_str())));
     //_nimble_global_output << "done with "<<i<<" "<<iNO->first<<" \n"; nimble_print_to_R( _nimble_global_output);
   }
-  UNPROTECT(1);
+  UNPROTECT(numNames + 1);
   return(Sans);
 }
 

--- a/packages/nimble/inst/CppCode/predefinedNimbleLists.cpp
+++ b/packages/nimble/inst/CppCode/predefinedNimbleLists.cpp
@@ -108,9 +108,9 @@ void OptimResultNimbleList::copyFromSEXP(SEXP S_nimList_) {
   SEXP S_convergence;
   SEXP S_message;
   SEXP S_hessian;
-  RObjectPointer = S_nimList_;
+  R_PreserveObject(RObjectPointer = S_nimList_);
   PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+  SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
   PROTECT(S_par = Rf_findVarInFrame(PROTECT(GET_SLOT(S_nimList_, S__dot_xData)),
                                     Rf_install("par")));
   PROTECT(S_value =
@@ -134,7 +134,7 @@ void OptimResultNimbleList::copyFromSEXP(SEXP S_nimList_) {
   convergence = SEXP_2_int(S_convergence);
   message = STRSEXP_2_string(S_message);
   SEXP_2_NimArr<2>(S_hessian, hessian);
-  UNPROTECT(13);
+  UNPROTECT(14);
 }
 SEXP OptimResultNimbleList::copyToSEXP() {
   SEXP S__dot_xData;
@@ -146,7 +146,7 @@ SEXP OptimResultNimbleList::copyToSEXP() {
   SEXP S_hessian;
   if (!RCopiedFlag) {
     PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-    SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+    SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
     PROTECT(S_par = NimArr_2_SEXP<1>(par));
     PROTECT(S_value = double_2_SEXP(value));
     PROTECT(S_counts = NimArr_2_SEXP<1>(counts));
@@ -166,7 +166,7 @@ SEXP OptimResultNimbleList::copyToSEXP() {
     Rf_defineVar(Rf_install("hessian"), S_hessian,
                  PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));
     RCopiedFlag = true;
-    UNPROTECT(13);
+    UNPROTECT(14);
   }
   return (RObjectPointer);
 }
@@ -174,12 +174,16 @@ void OptimResultNimbleList::createNewSEXP() {
   SEXP S_newNimList;
   SEXP S_listName;
   PROTECT(S_listName = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S_listName, 0, Rf_mkChar("OptimResultNimbleList"));
+  SET_STRING_ELT(S_listName, 0, PROTECT(Rf_mkChar("OptimResultNimbleList")));
   PROTECT(S_newNimList = makeNewNimbleList(S_listName));
-  RObjectPointer = S_newNimList;
-  UNPROTECT(2);
+  R_PreserveObject(RObjectPointer = S_newNimList);
+  UNPROTECT(3);
 }
-void OptimResultNimbleList::resetFlags() { RCopiedFlag = false; }
+void OptimResultNimbleList::resetFlags() {
+  RCopiedFlag = false;
+  if(RObjectPointer) R_ReleaseObject(RObjectPointer);
+  RObjectPointer = NULL;
+}
 void OptimResultNimbleList::copyFromRobject(SEXP Robject) {
   SETUP_S_xData;
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("par");
@@ -187,7 +191,7 @@ void OptimResultNimbleList::copyFromRobject(SEXP Robject) {
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("counts");
   COPY_INTEGER_SCALAR_FROM_R_OBJECT("convergence");
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("hessian");
-  UNPROTECT(7);
+  UNPROTECT(8);
 }
 OptimResultNimbleList::OptimResultNimbleList() {
   RCopiedFlag = false;
@@ -265,9 +269,9 @@ void OptimControlNimbleList::copyFromSEXP(SEXP S_nimList_) {
   SEXP S_pgtol;
   SEXP S_temp;
   SEXP S_tmax;
-  RObjectPointer = S_nimList_;
+    R_PreserveObject(RObjectPointer = S_nimList_);
   PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+  SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
   PROTECT(S_trace =
               Rf_findVarInFrame(PROTECT(GET_SLOT(S_nimList_, S__dot_xData)),
                                 Rf_install("trace")));
@@ -331,7 +335,7 @@ void OptimControlNimbleList::copyFromSEXP(SEXP S_nimList_) {
   pgtol = SEXP_2_double(S_pgtol);
   temp = SEXP_2_double(S_temp);
   tmax = SEXP_2_int(S_tmax);
-  UNPROTECT(35);
+  UNPROTECT(36);
 }
 SEXP OptimControlNimbleList::copyToSEXP() {
   SEXP S__dot_xData;
@@ -354,7 +358,7 @@ SEXP OptimControlNimbleList::copyToSEXP() {
   SEXP S_tmax;
   if (!RCopiedFlag) {
     PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-    SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+    SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
     PROTECT(S_trace = int_2_SEXP(trace));
     PROTECT(S_fnscale = double_2_SEXP(fnscale));
     PROTECT(S_parscale = NimArr_2_SEXP<1>(parscale));
@@ -407,7 +411,7 @@ SEXP OptimControlNimbleList::copyToSEXP() {
     Rf_defineVar(Rf_install("tmax"), S_tmax,
                  PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));
     RCopiedFlag = true;
-    UNPROTECT(35);
+    UNPROTECT(36);
   }
   return (RObjectPointer);
 }
@@ -415,12 +419,16 @@ void OptimControlNimbleList::createNewSEXP() {
   SEXP S_newNimList;
   SEXP S_listName;
   PROTECT(S_listName = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S_listName, 0, Rf_mkChar("OptimControlNimbleList"));
+  SET_STRING_ELT(S_listName, 0, PROTECT(Rf_mkChar("OptimControlNimbleList")));
   PROTECT(S_newNimList = makeNewNimbleList(S_listName));
-  RObjectPointer = S_newNimList;
-  UNPROTECT(2);
+  R_PreserveObject(RObjectPointer = S_newNimList);
+  UNPROTECT(3);
 }
-void OptimControlNimbleList::resetFlags() { RCopiedFlag = false; }
+void OptimControlNimbleList::resetFlags() {
+  RCopiedFlag = false;
+  if(RObjectPointer) R_ReleaseObject(RObjectPointer);
+  RObjectPointer = NULL;
+}
 void OptimControlNimbleList::copyFromRobject(SEXP Robject) {
   SETUP_S_xData;
   COPY_INTEGER_SCALAR_FROM_R_OBJECT("trace");
@@ -440,7 +448,7 @@ void OptimControlNimbleList::copyFromRobject(SEXP Robject) {
   COPY_DOUBLE_SCALAR_FROM_R_OBJECT("pgtol");
   COPY_DOUBLE_SCALAR_FROM_R_OBJECT("temp");
   COPY_INTEGER_SCALAR_FROM_R_OBJECT("tmax");
-  UNPROTECT(19);
+  UNPROTECT(20);
 }
 OptimControlNimbleList::OptimControlNimbleList() {
   RCopiedFlag = false;
@@ -515,9 +523,9 @@ void NIMBLE_ADCLASS::copyFromSEXP(SEXP S_nimList_) {
   SEXP S_value;
   SEXP S_jacobian;
   SEXP S_hessian;
-  RObjectPointer = S_nimList_;
+  R_PreserveObject(RObjectPointer = S_nimList_);
   PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+  SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
   PROTECT(S_value =
               Rf_findVarInFrame(PROTECT(GET_SLOT(S_nimList_, S__dot_xData)),
                                 Rf_install("value")));
@@ -530,7 +538,7 @@ void NIMBLE_ADCLASS::copyFromSEXP(SEXP S_nimList_) {
   SEXP_2_NimArr<1>(S_value, value);
   SEXP_2_NimArr<2>(S_jacobian, jacobian);
   SEXP_2_NimArr<3>(S_hessian, hessian);
-  UNPROTECT(7);
+  UNPROTECT(8);
 }
 SEXP NIMBLE_ADCLASS::copyToSEXP() {
   PROTECT(RObjectPointer);
@@ -560,19 +568,23 @@ void NIMBLE_ADCLASS::createNewSEXP() {
   SEXP S_newNimList;
   SEXP S_listName;
   PROTECT(S_listName = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S_listName, 0, Rf_mkChar("NIMBLE_ADCLASS"));
+  SET_STRING_ELT(S_listName, 0, PROTECT(Rf_mkChar("NIMBLE_ADCLASS")));
   PROTECT(S_newNimList = makeNewNimbleList(S_listName));
-  RObjectPointer = S_newNimList;
-  UNPROTECT(2);
+  R_PreserveObject(RObjectPointer = S_newNimList);
+  UNPROTECT(3);
 }
-void NIMBLE_ADCLASS::resetFlags() { RCopiedFlag = false; }
+void NIMBLE_ADCLASS::resetFlags() {
+  RCopiedFlag = false;
+  if(RObjectPointer) R_ReleaseObject(RObjectPointer);
+  RObjectPointer = NULL;
+}
 
 void NIMBLE_ADCLASS::copyFromRobject(SEXP Robject) {
   SETUP_S_xData;
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("value");
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("jacobian");
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("hessian");
-  UNPROTECT(5);
+  UNPROTECT(6);
 }
 
 NIMBLE_ADCLASS::NIMBLE_ADCLASS() {
@@ -634,9 +646,9 @@ void waicNimbleList::copyFromSEXP(SEXP S_nimList_) {
   SEXP S_WAIC;
   SEXP S_lppd;
   SEXP S_pWAIC;
-  RObjectPointer = S_nimList_;
+  R_PreserveObject(RObjectPointer = S_nimList_);
   PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+  SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
   PROTECT(S_WAIC = Rf_findVarInFrame(
               PROTECT(GET_SLOT(S_nimList_, S__dot_xData)), Rf_install("WAIC")));
   PROTECT(S_lppd = Rf_findVarInFrame(
@@ -647,7 +659,7 @@ void waicNimbleList::copyFromSEXP(SEXP S_nimList_) {
   WAIC = SEXP_2_double(S_WAIC);
   lppd = SEXP_2_double(S_lppd);
   pWAIC = SEXP_2_double(S_pWAIC);
-  UNPROTECT(7);
+  UNPROTECT(8);
 }
 SEXP waicNimbleList::copyToSEXP() {
   SEXP S__dot_xData;
@@ -656,7 +668,7 @@ SEXP waicNimbleList::copyToSEXP() {
   SEXP S_pWAIC;
   if (!RCopiedFlag) {
     PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-    SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+    SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
     PROTECT(S_WAIC = double_2_SEXP(WAIC));
     PROTECT(S_lppd = double_2_SEXP(lppd));
     PROTECT(S_pWAIC = double_2_SEXP(pWAIC));
@@ -667,7 +679,7 @@ SEXP waicNimbleList::copyToSEXP() {
     Rf_defineVar(Rf_install("pWAIC"), S_pWAIC,
                  PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));
     RCopiedFlag = true;
-    UNPROTECT(7);
+    UNPROTECT(8);
   }
   return (RObjectPointer);
 }
@@ -675,18 +687,22 @@ void waicNimbleList::createNewSEXP() {
   SEXP S_newNimList;
   SEXP S_listName;
   PROTECT(S_listName = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S_listName, 0, Rf_mkChar("waicNimbleList"));
+  SET_STRING_ELT(S_listName, 0, PROTECT(Rf_mkChar("waicNimbleList")));
   PROTECT(S_newNimList = makeNewNimbleList(S_listName));
-  RObjectPointer = S_newNimList;
-  UNPROTECT(2);
+  R_PreserveObject(RObjectPointer = S_newNimList);
+  UNPROTECT(3);
 }
-void waicNimbleList::resetFlags() { RCopiedFlag = false; }
+void waicNimbleList::resetFlags() {
+  RCopiedFlag = false;
+  if(RObjectPointer) R_ReleaseObject(RObjectPointer);
+  RObjectPointer = NULL;
+}
 void waicNimbleList::copyFromRobject(SEXP Robject) {
   SETUP_S_xData;
   COPY_DOUBLE_SCALAR_FROM_R_OBJECT("WAIC");
   COPY_DOUBLE_SCALAR_FROM_R_OBJECT("lppd");
   COPY_DOUBLE_SCALAR_FROM_R_OBJECT("pWAIC");
-  UNPROTECT(5);
+  UNPROTECT(6);
 }
 waicNimbleList::waicNimbleList() {
   RCopiedFlag = false;
@@ -755,9 +771,9 @@ void waicDetailsNimbleList::copyFromSEXP(SEXP S_nimList_) {
   SEXP S_WAIC_elements;
   SEXP S_lppd_elements;
   SEXP S_pWAIC_elements;
-  RObjectPointer = S_nimList_;
+  R_PreserveObject(RObjectPointer = S_nimList_);
   PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+  SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
   PROTECT(S_marginal =
               Rf_findVarInFrame(PROTECT(GET_SLOT(S_nimList_, S__dot_xData)),
                                 Rf_install("marginal")));
@@ -805,7 +821,7 @@ void waicDetailsNimbleList::copyFromSEXP(SEXP S_nimList_) {
   SEXP_2_NimArr<1>(S_WAIC_elements, WAIC_elements);
   SEXP_2_NimArr<1>(S_lppd_elements, lppd_elements);
   SEXP_2_NimArr<1>(S_pWAIC_elements, pWAIC_elements);
-  UNPROTECT(25);
+  UNPROTECT(26);
 }
 SEXP waicDetailsNimbleList::copyToSEXP() {
   SEXP S__dot_xData;
@@ -823,7 +839,7 @@ SEXP waicDetailsNimbleList::copyToSEXP() {
   SEXP S_pWAIC_elements;
   if (!RCopiedFlag) {
     PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-    SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+    SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
     PROTECT(S_marginal = bool_2_SEXP(marginal));
     PROTECT(S_niterMarginal = double_2_SEXP(niterMarginal));
     PROTECT(S_thin = bool_2_SEXP(thin));
@@ -863,7 +879,7 @@ SEXP waicDetailsNimbleList::copyToSEXP() {
     Rf_defineVar(Rf_install("pWAIC_elements"), S_pWAIC_elements,
                  PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));
     RCopiedFlag = true;
-    UNPROTECT(25);
+    UNPROTECT(26);
   }
   return (RObjectPointer);
 }
@@ -871,12 +887,16 @@ void waicDetailsNimbleList::createNewSEXP() {
   SEXP S_newNimList;
   SEXP S_listName;
   PROTECT(S_listName = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S_listName, 0, Rf_mkChar("waicDetailsNimbleList"));
+  SET_STRING_ELT(S_listName, 0, PROTECT(Rf_mkChar("waicDetailsNimbleList")));
   PROTECT(S_newNimList = makeNewNimbleList(S_listName));
-  RObjectPointer = S_newNimList;
-  UNPROTECT(2);
+  R_PreserveObject(RObjectPointer = S_newNimList);
+  UNPROTECT(3);
 }
-void waicDetailsNimbleList::resetFlags() { RCopiedFlag = false; }
+void waicDetailsNimbleList::resetFlags() {
+  RCopiedFlag = false;
+  if(RObjectPointer) R_ReleaseObject(RObjectPointer);
+  RObjectPointer = NULL;
+}
 void waicDetailsNimbleList::copyFromRobject(SEXP Robject) {
   SETUP_S_xData;
   COPY_LOGICAL_SCALAR_FROM_R_OBJECT("marginal");
@@ -891,7 +911,7 @@ void waicDetailsNimbleList::copyFromRobject(SEXP Robject) {
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("WAIC_elements");
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("lppd_elements");
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("pWAIC_elements");
-  UNPROTECT(13);
+  UNPROTECT(14);
 }
 waicDetailsNimbleList::waicDetailsNimbleList() {
   RCopiedFlag = false;
@@ -962,9 +982,9 @@ void AGHQuad_params::copyFromSEXP(SEXP S_nimList_) {
   SEXP S_names;
   SEXP S_estimates;
   SEXP S_stdErrors;
-  RObjectPointer = S_nimList_;
+  R_PreserveObject(RObjectPointer = S_nimList_);
   PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+  SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
   PROTECT(S_names =
           Rf_findVarInFrame(PROTECT(GET_SLOT(S_nimList_, S__dot_xData)),
                             Rf_install("names")));
@@ -977,7 +997,7 @@ void AGHQuad_params::copyFromSEXP(SEXP S_nimList_) {
   STRSEXP_2_vectorString(S_names, names);
   SEXP_2_NimArr<1>(S_estimates, estimates);
   SEXP_2_NimArr<1>(S_stdErrors, stdErrors);
-  UNPROTECT(7);
+  UNPROTECT(8);
 }
 
 SEXP AGHQuad_params::copyToSEXP() {
@@ -987,7 +1007,7 @@ SEXP AGHQuad_params::copyToSEXP() {
   SEXP S_stdErrors;
   if (!RCopiedFlag) {
     PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-    SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+    SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
     PROTECT(S_names = vectorString_2_STRSEXP(names));
     PROTECT(S_estimates = NimArr_2_SEXP<1>(estimates));
     PROTECT(S_stdErrors = NimArr_2_SEXP<1>(stdErrors));
@@ -998,7 +1018,7 @@ SEXP AGHQuad_params::copyToSEXP() {
     Rf_defineVar(Rf_install("stdErrors"), S_stdErrors,
                  PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));
     RCopiedFlag = true;
-    UNPROTECT(7);
+    UNPROTECT(8);
   }
   return (RObjectPointer);
 }
@@ -1006,12 +1026,16 @@ void AGHQuad_params::createNewSEXP() {
   SEXP S_newNimList;
   SEXP S_listName;
   PROTECT(S_listName = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S_listName, 0, Rf_mkChar("AGHQuad_params"));
+  SET_STRING_ELT(S_listName, 0, PROTECT(Rf_mkChar("AGHQuad_params")));
   PROTECT(S_newNimList = makeNewNimbleList(S_listName));
-  RObjectPointer = S_newNimList;
-  UNPROTECT(2);
+  R_PreserveObject(RObjectPointer = S_newNimList);
+  UNPROTECT(3);
 }
-void AGHQuad_params::resetFlags() { RCopiedFlag = false; }
+void AGHQuad_params::resetFlags() {
+  RCopiedFlag = false;
+  if(RObjectPointer) R_ReleaseObject(RObjectPointer);
+  RObjectPointer = NULL;
+}
 void AGHQuad_params::copyFromRobject(SEXP Robject) {
   SETUP_S_xData;
   // There is no macro for a string vector, so do it by hand here
@@ -1021,7 +1045,7 @@ void AGHQuad_params::copyFromRobject(SEXP Robject) {
                          *static_cast< std::vector<string>* >(getObjectPtr(svarName)));
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("estimates");
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("stdErrors");
-  UNPROTECT(3);
+  UNPROTECT(4);
 }
 AGHQuad_params::AGHQuad_params() {
   RCopiedFlag = false;
@@ -1084,9 +1108,9 @@ void AGHQuad_summary::copyFromSEXP(SEXP S_nimList_) {
   SEXP S_randomEffects;
   SEXP S_vcov;
   SEXP S_scale;
-  RObjectPointer = S_nimList_;
+  R_PreserveObject(RObjectPointer = S_nimList_);
   PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+  SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
   PROTECT(S_params =
           Rf_findVarInFrame(PROTECT(GET_SLOT(S_nimList_, S__dot_xData)),
                             Rf_install("params")));
@@ -1105,7 +1129,7 @@ void AGHQuad_summary::copyFromSEXP(SEXP S_nimList_) {
   randomEffects->copyFromSEXP(S_randomEffects);
   SEXP_2_NimArr<2>(S_vcov, vcov);
   scale = STRSEXP_2_string(S_scale);
-  UNPROTECT(9);
+  UNPROTECT(10);
 }
 
 SEXP  AGHQuad_summary::copyToSEXP (  )  {
@@ -1116,7 +1140,7 @@ SEXP  AGHQuad_summary::copyToSEXP (  )  {
   SEXP S_scale;
   if (!RCopiedFlag){
     PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-    SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+    SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
     if (!(*params).RObjectPointer) params->createNewSEXP();
     PROTECT(S_params = params->copyToSEXP());
     if (!(*randomEffects).RObjectPointer) randomEffects->createNewSEXP();
@@ -1128,7 +1152,7 @@ SEXP  AGHQuad_summary::copyToSEXP (  )  {
     Rf_defineVar(Rf_install("vcov"), S_vcov, PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));
     Rf_defineVar(Rf_install("scale"), S_scale, PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));
     RCopiedFlag = true;
-    UNPROTECT(9);
+    UNPROTECT(10);
   }
   return(RObjectPointer);
 }
@@ -1137,15 +1161,17 @@ void  AGHQuad_summary::createNewSEXP (  )  {
   SEXP S_newNimList;
   SEXP S_listName;
   PROTECT(S_listName = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S_listName, 0, Rf_mkChar("AGHQuad_summary"));
+  SET_STRING_ELT(S_listName, 0, PROTECT(Rf_mkChar("AGHQuad_summary")));
   PROTECT(S_newNimList = makeNewNimbleList(S_listName));
-  RObjectPointer = S_newNimList;
-  UNPROTECT(2);
+  R_PreserveObject(RObjectPointer = S_newNimList);
+  UNPROTECT(3);
 }
 void  AGHQuad_summary::resetFlags (  )  {
   RCopiedFlag = false;
   params->resetFlags();
   randomEffects->resetFlags();
+  if(RObjectPointer) R_ReleaseObject(RObjectPointer);
+  RObjectPointer = NULL;
 }
 void  AGHQuad_summary::copyFromRobject ( SEXP Robject )  {
   SETUP_S_xData;
@@ -1153,7 +1179,7 @@ void  AGHQuad_summary::copyFromRobject ( SEXP Robject )  {
   // or are those handled by direct copying calls from R (for cases not included in the
   // copyFromRobject scheme)?
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("vcov");
-  UNPROTECT(3);
+  UNPROTECT(4);
 }
 AGHQuad_summary::AGHQuad_summary (  )  {
   RCopiedFlag = false;

--- a/packages/nimble/inst/include/nimble/RcppNimbleUtils.h
+++ b/packages/nimble/inst/include/nimble/RcppNimbleUtils.h
@@ -31,7 +31,7 @@
   SEXP S_string_xData; \
   SEXP S_xData; \
   PROTECT(S_string_xData = Rf_allocVector(STRSXP, 1)); \
-  SET_STRING_ELT(S_string_xData, 0, Rf_mkChar(".xData")); \
+  SET_STRING_ELT(S_string_xData, 0, PROTECT(Rf_mkChar(".xData"))); \
   PROTECT(S_xData = GET_SLOT(Robject, S_string_xData));
 
 #define COPY_NUMERIC_VECTOR_FROM_R_OBJECT(varName) \

--- a/packages/nimble/inst/include/nimble/nimOptim.h
+++ b/packages/nimble/inst/include/nimble/nimOptim.h
@@ -142,22 +142,27 @@ void NimOptimProblem_Fun<Fn>::gradient() {
             // on the fn scale and so are upper_ and lower_.
             const double h_pos = std::min(h, upper_[i] - par_[i]);
             const double h_neg = std::min(h, par_[i] - lower_[i]);
+            // We have to defensively copy par_h = par_ each time in case fn_ modifies the length or values of par_h
+            par_h = par_;
             par_h[i] = par_[i] + h_pos;
             const double pos = fn_(par_h);
+            par_h = par_;
             par_h[i] = par_[i] - h_neg;
             const double neg = fn_(par_h);
-            par_h[i] = par_[i];
+            //par_h[i] = par_[i];
             ans_[i] = parscale[i] * (pos - neg) / (h_pos + h_neg);
         }
     } else {
         // Unconstrained optimization.
         for (int i = 0; i < n; ++i) {
             const double h = working_ndeps[i]*parscale[i];
+            par_h = par_;
             par_h[i] = par_[i] + h;
             const double pos = fn_(par_h);
+            par_h = par_;
             par_h[i] = par_[i] - h;
             const double neg = fn_(par_h);
-            par_h[i] = par_[i];
+            //par_h[i] = par_[i];
             ans_[i] = (pos - neg) / (2 * working_ndeps[i]);
         }
     }
@@ -182,9 +187,9 @@ class NimOptimProblem_Fun_Grad : public NimOptimProblem {
       // This should return gradient on par/parscale.
       // But gr_ calculates the gradient wrt par.
       // So we have to multiply by parscale.
+      const int n = par_.dimSize(0);
       ans_ = gr_(par_);
       double* parscale = working_parscale.getPtr();
-      const int n = par_.dimSize(0);
       for (int i = 0; i < n; ++i) {
         ans_[i] *= parscale[i];
       }


### PR DESCRIPTION
I think I fixed this once before, but somehow evidently it didn't make it into devel. I'm not sure what happened.

The issue is that a nimOptim call provides an objective function and, optionally, a gradient function. In compiled code, these will take the parameter vector by reference, and they may modify it. If a parameter transformation is in use, they might even shorten the parameter vector.  If the calling code assumes the parameter vector was unchanged, a bug can result. Minor changes are made in this PR to protect against that scenario.

Specifically, I believe this was causing a crash in test-ADlaplace, in the test involving a length-changing transformation (from a Dirichlet). There seems to be some kind of other intermittent issue coming up in test-ADlaplace, and I am not sure if they are related.