### PR TITLE
fix uncompiled use of updateSettings in Laplace or AGHQ

### DIFF
--- a/packages/nimble/R/Laplace.R
+++ b/packages/nimble/R/Laplace.R
@@ -314,6 +314,8 @@ buildOneAGHQuad1D <- nimbleFunction(
           }
         }
       }
+      if((!one_time_fixes_done) & (length(constant_init_par) == 1))
+         constant_init_par <<- c(constant_init_par, -1)
       if(optimWarning != -1) {
         warn_optim <<- optimWarning != 0
       }
@@ -1132,6 +1134,8 @@ buildOneAGHQuad <- nimbleFunction(
           }
         }
       }
+      if((!one_time_fixes_done) & (length(constant_init_par) == 1))
+         constant_init_par <<- c(constant_init_par, -1)
       if(optimWarning != -1) {
         warn_optim <<- optimWarning != 0
       }


### PR DESCRIPTION
A minor bug in buildAGHQ came to my attention. If `updateSettings` method is used *prior to compilation* with inputs that change `constant_init_par`, it can break the `one_time_fixes` system by omitting the trailing -1 needed to confirm it is a vector for compilation. This PR fixes that. I have not added a test that triggers the bug and shows it is fixed by this PR. First I am putting this up to run current tests and can add a new test later.