### PR TITLE
address some minor issues with dataframes passed as inits and 3d getParam warning

### DIFF
--- a/UserManual/src/chapter_AD.Rmd
+++ b/UserManual/src/chapter_AD.Rmd
@@ -191,6 +191,8 @@ toyModel <- nimbleModel(toyCode, inits = list(mu = 0, sigma = 1, x = 0),
 
 Now `toyModel` can be used in algorithms such as HMC and Laplace approximation, as above, or new ones you might write, as below.
 
+Note that in models, all model variables are implemented as doubles, even when they will actually only ever take integer values. Therefore all arguments to user-defined distributions and functions used in models should be declared as type `double`. The `ADbreak` method discussed in Section \@ref(sec:AD-holding-out) should be used if you want to stop derivative tracking on a model variable.
+
 ## What operations are and aren't supported for AD
 
 Much of the math supported by NIMBLE will work for AD. Here are some details on what is and isn't supported, as well as on some options to control how linear algebra is handled.

--- a/packages/nimble/DESCRIPTION
+++ b/packages/nimble/DESCRIPTION
@@ -15,7 +15,7 @@ Description: A system for writing hierarchical statistical models largely
     one can use 'NIMBLE' for writing arbitrary other kinds of model-generic
     algorithms as well. A full User Manual is available at <https://r-nimble.org>.
 Version: 1.2.1
-Date: 2024-06-10
+Date: 2024-07-31
 Maintainer: Christopher Paciorek <paciorek@stat.berkeley.edu>
 Authors@R: c(
     person("Perry", "de Valpine", role = "aut"),

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -341,7 +341,7 @@ modelDefClass$methods(assignDimensions = function(dimensions, initsList, dataLis
 
     ## update added Dec 2023, DT ... tbt earlier update in newModel method (Oct 2015)
     ## handling for JAGS style inits (a list of lists)
-    if(length(initsList) > 0 && is.list(initsList[[1]]))   initsList <- initsList[[1]]
+    if(length(initsList) > 0 && is.list(initsList[[1]]) && !is.data.frame(initsList[[1]]))   initsList <- initsList[[1]]
     ##
     # add dimensions of any *non-scalar* inits to dimensionsList
     # we'll try to be smart about this: check for duplicate names in inits and dimensions, and make sure they agree
@@ -2908,7 +2908,7 @@ modelDefClass$methods(newModel = function(data = list(), inits = list(), where =
 
     ## handling for JAGS style inits (a list of lists)
     ## added Oct 2015, DT
-    if(length(inits) > 0 && is.list(inits[[1]])) {
+    if(length(inits) > 0 && is.list(inits[[1]]) && !is.data.frame(inits[[1]])) {
         message('  [Note] Detected JAGS-style initial values, provided as a list of lists. Using the first set of initial values')
         inits <- inits[[1]]
     }

--- a/packages/nimble/R/MCMC_WAIC.R
+++ b/packages/nimble/R/MCMC_WAIC.R
@@ -383,6 +383,10 @@ buildWAIC <- nimbleFunction(
 #' Important: The necessary variables to compute WAIC (all stochastic parent
 #' nodes of the data nodes) must have been monitored when setting up the MCMC.
 #'
+#' Also note that while the \code{model} argument can be either a compiled or
+#' uncompiled model, the model must have been compiled prior to calling
+#' \code{calculateWAIC}.
+#'
 #' See \code{help(waic)} for details on using NIMBLE's recommended online
 #' algorithm for WAIC.
 #' 

--- a/packages/nimble/R/externalCalls.R
+++ b/packages/nimble/R/externalCalls.R
@@ -20,6 +20,8 @@
 #' Note that a \code{nimbleExternalCall} can only be executed in a compiled \code{nimbleFunction}, not an uncompiled one.
 #' 
 #' If you have problems with spaces in file paths (e.g. for \code{oFile}), try compiling everything locally by including \code{dirName = "."} as an argument to \code{compileNimble}.
+#'
+#' Note that if you use \code{Rcpp} to generate object files, NIMBLE's use of the \code{--preclean} option to \code{R CMD SHLIB} can cause failures, so you may need to run \code{nimbleOptions(precleanCompilation=FALSE)} to prevent removal of needed object files.
 #' 
 #' @return A \code{nimbleFunction} that takes the indicated input arguments, calls \code{Cfun}, and returns the result.
 #'

--- a/packages/nimble/R/nimbleFunction_Rexecution.R
+++ b/packages/nimble/R/nimbleFunction_Rexecution.R
@@ -270,6 +270,8 @@ defaultParamInfo <- function() {
 #'
 #' @param nodeFunctionIndex For internal NIMBLE use only
 #'
+#' @param warn For internal NIMBLE use only
+#'
 #' @export
 #' @details
 #' Standard usage is as a method of a model, in the form \code{model$getParam(node, param)}, but the usage as a simple function with the model as the first argument as above is also allowed.
@@ -283,7 +285,7 @@ defaultParamInfo <- function() {
 #' parameter known to the distribution.  For example, one can request
 #' the scale or rate parameter of a gamma distribution, regardless of
 #' which one was used to declare the node.
-getParam <- function(model, node, param, nodeFunctionIndex) {
+getParam <- function(model, node, param, nodeFunctionIndex, warn = TRUE) {
     if(missing(param)) { ## already converted by keyword conversion
         stop('Missing either the node or the parameter. Please specify both the node and the parameter of interest. This error may also be triggered if this case of getParam (after keyword replacement) has not been updated for R execution with newNodeFunction system')
         ## nodeFunctionIndex would only be used here, when we make this part work
@@ -311,7 +313,8 @@ getParam <- function(model, node, param, nodeFunctionIndex) {
     type <- paramInfo$type
     unrolledIndicesMatrixRow <- model$modelDef$declInfo[[declID]]$unrolledIndicesMatrix[ indexingInfo$unrolledIndicesMatrixRows[1], ]
     if(nDim > 2) {
-        warning("Note that getParam is not available for parameters of dimension greater than two, but other calculations with models are unaffected")
+        if(warn)
+            messageIfVerbose("  [Warning] `getParam` is not available for parameters of dimension greater than two, but other calculations with models are unaffected.")
         return(NULL)
     }
     funName <- paste0('getParam_',nDim,'D_',type)

--- a/packages/nimble/R/types_util.R
+++ b/packages/nimble/R/types_util.R
@@ -239,6 +239,8 @@ as.list.CmodelValues <- function(x, varNames, iterationAsLastIndex = FALSE, ...)
   results <- list()
   for(v in varNames) {
     samples <- x[[v]]
+    if(!is.list(samples))  # 1-row result (issue #1476)
+        samples <- list(samples)
     dims <- dimOrLength(samples[[1]])
     matrixVersion <- do.call("c", lapply(samples, as.numeric))
     ansDims <- c(dims, nrows)


### PR DESCRIPTION
Fixes issue #1470 by adding an arg to `getParam` that allows one to turn off the warning when `getParam` used on >2d argument.

Fixes issue #1472 by not deciding that `inits` is a list of lists if the first element is a dataframe. Also converts dataframes in inits list to matrices with a note to the user.