### PR TITLE
WIP: remove virtualNodeFunctionDefinitions

### DIFF
--- a/packages/nimble/R/distributions_processInputList.R
+++ b/packages/nimble/R/distributions_processInputList.R
@@ -563,9 +563,6 @@ registerDistributions <- function(distributionsInput, userEnv = parent.frame(), 
             nimbleUserNamespace$distributions$add(distributionsInput)
         } else 
             nimbleUserNamespace$distributions <- distributionsClass(distributionsInput)
-        virtualNodeFunctionDefinitions <- ndf_createVirtualNodeFunctionDefinitionsList(userAdded = TRUE)
-        createNamedObjectsFromList(virtualNodeFunctionDefinitions, envir = .GlobalEnv)
-
     # note don't use rFunHandler as rUserDist nimbleFunction needs n as first arg so it works on R side, therefore we have n in the C version of the nimbleFunction and don't want to strip it out in Cpp generation
       }
     invisible(NULL)

--- a/packages/nimble/R/genCpp_processSpecificCalls.R
+++ b/packages/nimble/R/genCpp_processSpecificCalls.R
@@ -13,7 +13,6 @@ specificCallReplacements <- list(
     length = 'size',
     is.nan = 'nimIsNaN',
     any_nan = 'nimAnyNaN',
-    is.nan.vec = "nimAnyNaN", ## retained for backward compatibility use in nimbleHMC
     is.na = 'nimIsNA',
     any_na = 'nimAnyNA',
     lgamma = 'lgammafn',

--- a/packages/nimble/R/nimbleFunction_Rexecution.R
+++ b/packages/nimble/R/nimbleFunction_Rexecution.R
@@ -1207,15 +1207,17 @@ declare <- function(name, def){
 #' @export
 any_na <- function(x) any(is.na(x))
 
-## Retained for backwards compatibility
-is.na.vec <- function(x) any(is.na(x))
+## Deprecated as of v. 1.1.0
+is.na.vec <- function(x)
+    stop("`is.na.vec` has been removed from NIMBLE; please use `any_na`")
 
 #' @rdname any_na
 #' @export
 any_nan <- function(x) any(is.nan(x))
 
-## Retained for backwards compatibility
-is.nan.vec <- function(x) any(is.nan(x))
+## Deprecated as of v. 1.1.0
+is.nan.vec <- function(x)
+    stop("`is.nan.vec` has been removed from NIMBLE; please use `any_nan`")
 
 #' @export
 nimRound <- round


### PR DESCRIPTION
This investigates NCT issue 500 in which we're discussing whether the virtual nodeFunction definitions in the user global environment (for user-defined functions) and in the nimble namespace (for nimble's distribution functions) are needed.

This passes `test-user.R` when run manually. I am opening this PR to run full tests.