### PR TITLE
remove template arguments from NimArr constructors and destructors for C++20

### DIFF
--- a/packages/nimble/inst/include/nimble/NimArr.h
+++ b/packages/nimble/inst/include/nimble/NimArr.h
@@ -119,7 +119,7 @@ class NimArr<1, T> : public NimArrBase<T> {
     return (*NimArrBase<T>::vPtr)[calculateIndex(i)];
   }
 
-  ~NimArr<1, T>() {}
+  ~NimArr() {}
 
   template <class Tother>
   NimArr<1, T> &mapCopy(const NimArr<1, Tother> &other) {
@@ -217,7 +217,7 @@ class NimArr<1, T> : public NimArrBase<T> {
     return (*this);
   }
 
-  NimArr<1, T>(const NimArr<1, T> &other) : NimArrBase<T>(other) {
+  NimArr(const NimArr<1, T> &other) : NimArrBase<T>(other) {
     NimArrBase<T>::NAdims[0] = other.dim()[0]; // redundant with base class copy constructor?
     size1 = NimArrBase<T>::NAdims[0];
 
@@ -243,7 +243,7 @@ class NimArr<1, T> : public NimArrBase<T> {
     NimArrBase<T>::setVptr();
   }
 
-  NimArr<1, T>() : NimArrBase<T>() { setSize(0); }
+  NimArr() : NimArrBase<T>() { setSize(0); }
 
   void setMap(NimArrBase<T> &source, int off, int str1, int is1) {
     if (NimArrBase<T>::own_v) nimble_free(NimArrBase<T>::v);
@@ -280,13 +280,13 @@ class NimArr<1, T> : public NimArrBase<T> {
     mapTo.mapCopy(mapFrom);
   }
 
-  NimArr<1, T>(vector<T> &vm, int off, int str1, int is1)
+  NimArr(vector<T> &vm, int off, int str1, int is1)
       : NimArrBase<T>(vm, off) {
     NimArrBase<T>::NAdims[0] = NimArrBase<T>::NAlength = size1 = is1;
     NimArrBase<T>::NAstrides[0] = NimArrBase<T>::stride1 = str1;
   }
 
-  NimArr<1, T>(int is1) : NimArrBase<T>() { setSize(is1); }
+  NimArr(int is1) : NimArrBase<T>() { setSize(is1); }
 
   void initialize(T value, bool init, int is1) {
     setSize(is1, false, false);
@@ -352,7 +352,7 @@ class NimArr<2, T> : public NimArrBase<T> {
     return (*NimArrBase<T>::vPtr)[calculateIndex(divRes.rem, divRes.quot)];
   }
 
-  ~NimArr<2, T>() {}
+  ~NimArr() {}
 
   template <class Tother>
   NimArr<2, T> &mapCopy(const NimArr<2, Tother> &other) {
@@ -427,7 +427,7 @@ class NimArr<2, T> : public NimArrBase<T> {
     return *this;
   }
 
-  NimArr<2, T>(const NimArr<2, T> &other) : NimArrBase<T>(other) {
+  NimArr(const NimArr<2, T> &other) : NimArrBase<T>(other) {
     std::memcpy(NimArrBase<T>::NAdims, other.dim(), 2 * sizeof(int));
 
     size1 = NimArrBase<T>::NAdims[0];
@@ -459,7 +459,7 @@ class NimArr<2, T> : public NimArrBase<T> {
     NimArrBase<T>::setVptr();
   }
 
-  NimArr<2, T>() : NimArrBase<T>() { setSize(0, 0); }
+  NimArr() : NimArrBase<T>() { setSize(0, 0); }
 
   void setMap(NimArrBase<T> &source, int off, int str1, int str2, int is1,
               int is2) {
@@ -503,7 +503,7 @@ class NimArr<2, T> : public NimArrBase<T> {
     mapTo.mapCopy(mapFrom);
   }
 
-  NimArr<2, T>(vector<T> &vm, int off, int str1, int str2, int is1, int is2)
+  NimArr(vector<T> &vm, int off, int str1, int str2, int is1, int is2)
       : NimArrBase<T>(vm, off) {
     NimArrBase<T>::NAdims[0] = size1 = is1;
     NimArrBase<T>::NAdims[1] = size2 = is2;
@@ -513,7 +513,7 @@ class NimArr<2, T> : public NimArrBase<T> {
     NimArrBase<T>::NAstrides[1] = stride2 = str2;
   }
 
-  NimArr<2, T>(int is1, int is2) : NimArrBase<T>() { setSize(is1, is2); }
+  NimArr(int is1, int is2) : NimArrBase<T>() { setSize(is1, is2); }
 
   void initialize(T value, bool init, int is1, int is2) {
     setSize(is1, is2, false, false);
@@ -583,7 +583,7 @@ class NimArr<3, T> : public NimArrBase<T> {
                                                  divRes2.quot)];
   }
 
-  ~NimArr<3, T>() {}
+  ~NimArr() {}
 
   template <class Tother>
   NimArr<3, T> &mapCopy(const NimArr<3, Tother> &other) {
@@ -672,7 +672,7 @@ class NimArr<3, T> : public NimArrBase<T> {
     return *this;
   }
 
-  NimArr<3, T>(const NimArr<3, T> &other) : NimArrBase<T>(other) {
+  NimArr(const NimArr<3, T> &other) : NimArrBase<T>(other) {
     std::memcpy(NimArrBase<T>::NAdims, other.dim(), 3 * sizeof(int));
     size1 = NimArrBase<T>::NAdims[0];
     size2 = NimArrBase<T>::NAdims[1];
@@ -709,7 +709,7 @@ class NimArr<3, T> : public NimArrBase<T> {
     NimArrBase<T>::setVptr();
   }
 
-  NimArr<3, T>() : NimArrBase<T>() { setSize(0, 0, 0); }
+  NimArr() : NimArrBase<T>() { setSize(0, 0, 0); }
 
   void setMap(NimArrBase<T> &source, int off, int str1, int str2, int str3,
               int is1, int is2, int is3) {
@@ -758,7 +758,7 @@ class NimArr<3, T> : public NimArrBase<T> {
     mapTo.mapCopy(mapFrom);
   }
 
-  NimArr<3, T>(vector<T> &vm, int off, int str1, int str2, int str3, int is1,
+  NimArr(vector<T> &vm, int off, int str1, int str2, int str3, int is1,
                int is2, int is3)
       : NimArrBase<T>(vm, off) {
     NimArrBase<T>::NAdims[0] = size1 = is1;
@@ -772,7 +772,7 @@ class NimArr<3, T> : public NimArrBase<T> {
     NimArrBase<T>::NAlength = size1 * size2 * size3;
   }
 
-  NimArr<3, T>(int is1, int is2, int is3) : NimArrBase<T>() {
+  NimArr(int is1, int is2, int is3) : NimArrBase<T>() {
     setSize(is1, is2, is3);
   }
 
@@ -851,7 +851,7 @@ class NimArr<4, T> : public NimArrBase<T> {
                                                  divRes3.rem, divRes3.quot)];
   }
 
-  ~NimArr<4, T>() {}
+  ~NimArr() {}
 
   template <class Tother>
   NimArr<4, T> &mapCopy(const NimArr<4, Tother> &other) {
@@ -955,7 +955,7 @@ class NimArr<4, T> : public NimArrBase<T> {
     return *this;
   }
 
-  NimArr<4, T>(const NimArr<4, T> &other) : NimArrBase<T>(other) {
+  NimArr(const NimArr<4, T> &other) : NimArrBase<T>(other) {
     std::memcpy(NimArrBase<T>::NAdims, other.dim(), 4 * sizeof(int));
     size1 = NimArrBase<T>::NAdims[0];
     size2 = NimArrBase<T>::NAdims[1];
@@ -999,7 +999,7 @@ class NimArr<4, T> : public NimArrBase<T> {
     NimArrBase<T>::setVptr();
   }
 
-  NimArr<4, T>() : NimArrBase<T>() { setSize(0, 0, 0, 0); }
+  NimArr() : NimArrBase<T>() { setSize(0, 0, 0, 0); }
 
   void setMap(NimArrBase<T> &source, int off, int str1, int str2, int str3,
               int str4, int is1, int is2, int is3, int is4) {
@@ -1053,7 +1053,7 @@ class NimArr<4, T> : public NimArrBase<T> {
     mapTo.mapCopy(mapFrom);
   }
 
-  NimArr<4, T>(vector<T> &vm, int off, int str1, int str2, int str3, int str4,
+  NimArr(vector<T> &vm, int off, int str1, int str2, int str3, int str4,
                int is1, int is2, int is3, int is4)
       : NimArrBase<T>(vm, off) {
     NimArrBase<T>::NAdims[0] = size1 = is1;
@@ -1069,7 +1069,7 @@ class NimArr<4, T> : public NimArrBase<T> {
     NimArrBase<T>::NAlength = size1 * size2 * size3 * size4;
   }
 
-  NimArr<4, T>(int is1, int is2, int is3, int is4) : NimArrBase<T>() {
+  NimArr(int is1, int is2, int is3, int is4) : NimArrBase<T>() {
     setSize(is1, is2, is3, is4);
   }
 
@@ -1157,7 +1157,7 @@ class NimArr<5, T> : public NimArrBase<T> {
 						 divRes4.quot)];
   }
 
-  ~NimArr<5, T>() {}
+  ~NimArr() {}
 
   template <class Tother>
   NimArr<5, T> &mapCopy(const NimArr<5, Tother> &other) {
@@ -1276,7 +1276,7 @@ class NimArr<5, T> : public NimArrBase<T> {
     return *this;
   }
 
-  NimArr<5, T>(const NimArr<5, T> &other) : NimArrBase<T>(other) {
+  NimArr(const NimArr<5, T> &other) : NimArrBase<T>(other) {
     std::memcpy(NimArrBase<T>::NAdims, other.dim(), 5 * sizeof(int));
     size1 = NimArrBase<T>::NAdims[0];
     size2 = NimArrBase<T>::NAdims[1];
@@ -1326,7 +1326,7 @@ class NimArr<5, T> : public NimArrBase<T> {
     NimArrBase<T>::setVptr();
   }
 
-  NimArr<5, T>() : NimArrBase<T>() { setSize(0, 0, 0, 0, 0); }
+  NimArr() : NimArrBase<T>() { setSize(0, 0, 0, 0, 0); }
 
   void setMap(NimArrBase<T> &source, int off, int str1, int str2, int str3,
               int str4, int str5, int is1, int is2, int is3, int is4, int is5) {
@@ -1384,7 +1384,7 @@ class NimArr<5, T> : public NimArrBase<T> {
     mapTo.mapCopy(mapFrom);
   }
 
-  NimArr<5, T>(vector<T> &vm, int off, int str1, int str2, int str3, int str4, int str5,
+  NimArr(vector<T> &vm, int off, int str1, int str2, int str3, int str4, int str5,
                int is1, int is2, int is3, int is4, int is5)
       : NimArrBase<T>(vm, off) {
     NimArrBase<T>::NAdims[0] = size1 = is1;
@@ -1402,7 +1402,7 @@ class NimArr<5, T> : public NimArrBase<T> {
     NimArrBase<T>::NAlength = size1 * size2 * size3 * size4 * size5;
   }
 
-  NimArr<5, T>(int is1, int is2, int is3, int is4, int is5) : NimArrBase<T>() {
+  NimArr(int is1, int is2, int is3, int is4, int is5) : NimArrBase<T>() {
     setSize(is1, is2, is3, is4, is5);
   }
 
@@ -1498,7 +1498,7 @@ class NimArr<6, T> : public NimArrBase<T> {
 						 divRes5.rem, divRes5.quot)];
   }
 
-  ~NimArr<6, T>() {}
+  ~NimArr() {}
 
   template <class Tother>
   NimArr<6, T> &mapCopy(const NimArr<6, Tother> &other) {
@@ -1632,7 +1632,7 @@ class NimArr<6, T> : public NimArrBase<T> {
     return *this;
   }
 
-  NimArr<6, T>(const NimArr<6, T> &other) : NimArrBase<T>(other) {
+  NimArr(const NimArr<6, T> &other) : NimArrBase<T>(other) {
     std::memcpy(NimArrBase<T>::NAdims, other.dim(), 6 * sizeof(int));
     size1 = NimArrBase<T>::NAdims[0];
     size2 = NimArrBase<T>::NAdims[1];
@@ -1688,7 +1688,7 @@ class NimArr<6, T> : public NimArrBase<T> {
     NimArrBase<T>::setVptr();
   }
 
-  NimArr<6, T>() : NimArrBase<T>() { setSize(0, 0, 0, 0, 0, 0); }
+  NimArr() : NimArrBase<T>() { setSize(0, 0, 0, 0, 0, 0); }
 
   void setMap(NimArrBase<T> &source, int off,
 	      int str1, int str2, int str3, int str4, int str5, int str6,
@@ -1751,7 +1751,7 @@ class NimArr<6, T> : public NimArrBase<T> {
     mapTo.mapCopy(mapFrom);
   }
 
-  NimArr<6, T>(vector<T> &vm, int off,
+  NimArr(vector<T> &vm, int off,
 	       int str1, int str2, int str3, int str4, int str5, int str6,
                int is1, int is2, int is3, int is4, int is5, int is6)
       : NimArrBase<T>(vm, off) {
@@ -1772,7 +1772,7 @@ class NimArr<6, T> : public NimArrBase<T> {
     NimArrBase<T>::NAlength = size1 * size2 * size3 * size4 * size5 * size6;
   }
 
-  NimArr<6, T>(int is1, int is2, int is3, int is4, int is5, int is6) : NimArrBase<T>() {
+  NimArr(int is1, int is2, int is3, int is4, int is5, int is6) : NimArrBase<T>() {
     setSize(is1, is2, is3, is4, is5, is6);
   }
 
@@ -1853,7 +1853,7 @@ class NimArr<6, T> : public NimArrBase<T> {
 template <int ndim, class T>
 class VecNimArr : public VecNimArrBase<T> {
  public:
-  ~VecNimArr<ndim, T>() {}
+  ~VecNimArr() {}
   std::vector<NimArr<ndim, T> > values;
   NimArr<ndim, T> &operator[](unsigned int i) {
     if (i >= values.size()) {


### PR DESCRIPTION
This attempts to fix the recent new CRAN R-devel warnings on fedora-gcc.

@paciorek Do you have a way to test whether this resolves the CRAN testing warnings on that platform?
