### PR TITLE
Remove testthat::context() calls

### DIFF
--- a/packages/nimble/tests/testthat/test-ADdsl.R
+++ b/packages/nimble/tests/testthat/test-ADdsl.R
@@ -7,8 +7,6 @@ nimbleOptions(enableDerivs = TRUE)
 nimbleOptions(buildModelDerivs = TRUE)
 nimbleOptions(useClearCompiledInADTesting = FALSE)
 
-context("Testing of derivatives for distributions and dsl functions")
-
 # tested:
 # 'dbeta' (although boundary at x=0 and x=1 not consistent between R and c++),
 # 'dbinom' (works as long as wrt = prob and not x or size),

--- a/packages/nimble/tests/testthat/test-ADfunctions.R
+++ b/packages/nimble/tests/testthat/test-ADfunctions.R
@@ -8,8 +8,6 @@ nimbleOptions(enableDerivs = TRUE)
 nimbleOptions(buildModelDerivs = TRUE)
 nimbleOptions(allowDynamicIndexing = FALSE)
 
-context("Testing of derivatives for nimbleFunctions.")
-
 test_that('Derivatives of dnorm function correctly.',
   {
     ADfun1 <- nimbleFunction(

--- a/packages/nimble/tests/testthat/test-ADmodels-bigmv.R
+++ b/packages/nimble/tests/testthat/test-ADmodels-bigmv.R
@@ -15,8 +15,6 @@ relTol[4] <- 1e-4
 
 verbose <- FALSE
 
-context("Testing of derivatives for calculate() for nimbleModel with various mv distributions")
-
 code <- nimbleCode({
     Sigma1[1:n,1:n] <- exp(-dist[1:n,1:n]/rho)
 

--- a/packages/nimble/tests/testthat/test-ADmodels.R
+++ b/packages/nimble/tests/testthat/test-ADmodels.R
@@ -15,7 +15,6 @@ relTol[4] <- 1e-4
 
 verbose <- FALSE
 
-context("Testing of derivatives for calculate() for nimbleModels")
 
 test_that('pow and pow_int work', {  ## 28 sec.
 

--- a/packages/nimble/tests/testthat/test-allocation.R
+++ b/packages/nimble/tests/testthat/test-allocation.R
@@ -7,8 +7,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context('Testing of numeric, integer, logical, matrix and array allocation')
-
 numericTests <- list(
     list(name = 'numeric: length',
          expr = quote(out <- numeric(5)),

--- a/packages/nimble/tests/testthat/test-benchmark-building-steps.R
+++ b/packages/nimble/tests/testthat/test-benchmark-building-steps.R
@@ -9,7 +9,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context('Benchmarking model and MCMC building and compiling steps')
 cat('\n')
 
 timeSteps <- function(code, data = list(), constants = list(), inits = list()) {

--- a/packages/nimble/tests/testthat/test-benchmarks.R
+++ b/packages/nimble/tests/testthat/test-benchmarks.R
@@ -14,7 +14,6 @@ if (nchar(Sys.getenv('CI'))) nimbleOptions(showCompilerOutput = TRUE)
 RwarnLevel <- options('warn')$warn
 options(warn = 1)
 
-context('Benchmarking NIMBLE code')
 cat('\n')
 
 ## Computes number of iterations per second.

--- a/packages/nimble/tests/testthat/test-bnp.R
+++ b/packages/nimble/tests/testthat/test-bnp.R
@@ -9,7 +9,6 @@ nimbleOptions(verbose = TRUE)
 nimbleProgressBarSetting <- nimbleOptions('MCMCprogressBar')
 nimbleOptions(MCMCprogressBar = FALSE)
 
-context('Testing of BNP functionality')
 
 
 

--- a/packages/nimble/tests/testthat/test-car.R
+++ b/packages/nimble/tests/testthat/test-car.R
@@ -1,7 +1,5 @@
 source(system.file(file.path('tests', 'testthat', 'test_utils.R'), package = 'nimble'))
 
-context("Testing of CAR distributions")
-
 RwarnLevel <- options('warn')$warn
 options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')

--- a/packages/nimble/tests/testthat/test-checkDSL.R
+++ b/packages/nimble/tests/testthat/test-checkDSL.R
@@ -5,8 +5,6 @@ source(system.file(file.path('tests', 'testthat', 'test_utils.R'), package = 'ni
 RwarnLevel <- options('warn')$warn
 options(warn = 1)
 
-context('Testing of nimbleFunction (DSL) code checking')
-
 test_that("Test of DSL check of valid RCfunction", expect_silent(
 test1 <- nimbleFunction(
     run = function(x = double(0)) {

--- a/packages/nimble/tests/testthat/test-copy.R
+++ b/packages/nimble/tests/testthat/test-copy.R
@@ -11,8 +11,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context('Testing of nimCopy and values')
-
 
 
 

--- a/packages/nimble/tests/testthat/test-coreR.R
+++ b/packages/nimble/tests/testthat/test-coreR.R
@@ -5,8 +5,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context("Testing of core R functions in NIMBLE code")
-
 ## fix result_type in nimbleEigen.h
 
 cTests <- list(

--- a/packages/nimble/tests/testthat/test-crossVal.R
+++ b/packages/nimble/tests/testthat/test-crossVal.R
@@ -1,7 +1,5 @@
 source(system.file(file.path('tests', 'testthat', 'test_utils.R'), package = 'nimble'))
 
-context("Testing of cross-validation")
-
 ###  BUGS model from Chapter 5 of Gelman and Hill
 ###  Below LOO-CV value from Gelman '13 "Understanding predictive 
 ###  information criteria for Bayesian models"

--- a/packages/nimble/tests/testthat/test-declare.R
+++ b/packages/nimble/tests/testthat/test-declare.R
@@ -5,8 +5,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context("Testing of declare, setSize, numeric, integer, matrix, and array")
-
 ## I. 1D cases
 
 ## I.i 1D declare without sizes, then resize without c()

--- a/packages/nimble/tests/testthat/test-distributions.R
+++ b/packages/nimble/tests/testthat/test-distributions.R
@@ -1,7 +1,6 @@
 ## File for testing distributions provided by NIMBLE
 
 source(system.file(file.path('tests', 'testthat', 'test_utils.R'), package = 'nimble'))
-context('Testing NIMBLE distributions')
 
 RwarnLevel <- options('warn')$warn
 options(warn = 1)

--- a/packages/nimble/tests/testthat/test-dsl_dists.R
+++ b/packages/nimble/tests/testthat/test-dsl_dists.R
@@ -1,7 +1,5 @@
 source(system.file(file.path('tests', 'testthat', 'test_utils.R'), package = 'nimble'))
 
-context("Testing of keyword processing for distribution functions in nimbleFunctions")
-
 test_that("Test that keyword processing for qbeta works", {
     nf <- nimbleFunction(
         run = function(p = double(0)) {

--- a/packages/nimble/tests/testthat/test-dynamicIndexing.R
+++ b/packages/nimble/tests/testthat/test-dynamicIndexing.R
@@ -1,7 +1,5 @@
 source(system.file(file.path('tests', 'testthat', 'test_utils.R'), package = 'nimble'))
 
-context("Testing of dynamic indexing")
-
 RwarnLevel <- options('warn')$warn
 options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')

--- a/packages/nimble/tests/testthat/test-errors.R
+++ b/packages/nimble/tests/testthat/test-errors.R
@@ -5,8 +5,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context("Testing of error handling.")
-
 test_that("Testing of stopping on run-time size errors", {
   # First construct a nimbleFunction.
   current_option <- getNimbleOption("stopOnSizeErrors")

--- a/packages/nimble/tests/testthat/test-expandNodeNames.R
+++ b/packages/nimble/tests/testthat/test-expandNodeNames.R
@@ -5,8 +5,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context("Testing of expandNodeNames")
-
 test_that("expandNodeNames works for various cases, including going beyond extent of variable", {
     
    code <- nimbleCode({

--- a/packages/nimble/tests/testthat/test-getBound.R
+++ b/packages/nimble/tests/testthat/test-getBound.R
@@ -5,8 +5,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context("Testing of getBound")
-
 test_that("building of model with initial value issues in bounds", {
     code <- nimbleCode({
         y1 ~ T(dnorm(mu, sd = sig),b,d)  # non-constant trunc bounds

--- a/packages/nimble/tests/testthat/test-getDependencies.R
+++ b/packages/nimble/tests/testthat/test-getDependencies.R
@@ -5,8 +5,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context("Testing of getDependencies")
-
 ## note this testing is not intended to blur into general model processing testing.
 ## It assumes the model processing is ok and really tests traversal of the graph to get dependencies
 

--- a/packages/nimble/tests/testthat/test-getDistributionInfo.R
+++ b/packages/nimble/tests/testthat/test-getDistributionInfo.R
@@ -7,8 +7,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = TRUE)
 
-context('Testing distributions API')
-
 # tests of distribution functions applied to distribution name
 
 test_that("Test that requesting unknown distribution returns error",

--- a/packages/nimble/tests/testthat/test-getParam.R
+++ b/packages/nimble/tests/testthat/test-getParam.R
@@ -9,8 +9,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context("Testing of getParam")
-
 
 test_getParam(quote(dbern(prob = 0.2)))
 test_getParam(quote(dbin(prob = 0.2, size = 3)))

--- a/packages/nimble/tests/testthat/test-initializeModel.R
+++ b/packages/nimble/tests/testthat/test-initializeModel.R
@@ -5,8 +5,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context("Testing of model initializaion using initializeModel")
-
 
 test_that('initializeModel works', {
     code <- nimbleCode({

--- a/packages/nimble/tests/testthat/test-integrate.R
+++ b/packages/nimble/tests/testthat/test-integrate.R
@@ -5,8 +5,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context("Testing of nimIntegrate() in NIMBLE code")
-
 test_that("Basic use of integrate in an RCfunction calling an RCfunction", {
     integrand <- nimbleFunction(
         run = function(x = double(1), theta = double(1)) {

--- a/packages/nimble/tests/testthat/test-macros.R
+++ b/packages/nimble/tests/testthat/test-macros.R
@@ -8,8 +8,6 @@ nimbleOptions(verbose = FALSE)
 nimbleOptions(enableModelMacros = TRUE)
 nimbleOptions(enableMacroComments = FALSE)
 
-context("Testing model macros")
-
 test_that('Macro expansion 1',
 {
     ## This converts a ~ testMacro(b)

--- a/packages/nimble/tests/testthat/test-math.R
+++ b/packages/nimble/tests/testthat/test-math.R
@@ -9,8 +9,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context("Testing of math functions in NIMBLE code")
-
 source(system.file(file.path('tests', 'testthat', 'mathTestLists.R'), package = 'nimble'))
 
 set.seed(0)

--- a/packages/nimble/tests/testthat/test-mcem.R
+++ b/packages/nimble/tests/testthat/test-mcem.R
@@ -9,8 +9,6 @@ nimbleOptions(verbose = TRUE)
 nimbleProgressBarSetting <- nimbleOptions('MCMCprogressBar')
 nimbleOptions(MCMCprogressBar = FALSE)
 
-context("Testing of MCEM")
-
 goldFileName <- 'mcemTestLog_Correct.Rout'
 tempFileName <- 'mcemTestLog.Rout'
 generatingGoldFile <- !is.null(nimbleOptions('generateGoldFileForMCEMtesting'))

--- a/packages/nimble/tests/testthat/test-mcmc.R
+++ b/packages/nimble/tests/testthat/test-mcmc.R
@@ -1,7 +1,5 @@
 source(system.file(file.path('tests', 'testthat', 'test_utils.R'), package = 'nimble'))
 
-context("Testing of default MCMC")
-
 RwarnLevel <- options('warn')$warn
 options(warn = 1)
 

--- a/packages/nimble/tests/testthat/test-mcmcrj.R
+++ b/packages/nimble/tests/testthat/test-mcmcrj.R
@@ -8,8 +8,6 @@ nimbleOptions(verbose = FALSE)
 nimbleProgressBarSetting <- nimbleOptions('MCMCprogressBar')
 nimbleOptions(MCMCprogressBar = FALSE)
 
-context('Testing of MCMC_RJ functionality')
-
 test_that("Test configureRJ with no indicator variables", {
 
   ## Linear regression with 2 covariates, one in the model

--- a/packages/nimble/tests/testthat/test-misc.R
+++ b/packages/nimble/tests/testthat/test-misc.R
@@ -5,8 +5,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = TRUE)
 
-context("Testing of miscellaneous functionality")
-
 ## Regression test for Issue #563.
 test_that("while() works even when an intermediate variable is needed", {
     mynf = nimbleFunction(

--- a/packages/nimble/tests/testthat/test-modelValuesInterface.R
+++ b/packages/nimble/tests/testthat/test-modelValuesInterface.R
@@ -5,8 +5,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context("Testing of modelValues interfaces")
-
 test_that("copying of argument passing in nimbleFunctionInterface", {
     mvc <- modelValuesConf(vars = c('d1'),
                            types = c('double'),

--- a/packages/nimble/tests/testthat/test-models.R
+++ b/packages/nimble/tests/testthat/test-models.R
@@ -5,8 +5,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = TRUE)
 
-context("Testing of NIMBLE model building and operation")
-
 ## If you do *not* want to write to results files
 ##    comment out the sink() call below.  And consider setting verbose = FALSE 
 ## To record a new gold file, nimbleOptions('generateGoldFileForMCMCtesting') should contain the path to the directory where you want to put it

--- a/packages/nimble/tests/testthat/test-nimbleFunctionInterfaces.R
+++ b/packages/nimble/tests/testthat/test-nimbleFunctionInterfaces.R
@@ -5,8 +5,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context("Testing of nimbleFunction interfaces")
-
 ## goals here:
 ##   passing every kind of argument
 ##   populating every kind of member data upon instantiation

--- a/packages/nimble/tests/testthat/test-nimbleFunctionModelAccess.R
+++ b/packages/nimble/tests/testthat/test-nimbleFunctionModelAccess.R
@@ -1,7 +1,5 @@
 source(system.file(file.path('tests', 'testthat', 'test_utils.R'), package = 'nimble'))
 
-context("Testing how nimbleFunctions use model variables and nodes")
-
 test_that("nimbleFunction use of model variables and nodes works",
 {
     code <- nimbleCode({

--- a/packages/nimble/tests/testthat/test-nimbleList.R
+++ b/packages/nimble/tests/testthat/test-nimbleList.R
@@ -15,8 +15,6 @@ nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
 
-context('Testing nimbleLists')
-
 ########
 ## Test of creating new nimbleList in run code and specifying initial values for that list
 ## Here, the nlDef is created in the global environment, outside of setup code

--- a/packages/nimble/tests/testthat/test-nimbleList_RCfun.R
+++ b/packages/nimble/tests/testthat/test-nimbleList_RCfun.R
@@ -5,8 +5,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context('Testing nimbleLists in RC functions')
-
 ## All necessary nlDefinitions below:
 test_that("nimbleList RCfun Test 1", {
     testListDef1 <- nimbleList(nlScalar = double(0), nlVector = double(1), nlMatrix = double(2))

--- a/packages/nimble/tests/testthat/test-noSMC.R
+++ b/packages/nimble/tests/testthat/test-noSMC.R
@@ -5,8 +5,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context("Testing that SMC functionality throws errors pointing to nimbleSMC.")
-
 test_that("PF MCMCs fail with message", {
     timeModelCode <- nimbleCode({
         x[1] ~ dnorm(mu_0, 1)

--- a/packages/nimble/tests/testthat/test-numericTypes.R
+++ b/packages/nimble/tests/testthat/test-numericTypes.R
@@ -1,5 +1,4 @@
 source(system.file(file.path('tests', 'testthat', 'test_utils.R'), package = 'nimble'))
-context("Testing of numeric type handling and casting")
 
 RwarnLevel <- options('warn')$warn
 ## There are a bunch of NaN warnings we want to ignore.

--- a/packages/nimble/tests/testthat/test-optim.R
+++ b/packages/nimble/tests/testthat/test-optim.R
@@ -5,9 +5,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-
-context("Testing of the optim() function in NIMBLE code")
-
 # The methods "SANN" and "Brent" are not supported.
 methodsAllowingGradient <- c("Nelder-Mead", "BFGS", "CG", "L-BFGS-B")
 methodsAllowingBounds <- c("L-BFGS-B")

--- a/packages/nimble/tests/testthat/test-options.R
+++ b/packages/nimble/tests/testthat/test-options.R
@@ -5,8 +5,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context("Testing of nimble options")
-
 test_that('withNimbleOptions works for zero options', {
     expected <- 'foo'
     actual <- withNimbleOptions(list(), 'foo')

--- a/packages/nimble/tests/testthat/test-parameterTransform.R
+++ b/packages/nimble/tests/testthat/test-parameterTransform.R
@@ -5,8 +5,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
-context('Testing of parameterTransform nimbleFunction')
-
 
 ##
 ## parameterTransform testing code below

--- a/packages/nimble/tests/testthat/test-returnTypeErrorTrapping.R
+++ b/packages/nimble/tests/testthat/test-returnTypeErrorTrapping.R
@@ -1,5 +1,4 @@
 source(system.file(file.path('tests', 'testthat', 'test_utils.R'), package = 'nimble'))
-context('Testing return() type error trapping')
 
 RwarnLevel <- options('warn')$warn
 options(warn = 1)

--- a/packages/nimble/tests/testthat/test-setData.R
+++ b/packages/nimble/tests/testthat/test-setData.R
@@ -5,8 +5,6 @@ options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = TRUE)
 
-context("Testing setData")
-
 model <- nimbleModel(
     nimbleCode({
         for(i in 1:5) {

--- a/packages/nimble/tests/testthat/test-size.R
+++ b/packages/nimble/tests/testthat/test-size.R
@@ -14,8 +14,6 @@ nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = FALSE)
 
 
-context("Testing of size/dimension checks in NIMBLE code")
-
 goldFileName <- 'sizeTestLog_Correct.Rout'
 tempFileName <- 'sizeTestLog.Rout'
 generatingGoldFile <- !is.null(nimbleOptions('generateGoldFileForSizeTesting'))

--- a/packages/nimble/tests/testthat/test-testTools.R
+++ b/packages/nimble/tests/testthat/test-testTools.R
@@ -4,8 +4,6 @@ RwarnLevel <- options('warn')$warn
 options(warn = 1)
 
 
-context("Testing of testing tools")
-
 ## new way to force anything compiled to be clear-compiled
 ## (note, no check for windows is done [yet?])
 test_that('testing withTempProject',

--- a/packages/nimble/tests/testthat/test-trunc.R
+++ b/packages/nimble/tests/testthat/test-trunc.R
@@ -1,7 +1,5 @@
 source(system.file(file.path('tests', 'testthat', 'test_utils.R'), package = 'nimble'))
 
-context("Testing of truncation, censoring, and constraints")
-
 RwarnLevel <- options('warn')$warn
 options(warn = 1)
 nimbleVerboseSetting <- nimbleOptions('verbose')

--- a/packages/nimble/tests/testthat/test-user.R
+++ b/packages/nimble/tests/testthat/test-user.R
@@ -1,7 +1,5 @@
 source(system.file(file.path('tests', 'testthat', 'test_utils.R'), package = 'nimble'))
 
-context("Testing of user-supplied distributions and functions in BUGS code")
-
 nimbleVerboseSetting <- nimbleOptions('verbose')
 nimbleOptions(verbose = TRUE)
 

--- a/packages/nimble/tests/testthat/test-waic.R
+++ b/packages/nimble/tests/testthat/test-waic.R
@@ -5,8 +5,6 @@ nimbleOptions(verbose = FALSE)
 nimbleProgressBarSetting <- nimbleOptions('MCMCprogressBar')
 nimbleOptions(MCMCprogressBar = FALSE)
 
-context("Testing of WAIC")
-
 ###  BUGS models from Chapter 5 of Gelman and Hill
 ###  Below WAIC values from Gelman '13 "Understanding predictive 
 ###  information criteria for Bayesian models"


### PR DESCRIPTION
testthat::context() has been deprecated for quite a while, so this PR removes uses of it in tests/testthat.