### PR TITLE
Check on VECTOR_ELT intermittent errors

### DIFF
--- a/packages/nimble/R/cppDefs_nimbleFunction.R
+++ b/packages/nimble/R/cppDefs_nimbleFunction.R
@@ -1212,7 +1212,7 @@ makeCopyFromRobjectDef <- function(cppCopyTypes,
                             c(list('{'),
                               list(cppLiteral("SETUP_S_xData;")),
                               copyCalls,
-                              list(cppLiteral(paste0("UNPROTECT(",unprotectCount,");")))),
+                              list(cppLiteral(paste0("UNPROTECT(",unprotectCount,"+1);")))),
                             quote = TRUE
                             )
     }

--- a/packages/nimble/R/cppDefs_nimbleList.R
+++ b/packages/nimble/R/cppDefs_nimbleList.R
@@ -199,12 +199,12 @@ cppNimbleListClass <- setRefClass('cppNimbleListClass',
                                         listElementTable$addSymbol(cppSEXP(name = "S_listName"))
                                       
                                         newListLine[[1]] <- substitute({PROTECT(S_listName <- Rf_allocVector(STRSXP, 1));
-                                          SET_STRING_ELT(S_listName, 0, Rf_mkChar(LISTNAME));}, 
+                                          SET_STRING_ELT(S_listName, 0, PROTECT(Rf_mkChar(LISTNAME)));},
                                           list(LISTNAME = nimCompProc$nimbleListObj$className))
                                         newListLine[[2]] <- substitute(PROTECT(S_newNimList <- makeNewNimbleList(S_listName)),
                                                                            list())
-                                        newListLine[[3]] <- quote(cppLiteral('RObjectPointer = S_newNimList;'))
-                                        newListLine[[4]] <-   substitute(UNPROTECT(2), list())
+                                        newListLine[[3]] <- quote(cppLiteral('R_PreserveObject(RObjectPointer = S_newNimList);'))
+                                        newListLine[[4]] <-   substitute(UNPROTECT(2+1), list())
                                         allCode <- embedListInRbracket(c(newListLine))
                                         functionDefs[[paste0(name, "_createNewSEXP")]] <<- cppFunctionDef(name = "createNewSEXP",
                                                                                                     args = interfaceArgs,
@@ -231,7 +231,7 @@ cppNimbleListClass <- setRefClass('cppNimbleListClass',
                                         environmentCPPName <- Rname2CppName('S_.xData')  ## create SEXP for ref class environment 
                                         listElementTable$addSymbol(cppSEXP(name = environmentCPPName))
                                         envLine <- substitute({PROTECT(ENVNAME <- Rf_allocVector(STRSXP, 1));
-                                          SET_STRING_ELT(ENVNAME, 0, Rf_mkChar(".xData"));}, 
+                                          SET_STRING_ELT(ENVNAME, 0, PROTECT(Rf_mkChar(".xData")));},
                                           list(ENVNAME = as.name(environmentCPPName)))
                                         
                                         for(i in seq_along(elementNames)){
@@ -251,7 +251,7 @@ cppNimbleListClass <- setRefClass('cppNimbleListClass',
                                                                        list()))
                                         returnLine <- list(substitute(return(ROBJ),
                                                            list(ROBJ = as.name('RObjectPointer'))))
-                                        unprotectLine <- list(substitute(UNPROTECT(N), list(N = 2 * numElements + 1)))
+                                        unprotectLine <- list(substitute(UNPROTECT(N), list(N = 2 * numElements + 1 + 1)))
                                         allCode <- embedListInRbracket(c(conditionalClauseStart, list(envLine),  conditionalLineList,
                                                                          copyToListLines, setFlagLine, unprotectLine,
                                                                          conditionalClauseEnd, returnLine))
@@ -274,12 +274,12 @@ cppNimbleListClass <- setRefClass('cppNimbleListClass',
                                         Snames <- character(length(argNames))
                                         returnType <- "void"
                                         listElementTable <- symbolTable()
-                                        storeSexpLine <- list(quote(cppLiteral('RObjectPointer =  S_nimList_;')))
+                                        storeSexpLine <- list(quote(cppLiteral('R_PreserveObject(RObjectPointer =  S_nimList_);')))
 
                                         environmentCPPName <- Rname2CppName('S_.xData')  ## create SEXP for ref class environment 
                                         listElementTable$addSymbol(cppSEXP(name = environmentCPPName))
                                         envLine <- substitute({PROTECT(ENVNAME <- Rf_allocVector(STRSXP, 1));
-                                          SET_STRING_ELT(ENVNAME, 0, Rf_mkChar(".xData"));}, 
+                                          SET_STRING_ELT(ENVNAME, 0, PROTECT(Rf_mkChar(".xData")));},
                                           list(ENVNAME = as.name(environmentCPPName)))
 
                                         for(i in seq_along(argNames)) {
@@ -294,7 +294,7 @@ cppNimbleListClass <- setRefClass('cppNimbleListClass',
                                             copyLines <- c(copyLines, copyLine)
                                         }
                                         numArgs <- length(argNames)
-                                        unprotectLine <- substitute(UNPROTECT(N), list(N = 2 * numArgs + 1))
+                                        unprotectLine <- substitute(UNPROTECT(N), list(N = 2 * numArgs + 1 + 1))
                                         allCode <- embedListInRbracket(c(storeSexpLine, envLine, 
                                                                          copyFromListLines, copyLines,
                                                                          list(unprotectLine)))

--- a/packages/nimble/R/cppDefs_nimbleList.R
+++ b/packages/nimble/R/cppDefs_nimbleList.R
@@ -325,7 +325,8 @@ cppNimbleListClass <- setRefClass('cppNimbleListClass',
                                                                  resetRCopiedFlagLine)
                                           }
                                         }
-                                        allCode <- embedListInRbracket(c(resetFlagLine, resetNestedFlagLines))
+                                        resetRObjLines <- list(quote(cppLiteral("if(RObjectPointer) R_ReleaseObject(RObjectPointer); RObjectPointer=NULL;")))
+                                        allCode <- embedListInRbracket(c(resetFlagLine, resetNestedFlagLines, resetRObjLines))
                                         functionDefs[[paste0(name, "_resetFlags")]] <<- cppFunctionDef(name = "resetFlags",
                                                                                                    args = interfaceArgs,
                                                                                                    code = cppCodeBlock(code = RparseTree2ExprClasses(allCode), objectDefs = listElementTable),

--- a/packages/nimble/inst/CppCode/NamedObjects.cpp
+++ b/packages/nimble/inst/CppCode/NamedObjects.cpp
@@ -103,10 +103,10 @@ SEXP getAvailableNames(SEXP Sextptr) {
     // _nimble_global_output << "starting "<<i<<"\n"; nimble_print_to_R( _nimble_global_output);
     //_nimble_global_output << iNO->first.c_str() <<" \n";
     //nimble_print_to_R( _nimble_global_output);
-    SET_STRING_ELT(Sans, i, Rf_mkChar(iNO->first.c_str()));
+    SET_STRING_ELT(Sans, i, PROTECT(Rf_mkChar(iNO->first.c_str())));
     //_nimble_global_output << "done with "<<i<<" "<<iNO->first<<" \n"; nimble_print_to_R( _nimble_global_output);
   }
-  UNPROTECT(1);
+  UNPROTECT(numNames + 1);
   return(Sans);
 }
 

--- a/packages/nimble/inst/CppCode/predefinedNimbleLists.cpp
+++ b/packages/nimble/inst/CppCode/predefinedNimbleLists.cpp
@@ -179,7 +179,11 @@ void OptimResultNimbleList::createNewSEXP() {
   R_PreserveObject(RObjectPointer = S_newNimList);
   UNPROTECT(3);
 }
-void OptimResultNimbleList::resetFlags() { RCopiedFlag = false; }
+void OptimResultNimbleList::resetFlags() {
+  RCopiedFlag = false;
+  if(RObjectPointer) R_ReleaseObject(RObjectPointer);
+  RObjectPointer = NULL;
+}
 void OptimResultNimbleList::copyFromRobject(SEXP Robject) {
   SETUP_S_xData;
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("par");
@@ -420,7 +424,11 @@ void OptimControlNimbleList::createNewSEXP() {
   R_PreserveObject(RObjectPointer = S_newNimList);
   UNPROTECT(3);
 }
-void OptimControlNimbleList::resetFlags() { RCopiedFlag = false; }
+void OptimControlNimbleList::resetFlags() {
+  RCopiedFlag = false;
+  if(RObjectPointer) R_ReleaseObject(RObjectPointer);
+  RObjectPointer = NULL;
+}
 void OptimControlNimbleList::copyFromRobject(SEXP Robject) {
   SETUP_S_xData;
   COPY_INTEGER_SCALAR_FROM_R_OBJECT("trace");
@@ -565,7 +573,11 @@ void NIMBLE_ADCLASS::createNewSEXP() {
   R_PreserveObject(RObjectPointer = S_newNimList);
   UNPROTECT(3);
 }
-void NIMBLE_ADCLASS::resetFlags() { RCopiedFlag = false; }
+void NIMBLE_ADCLASS::resetFlags() {
+  RCopiedFlag = false;
+  if(RObjectPointer) R_ReleaseObject(RObjectPointer);
+  RObjectPointer = NULL;
+}
 
 void NIMBLE_ADCLASS::copyFromRobject(SEXP Robject) {
   SETUP_S_xData;
@@ -680,7 +692,11 @@ void waicNimbleList::createNewSEXP() {
   R_PreserveObject(RObjectPointer = S_newNimList);
   UNPROTECT(3);
 }
-void waicNimbleList::resetFlags() { RCopiedFlag = false; }
+void waicNimbleList::resetFlags() {
+  RCopiedFlag = false;
+  if(RObjectPointer) R_ReleaseObject(RObjectPointer);
+  RObjectPointer = NULL;
+}
 void waicNimbleList::copyFromRobject(SEXP Robject) {
   SETUP_S_xData;
   COPY_DOUBLE_SCALAR_FROM_R_OBJECT("WAIC");
@@ -876,7 +892,11 @@ void waicDetailsNimbleList::createNewSEXP() {
   R_PreserveObject(RObjectPointer = S_newNimList);
   UNPROTECT(3);
 }
-void waicDetailsNimbleList::resetFlags() { RCopiedFlag = false; }
+void waicDetailsNimbleList::resetFlags() {
+  RCopiedFlag = false;
+  if(RObjectPointer) R_ReleaseObject(RObjectPointer);
+  RObjectPointer = NULL;
+}
 void waicDetailsNimbleList::copyFromRobject(SEXP Robject) {
   SETUP_S_xData;
   COPY_LOGICAL_SCALAR_FROM_R_OBJECT("marginal");
@@ -1011,7 +1031,11 @@ void AGHQuad_params::createNewSEXP() {
   R_PreserveObject(RObjectPointer = S_newNimList);
   UNPROTECT(3);
 }
-void AGHQuad_params::resetFlags() { RCopiedFlag = false; }
+void AGHQuad_params::resetFlags() {
+  RCopiedFlag = false;
+  if(RObjectPointer) R_ReleaseObject(RObjectPointer);
+  RObjectPointer = NULL;
+}
 void AGHQuad_params::copyFromRobject(SEXP Robject) {
   SETUP_S_xData;
   // There is no macro for a string vector, so do it by hand here
@@ -1146,6 +1170,8 @@ void  AGHQuad_summary::resetFlags (  )  {
   RCopiedFlag = false;
   params->resetFlags();
   randomEffects->resetFlags();
+  if(RObjectPointer) R_ReleaseObject(RObjectPointer);
+  RObjectPointer = NULL;
 }
 void  AGHQuad_summary::copyFromRobject ( SEXP Robject )  {
   SETUP_S_xData;

--- a/packages/nimble/inst/CppCode/predefinedNimbleLists.cpp
+++ b/packages/nimble/inst/CppCode/predefinedNimbleLists.cpp
@@ -108,9 +108,9 @@ void OptimResultNimbleList::copyFromSEXP(SEXP S_nimList_) {
   SEXP S_convergence;
   SEXP S_message;
   SEXP S_hessian;
-  RObjectPointer = S_nimList_;
+  R_PreserveObject(RObjectPointer = S_nimList_);
   PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+  SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
   PROTECT(S_par = Rf_findVarInFrame(PROTECT(GET_SLOT(S_nimList_, S__dot_xData)),
                                     Rf_install("par")));
   PROTECT(S_value =
@@ -134,7 +134,7 @@ void OptimResultNimbleList::copyFromSEXP(SEXP S_nimList_) {
   convergence = SEXP_2_int(S_convergence);
   message = STRSEXP_2_string(S_message);
   SEXP_2_NimArr<2>(S_hessian, hessian);
-  UNPROTECT(13);
+  UNPROTECT(14);
 }
 SEXP OptimResultNimbleList::copyToSEXP() {
   SEXP S__dot_xData;
@@ -146,7 +146,7 @@ SEXP OptimResultNimbleList::copyToSEXP() {
   SEXP S_hessian;
   if (!RCopiedFlag) {
     PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-    SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+    SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
     PROTECT(S_par = NimArr_2_SEXP<1>(par));
     PROTECT(S_value = double_2_SEXP(value));
     PROTECT(S_counts = NimArr_2_SEXP<1>(counts));
@@ -166,7 +166,7 @@ SEXP OptimResultNimbleList::copyToSEXP() {
     Rf_defineVar(Rf_install("hessian"), S_hessian,
                  PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));
     RCopiedFlag = true;
-    UNPROTECT(13);
+    UNPROTECT(14);
   }
   return (RObjectPointer);
 }
@@ -174,10 +174,10 @@ void OptimResultNimbleList::createNewSEXP() {
   SEXP S_newNimList;
   SEXP S_listName;
   PROTECT(S_listName = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S_listName, 0, Rf_mkChar("OptimResultNimbleList"));
+  SET_STRING_ELT(S_listName, 0, PROTECT(Rf_mkChar("OptimResultNimbleList")));
   PROTECT(S_newNimList = makeNewNimbleList(S_listName));
-  RObjectPointer = S_newNimList;
-  UNPROTECT(2);
+  R_PreserveObject(RObjectPointer = S_newNimList);
+  UNPROTECT(3);
 }
 void OptimResultNimbleList::resetFlags() { RCopiedFlag = false; }
 void OptimResultNimbleList::copyFromRobject(SEXP Robject) {
@@ -187,7 +187,7 @@ void OptimResultNimbleList::copyFromRobject(SEXP Robject) {
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("counts");
   COPY_INTEGER_SCALAR_FROM_R_OBJECT("convergence");
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("hessian");
-  UNPROTECT(7);
+  UNPROTECT(8);
 }
 OptimResultNimbleList::OptimResultNimbleList() {
   RCopiedFlag = false;
@@ -265,9 +265,9 @@ void OptimControlNimbleList::copyFromSEXP(SEXP S_nimList_) {
   SEXP S_pgtol;
   SEXP S_temp;
   SEXP S_tmax;
-  RObjectPointer = S_nimList_;
+    R_PreserveObject(RObjectPointer = S_nimList_);
   PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+  SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
   PROTECT(S_trace =
               Rf_findVarInFrame(PROTECT(GET_SLOT(S_nimList_, S__dot_xData)),
                                 Rf_install("trace")));
@@ -331,7 +331,7 @@ void OptimControlNimbleList::copyFromSEXP(SEXP S_nimList_) {
   pgtol = SEXP_2_double(S_pgtol);
   temp = SEXP_2_double(S_temp);
   tmax = SEXP_2_int(S_tmax);
-  UNPROTECT(35);
+  UNPROTECT(36);
 }
 SEXP OptimControlNimbleList::copyToSEXP() {
   SEXP S__dot_xData;
@@ -354,7 +354,7 @@ SEXP OptimControlNimbleList::copyToSEXP() {
   SEXP S_tmax;
   if (!RCopiedFlag) {
     PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-    SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+    SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
     PROTECT(S_trace = int_2_SEXP(trace));
     PROTECT(S_fnscale = double_2_SEXP(fnscale));
     PROTECT(S_parscale = NimArr_2_SEXP<1>(parscale));
@@ -407,7 +407,7 @@ SEXP OptimControlNimbleList::copyToSEXP() {
     Rf_defineVar(Rf_install("tmax"), S_tmax,
                  PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));
     RCopiedFlag = true;
-    UNPROTECT(35);
+    UNPROTECT(36);
   }
   return (RObjectPointer);
 }
@@ -415,10 +415,10 @@ void OptimControlNimbleList::createNewSEXP() {
   SEXP S_newNimList;
   SEXP S_listName;
   PROTECT(S_listName = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S_listName, 0, Rf_mkChar("OptimControlNimbleList"));
+  SET_STRING_ELT(S_listName, 0, PROTECT(Rf_mkChar("OptimControlNimbleList")));
   PROTECT(S_newNimList = makeNewNimbleList(S_listName));
-  RObjectPointer = S_newNimList;
-  UNPROTECT(2);
+  R_PreserveObject(RObjectPointer = S_newNimList);
+  UNPROTECT(3);
 }
 void OptimControlNimbleList::resetFlags() { RCopiedFlag = false; }
 void OptimControlNimbleList::copyFromRobject(SEXP Robject) {
@@ -440,7 +440,7 @@ void OptimControlNimbleList::copyFromRobject(SEXP Robject) {
   COPY_DOUBLE_SCALAR_FROM_R_OBJECT("pgtol");
   COPY_DOUBLE_SCALAR_FROM_R_OBJECT("temp");
   COPY_INTEGER_SCALAR_FROM_R_OBJECT("tmax");
-  UNPROTECT(19);
+  UNPROTECT(20);
 }
 OptimControlNimbleList::OptimControlNimbleList() {
   RCopiedFlag = false;
@@ -515,9 +515,9 @@ void NIMBLE_ADCLASS::copyFromSEXP(SEXP S_nimList_) {
   SEXP S_value;
   SEXP S_jacobian;
   SEXP S_hessian;
-  RObjectPointer = S_nimList_;
+  R_PreserveObject(RObjectPointer = S_nimList_);
   PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+  SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
   PROTECT(S_value =
               Rf_findVarInFrame(PROTECT(GET_SLOT(S_nimList_, S__dot_xData)),
                                 Rf_install("value")));
@@ -530,7 +530,7 @@ void NIMBLE_ADCLASS::copyFromSEXP(SEXP S_nimList_) {
   SEXP_2_NimArr<1>(S_value, value);
   SEXP_2_NimArr<2>(S_jacobian, jacobian);
   SEXP_2_NimArr<3>(S_hessian, hessian);
-  UNPROTECT(7);
+  UNPROTECT(8);
 }
 SEXP NIMBLE_ADCLASS::copyToSEXP() {
   PROTECT(RObjectPointer);
@@ -560,10 +560,10 @@ void NIMBLE_ADCLASS::createNewSEXP() {
   SEXP S_newNimList;
   SEXP S_listName;
   PROTECT(S_listName = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S_listName, 0, Rf_mkChar("NIMBLE_ADCLASS"));
+  SET_STRING_ELT(S_listName, 0, PROTECT(Rf_mkChar("NIMBLE_ADCLASS")));
   PROTECT(S_newNimList = makeNewNimbleList(S_listName));
-  RObjectPointer = S_newNimList;
-  UNPROTECT(2);
+  R_PreserveObject(RObjectPointer = S_newNimList);
+  UNPROTECT(3);
 }
 void NIMBLE_ADCLASS::resetFlags() { RCopiedFlag = false; }
 
@@ -572,7 +572,7 @@ void NIMBLE_ADCLASS::copyFromRobject(SEXP Robject) {
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("value");
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("jacobian");
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("hessian");
-  UNPROTECT(5);
+  UNPROTECT(6);
 }
 
 NIMBLE_ADCLASS::NIMBLE_ADCLASS() {
@@ -634,9 +634,9 @@ void waicNimbleList::copyFromSEXP(SEXP S_nimList_) {
   SEXP S_WAIC;
   SEXP S_lppd;
   SEXP S_pWAIC;
-  RObjectPointer = S_nimList_;
+  R_PreserveObject(RObjectPointer = S_nimList_);
   PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+  SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
   PROTECT(S_WAIC = Rf_findVarInFrame(
               PROTECT(GET_SLOT(S_nimList_, S__dot_xData)), Rf_install("WAIC")));
   PROTECT(S_lppd = Rf_findVarInFrame(
@@ -647,7 +647,7 @@ void waicNimbleList::copyFromSEXP(SEXP S_nimList_) {
   WAIC = SEXP_2_double(S_WAIC);
   lppd = SEXP_2_double(S_lppd);
   pWAIC = SEXP_2_double(S_pWAIC);
-  UNPROTECT(7);
+  UNPROTECT(8);
 }
 SEXP waicNimbleList::copyToSEXP() {
   SEXP S__dot_xData;
@@ -656,7 +656,7 @@ SEXP waicNimbleList::copyToSEXP() {
   SEXP S_pWAIC;
   if (!RCopiedFlag) {
     PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-    SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+    SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
     PROTECT(S_WAIC = double_2_SEXP(WAIC));
     PROTECT(S_lppd = double_2_SEXP(lppd));
     PROTECT(S_pWAIC = double_2_SEXP(pWAIC));
@@ -667,7 +667,7 @@ SEXP waicNimbleList::copyToSEXP() {
     Rf_defineVar(Rf_install("pWAIC"), S_pWAIC,
                  PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));
     RCopiedFlag = true;
-    UNPROTECT(7);
+    UNPROTECT(8);
   }
   return (RObjectPointer);
 }
@@ -675,10 +675,10 @@ void waicNimbleList::createNewSEXP() {
   SEXP S_newNimList;
   SEXP S_listName;
   PROTECT(S_listName = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S_listName, 0, Rf_mkChar("waicNimbleList"));
+  SET_STRING_ELT(S_listName, 0, PROTECT(Rf_mkChar("waicNimbleList")));
   PROTECT(S_newNimList = makeNewNimbleList(S_listName));
-  RObjectPointer = S_newNimList;
-  UNPROTECT(2);
+  R_PreserveObject(RObjectPointer = S_newNimList);
+  UNPROTECT(3);
 }
 void waicNimbleList::resetFlags() { RCopiedFlag = false; }
 void waicNimbleList::copyFromRobject(SEXP Robject) {
@@ -686,7 +686,7 @@ void waicNimbleList::copyFromRobject(SEXP Robject) {
   COPY_DOUBLE_SCALAR_FROM_R_OBJECT("WAIC");
   COPY_DOUBLE_SCALAR_FROM_R_OBJECT("lppd");
   COPY_DOUBLE_SCALAR_FROM_R_OBJECT("pWAIC");
-  UNPROTECT(5);
+  UNPROTECT(6);
 }
 waicNimbleList::waicNimbleList() {
   RCopiedFlag = false;
@@ -755,9 +755,9 @@ void waicDetailsNimbleList::copyFromSEXP(SEXP S_nimList_) {
   SEXP S_WAIC_elements;
   SEXP S_lppd_elements;
   SEXP S_pWAIC_elements;
-  RObjectPointer = S_nimList_;
+  R_PreserveObject(RObjectPointer = S_nimList_);
   PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+  SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
   PROTECT(S_marginal =
               Rf_findVarInFrame(PROTECT(GET_SLOT(S_nimList_, S__dot_xData)),
                                 Rf_install("marginal")));
@@ -805,7 +805,7 @@ void waicDetailsNimbleList::copyFromSEXP(SEXP S_nimList_) {
   SEXP_2_NimArr<1>(S_WAIC_elements, WAIC_elements);
   SEXP_2_NimArr<1>(S_lppd_elements, lppd_elements);
   SEXP_2_NimArr<1>(S_pWAIC_elements, pWAIC_elements);
-  UNPROTECT(25);
+  UNPROTECT(26);
 }
 SEXP waicDetailsNimbleList::copyToSEXP() {
   SEXP S__dot_xData;
@@ -823,7 +823,7 @@ SEXP waicDetailsNimbleList::copyToSEXP() {
   SEXP S_pWAIC_elements;
   if (!RCopiedFlag) {
     PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-    SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+    SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
     PROTECT(S_marginal = bool_2_SEXP(marginal));
     PROTECT(S_niterMarginal = double_2_SEXP(niterMarginal));
     PROTECT(S_thin = bool_2_SEXP(thin));
@@ -863,7 +863,7 @@ SEXP waicDetailsNimbleList::copyToSEXP() {
     Rf_defineVar(Rf_install("pWAIC_elements"), S_pWAIC_elements,
                  PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));
     RCopiedFlag = true;
-    UNPROTECT(25);
+    UNPROTECT(26);
   }
   return (RObjectPointer);
 }
@@ -871,10 +871,10 @@ void waicDetailsNimbleList::createNewSEXP() {
   SEXP S_newNimList;
   SEXP S_listName;
   PROTECT(S_listName = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S_listName, 0, Rf_mkChar("waicDetailsNimbleList"));
+  SET_STRING_ELT(S_listName, 0, PROTECT(Rf_mkChar("waicDetailsNimbleList")));
   PROTECT(S_newNimList = makeNewNimbleList(S_listName));
-  RObjectPointer = S_newNimList;
-  UNPROTECT(2);
+  R_PreserveObject(RObjectPointer = S_newNimList);
+  UNPROTECT(3);
 }
 void waicDetailsNimbleList::resetFlags() { RCopiedFlag = false; }
 void waicDetailsNimbleList::copyFromRobject(SEXP Robject) {
@@ -891,7 +891,7 @@ void waicDetailsNimbleList::copyFromRobject(SEXP Robject) {
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("WAIC_elements");
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("lppd_elements");
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("pWAIC_elements");
-  UNPROTECT(13);
+  UNPROTECT(14);
 }
 waicDetailsNimbleList::waicDetailsNimbleList() {
   RCopiedFlag = false;
@@ -962,9 +962,9 @@ void AGHQuad_params::copyFromSEXP(SEXP S_nimList_) {
   SEXP S_names;
   SEXP S_estimates;
   SEXP S_stdErrors;
-  RObjectPointer = S_nimList_;
+  R_PreserveObject(RObjectPointer = S_nimList_);
   PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+  SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
   PROTECT(S_names =
           Rf_findVarInFrame(PROTECT(GET_SLOT(S_nimList_, S__dot_xData)),
                             Rf_install("names")));
@@ -977,7 +977,7 @@ void AGHQuad_params::copyFromSEXP(SEXP S_nimList_) {
   STRSEXP_2_vectorString(S_names, names);
   SEXP_2_NimArr<1>(S_estimates, estimates);
   SEXP_2_NimArr<1>(S_stdErrors, stdErrors);
-  UNPROTECT(7);
+  UNPROTECT(8);
 }
 
 SEXP AGHQuad_params::copyToSEXP() {
@@ -987,7 +987,7 @@ SEXP AGHQuad_params::copyToSEXP() {
   SEXP S_stdErrors;
   if (!RCopiedFlag) {
     PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-    SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+    SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
     PROTECT(S_names = vectorString_2_STRSEXP(names));
     PROTECT(S_estimates = NimArr_2_SEXP<1>(estimates));
     PROTECT(S_stdErrors = NimArr_2_SEXP<1>(stdErrors));
@@ -998,7 +998,7 @@ SEXP AGHQuad_params::copyToSEXP() {
     Rf_defineVar(Rf_install("stdErrors"), S_stdErrors,
                  PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));
     RCopiedFlag = true;
-    UNPROTECT(7);
+    UNPROTECT(8);
   }
   return (RObjectPointer);
 }
@@ -1006,10 +1006,10 @@ void AGHQuad_params::createNewSEXP() {
   SEXP S_newNimList;
   SEXP S_listName;
   PROTECT(S_listName = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S_listName, 0, Rf_mkChar("AGHQuad_params"));
+  SET_STRING_ELT(S_listName, 0, PROTECT(Rf_mkChar("AGHQuad_params")));
   PROTECT(S_newNimList = makeNewNimbleList(S_listName));
-  RObjectPointer = S_newNimList;
-  UNPROTECT(2);
+  R_PreserveObject(RObjectPointer = S_newNimList);
+  UNPROTECT(3);
 }
 void AGHQuad_params::resetFlags() { RCopiedFlag = false; }
 void AGHQuad_params::copyFromRobject(SEXP Robject) {
@@ -1021,7 +1021,7 @@ void AGHQuad_params::copyFromRobject(SEXP Robject) {
                          *static_cast< std::vector<string>* >(getObjectPtr(svarName)));
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("estimates");
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("stdErrors");
-  UNPROTECT(3);
+  UNPROTECT(4);
 }
 AGHQuad_params::AGHQuad_params() {
   RCopiedFlag = false;
@@ -1084,9 +1084,9 @@ void AGHQuad_summary::copyFromSEXP(SEXP S_nimList_) {
   SEXP S_randomEffects;
   SEXP S_vcov;
   SEXP S_scale;
-  RObjectPointer = S_nimList_;
+  R_PreserveObject(RObjectPointer = S_nimList_);
   PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+  SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
   PROTECT(S_params =
           Rf_findVarInFrame(PROTECT(GET_SLOT(S_nimList_, S__dot_xData)),
                             Rf_install("params")));
@@ -1105,7 +1105,7 @@ void AGHQuad_summary::copyFromSEXP(SEXP S_nimList_) {
   randomEffects->copyFromSEXP(S_randomEffects);
   SEXP_2_NimArr<2>(S_vcov, vcov);
   scale = STRSEXP_2_string(S_scale);
-  UNPROTECT(9);
+  UNPROTECT(10);
 }
 
 SEXP  AGHQuad_summary::copyToSEXP (  )  {
@@ -1116,7 +1116,7 @@ SEXP  AGHQuad_summary::copyToSEXP (  )  {
   SEXP S_scale;
   if (!RCopiedFlag){
     PROTECT(S__dot_xData = Rf_allocVector(STRSXP, 1));
-    SET_STRING_ELT(S__dot_xData, 0, Rf_mkChar(".xData"));
+    SET_STRING_ELT(S__dot_xData, 0, PROTECT(Rf_mkChar(".xData")));
     if (!(*params).RObjectPointer) params->createNewSEXP();
     PROTECT(S_params = params->copyToSEXP());
     if (!(*randomEffects).RObjectPointer) randomEffects->createNewSEXP();
@@ -1128,7 +1128,7 @@ SEXP  AGHQuad_summary::copyToSEXP (  )  {
     Rf_defineVar(Rf_install("vcov"), S_vcov, PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));
     Rf_defineVar(Rf_install("scale"), S_scale, PROTECT(GET_SLOT(RObjectPointer, S__dot_xData)));
     RCopiedFlag = true;
-    UNPROTECT(9);
+    UNPROTECT(10);
   }
   return(RObjectPointer);
 }
@@ -1137,10 +1137,10 @@ void  AGHQuad_summary::createNewSEXP (  )  {
   SEXP S_newNimList;
   SEXP S_listName;
   PROTECT(S_listName = Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(S_listName, 0, Rf_mkChar("AGHQuad_summary"));
+  SET_STRING_ELT(S_listName, 0, PROTECT(Rf_mkChar("AGHQuad_summary")));
   PROTECT(S_newNimList = makeNewNimbleList(S_listName));
-  RObjectPointer = S_newNimList;
-  UNPROTECT(2);
+  R_PreserveObject(RObjectPointer = S_newNimList);
+  UNPROTECT(3);
 }
 void  AGHQuad_summary::resetFlags (  )  {
   RCopiedFlag = false;
@@ -1153,7 +1153,7 @@ void  AGHQuad_summary::copyFromRobject ( SEXP Robject )  {
   // or are those handled by direct copying calls from R (for cases not included in the
   // copyFromRobject scheme)?
   COPY_NUMERIC_VECTOR_FROM_R_OBJECT("vcov");
-  UNPROTECT(3);
+  UNPROTECT(4);
 }
 AGHQuad_summary::AGHQuad_summary (  )  {
   RCopiedFlag = false;

--- a/packages/nimble/inst/include/nimble/RcppNimbleUtils.h
+++ b/packages/nimble/inst/include/nimble/RcppNimbleUtils.h
@@ -31,7 +31,7 @@
   SEXP S_string_xData; \
   SEXP S_xData; \
   PROTECT(S_string_xData = Rf_allocVector(STRSXP, 1)); \
-  SET_STRING_ELT(S_string_xData, 0, Rf_mkChar(".xData")); \
+  SET_STRING_ELT(S_string_xData, 0, PROTECT(Rf_mkChar(".xData"))); \
   PROTECT(S_xData = GET_SLOT(Robject, S_string_xData));
 
 #define COPY_NUMERIC_VECTOR_FROM_R_OBJECT(varName) \

--- a/run_tests.R
+++ b/run_tests.R
@@ -39,6 +39,9 @@ if (length(grep('^-', argv, invert = TRUE))) {
     allTests <- list.files('packages/nimble/tests/testthat')
     allTests <- allTests[grepl('test-.*\\.R', allTests)]
 
+    ## SHORTCUT FOR BRANCH fix-vector-elt to run only tests that usually show the intermittent issue
+    allTests <- c("test-ADlaplace.R", "AD-nimbleList.R")
+
     # Avoid running these omitlisted tests, since they take too long
     # or involve experimental features.
     omitlist <- c(

--- a/run_tests.R
+++ b/run_tests.R
@@ -40,7 +40,7 @@ if (length(grep('^-', argv, invert = TRUE))) {
     allTests <- allTests[grepl('test-.*\\.R', allTests)]
 
     ## SHORTCUT FOR BRANCH fix-vector-elt to run only tests that usually show the intermittent issue
-    allTests <- c("test-ADlaplace.R", "AD-nimbleList.R")
+    allTests <- c("test-ADlaplace.R", "test-nimbleList.R")
 
     # Avoid running these omitlisted tests, since they take too long
     # or involve experimental features.

--- a/run_tests.R
+++ b/run_tests.R
@@ -39,9 +39,6 @@ if (length(grep('^-', argv, invert = TRUE))) {
     allTests <- list.files('packages/nimble/tests/testthat')
     allTests <- allTests[grepl('test-.*\\.R', allTests)]
 
-    ## SHORTCUT FOR BRANCH fix-vector-elt to run only tests that usually show the intermittent issue
-    allTests <- c("test-ADlaplace.R", "test-nimbleList.R")
-
     # Avoid running these omitlisted tests, since they take too long
     # or involve experimental features.
     omitlist <- c(


### PR DESCRIPTION
Do not merge.

This has some trial pieces to investigate the intermittent "`VECTOR_ELT`" error that appears intermittently and perhaps entirely (?) in testing.

Note two things to polish if this appears to fix the issue:

- The `R_PreserveObject` calls need to be matched by `R_ReleaseObject`, which would take setting up destructor/finalized behavior.
- The testing has been hot-wired to run only ADlaplace and nimbleLists because those are the usual ones where we see the issue.

If tests pass, the plan is to re-run them multiple times due to the intermittency of the issue.