### PR TITLE
update import of igraph to only import functions used

### DIFF
--- a/UserManual/src/chapter_AD.Rmd
+++ b/UserManual/src/chapter_AD.Rmd
@@ -191,6 +191,8 @@ toyModel <- nimbleModel(toyCode, inits = list(mu = 0, sigma = 1, x = 0),
 
 Now `toyModel` can be used in algorithms such as HMC and Laplace approximation, as above, or new ones you might write, as below.
 
+Note that in models, all model variables are implemented as doubles, even when they will actually only ever take integer values. Therefore all arguments to user-defined distributions and functions used in models should be declared as type `double`. The `ADbreak` method discussed in Section \@ref(sec:AD-holding-out) should be used if you want to stop derivative tracking on a model variable.
+
 ## What operations are and aren't supported for AD
 
 Much of the math supported by NIMBLE will work for AD. Here are some details on what is and isn't supported, as well as on some options to control how linear algebra is handled.

--- a/packages/nimble/DESCRIPTION
+++ b/packages/nimble/DESCRIPTION
@@ -15,7 +15,7 @@ Description: A system for writing hierarchical statistical models largely
     one can use 'NIMBLE' for writing arbitrary other kinds of model-generic
     algorithms as well. A full User Manual is available at <https://r-nimble.org>.
 Version: 1.2.1
-Date: 2024-06-10
+Date: 2024-07-31
 Maintainer: Christopher Paciorek <paciorek@stat.berkeley.edu>
 Authors@R: c(
     person("Perry", "de Valpine", role = "aut"),

--- a/packages/nimble/NAMESPACE
+++ b/packages/nimble/NAMESPACE
@@ -1,5 +1,5 @@
 import(methods)
-importFrom(igraph, plot.igraph, make_empty_graph, add_vertices, add_edges, top_sort, permute)
+importFrom(igraph, plot.igraph, make_empty_graph, add_vertices, add_edges, topo_sort, permute)
 importFrom(coda, effectiveSize, as.mcmc, as.mcmc.list)
 importFrom(R6, R6Class)
 importFrom(grDevices, dev.off, jpeg)

--- a/packages/nimble/NAMESPACE
+++ b/packages/nimble/NAMESPACE
@@ -1,5 +1,5 @@
 import(methods)
-import(igraph)
+importFrom(igraph, plot.igraph, make_empty_graph, add_vertices, add_edges, top_sort, permute)
 importFrom(coda, effectiveSize, as.mcmc, as.mcmc.list)
 importFrom(R6, R6Class)
 importFrom(grDevices, dev.off, jpeg)

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -2382,7 +2382,7 @@ modelDefClass$methods(genExpandedNodeAndParentNames3 = function(debug = FALSE) {
     
     ## 10. Build the graph for topological sorting
 #    if(debug) browser()
-    graph <<- make_empty_graph()
+    graph <<- igraph::make_empty_graph()
     graph <<- igraph::add_vertices(graph, length(allVertexNames), name = allVertexNames) ## add all vertices at once
     allEdges <- as.numeric(t(cbind(edgesFrom, edgesTo)))
     graph <<- igraph::add_edges(graph, allEdges)                                         ## add all edges at once

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -2382,16 +2382,16 @@ modelDefClass$methods(genExpandedNodeAndParentNames3 = function(debug = FALSE) {
     
     ## 10. Build the graph for topological sorting
 #    if(debug) browser()
-    graph <<- graph.empty()
-    graph <<- add_vertices(graph, length(allVertexNames), name = allVertexNames) ## add all vertices at once
+    graph <<- make_empty_graph()
+    graph <<- igraph::add_vertices(graph, length(allVertexNames), name = allVertexNames) ## add all vertices at once
     allEdges <- as.numeric(t(cbind(edgesFrom, edgesTo)))
-    graph <<- add_edges(graph, allEdges)                                         ## add all edges at once
+    graph <<- igraph::add_edges(graph, allEdges)                                         ## add all edges at once
 
     ## 11. Topologically sort and re-index all objects with vertex IDs
 #    if(debug) browser()
-    newGraphID_2_oldGraphID <- as.numeric(topo_sort(graph, mode = 'out'))
+    newGraphID_2_oldGraphID <- as.numeric(igraph::topo_sort(graph, mode = 'out'))
     oldGraphID_2_newGraphID <- sort(newGraphID_2_oldGraphID, index = TRUE)$ix
-    graph <<- permute(graph, oldGraphID_2_newGraphID)  # re-label vertices in the graph
+    graph <<- igraph::permute(graph, oldGraphID_2_newGraphID)  # re-label vertices in the graph
 
     ## 11b. make new maps that use the sorted IDS
 #    if(debug) browser()

--- a/packages/nimble/R/MCMC_WAIC.R
+++ b/packages/nimble/R/MCMC_WAIC.R
@@ -383,6 +383,10 @@ buildWAIC <- nimbleFunction(
 #' Important: The necessary variables to compute WAIC (all stochastic parent
 #' nodes of the data nodes) must have been monitored when setting up the MCMC.
 #'
+#' Also note that while the \code{model} argument can be either a compiled or
+#' uncompiled model, the model must have been compiled prior to calling
+#' \code{calculateWAIC}.
+#'
 #' See \code{help(waic)} for details on using NIMBLE's recommended online
 #' algorithm for WAIC.
 #' 

--- a/packages/nimble/R/types_util.R
+++ b/packages/nimble/R/types_util.R
@@ -239,6 +239,8 @@ as.list.CmodelValues <- function(x, varNames, iterationAsLastIndex = FALSE, ...)
   results <- list()
   for(v in varNames) {
     samples <- x[[v]]
+    if(!is.list(samples))  # 1-row result (issue #1476)
+        samples <- list(samples)
     dims <- dimOrLength(samples[[1]])
     matrixVersion <- do.call("c", lapply(samples, as.numeric))
     ansDims <- c(dims, nrows)

--- a/packages/prep_pkg.R
+++ b/packages/prep_pkg.R
@@ -155,6 +155,7 @@ imports <- c("methods", "igraph")
 imports <- paste("import(", imports, ")", sep = '', collapse = "\n")
 
 importFroms <- c("coda, effectiveSize, as.mcmc, as.mcmc.list",
+                 "igraph, plot.igraph, make_empty_graph, add_vertices, add_edges, top_sort, permute", 
                  "R6, R6Class",
                  "grDevices, dev.off, jpeg",
                  "graphics, lines, plot, text",

--- a/packages/prep_pkg.R
+++ b/packages/prep_pkg.R
@@ -155,7 +155,7 @@ imports <- c("methods", "igraph")
 imports <- paste("import(", imports, ")", sep = '', collapse = "\n")
 
 importFroms <- c("coda, effectiveSize, as.mcmc, as.mcmc.list",
-                 "igraph, plot.igraph, make_empty_graph, add_vertices, add_edges, top_sort, permute", 
+                 "igraph, plot.igraph, make_empty_graph, add_vertices, add_edges, topo_sort, permute", 
                  "R6, R6Class",
                  "grDevices, dev.off, jpeg",
                  "graphics, lines, plot, text",


### PR DESCRIPTION
This is better practice and should reduce name collisions such as #1469 