### PR TITLE
runMCMC no longer supports a single numeric value for setSeed argument

### DIFF
--- a/packages/nimble/R/MCMC_run.R
+++ b/packages/nimble/R/MCMC_run.R
@@ -18,7 +18,7 @@
 #'
 #' @param inits Optional argument to specify initial values for each chain.  See details.
 #'
-#' @param setSeed Logical or numeric argument.  If a numeric vector of length \code{nchains} is provided, then each element of this vector is provided as R's random number seed at the onset of the corresponding MCMC chain.  Otherwise, in the case of a logical value, if \code{TRUE}, then R's random number seed for the ith chain is set to be \code{i}, at the onset of each MCMC chain, and if \code{FALSE}, the random number seed is never set or modified.  The case of providing a single numeric value for this argument is not supported, except in the case when \code{nchains = 1}.  Default value is \code{FALSE}.
+#' @param setSeed Logical or numeric argument.  If a numeric vector of length \code{nchains} is provided, then each element of this vector is provided as R's random number seed at the onset of the corresponding MCMC chain.  Otherwise, in the case of a logical value, if \code{TRUE}, then R's random number seed for the ith chain is set to be \code{i}, at the onset of each MCMC chain, and if \code{FALSE}, the random number seed is never set or modified.  The case of providing a single numeric value for this argument is not supported, except in the case when \code{nchains = 1}.  If the same starting seed is desired for each chain, use \code{setSeed = rep(seed, nchains)}.  Default value is \code{FALSE}.
 #'
 #' @param progressBar Logical argument.  If \code{TRUE}, an MCMC progress bar is displayed during execution of each MCMC chain.  Default value is defined by the nimble package option MCMCprogressBar.
 #'

--- a/packages/nimble/R/MCMC_run.R
+++ b/packages/nimble/R/MCMC_run.R
@@ -18,7 +18,7 @@
 #'
 #' @param inits Optional argument to specify initial values for each chain.  See details.
 #'
-#' @param setSeed Logical or numeric argument.  If a single numeric value is provided, R's random number seed will be set to this value at the onset of each MCMC chain.  If a numeric vector of length \code{nchains} is provided, then each element of this vector is provided as R's random number seed at the onset of the corresponding MCMC chain.  Otherwise, in the case of a logical value, if \code{TRUE}, then R's random number seed for the ith chain is set to be \code{i}, at the onset of each MCMC chain.  Note that specifying the argument \code{setSeed = 0} does not prevent setting the RNG seed, but rather sets the random number generation seed to \code{0} at the beginning of each MCMC chain.  Default value is \code{FALSE}.
+#' @param setSeed Logical or numeric argument.  If a numeric vector of length \code{nchains} is provided, then each element of this vector is provided as R's random number seed at the onset of the corresponding MCMC chain.  Otherwise, in the case of a logical value, if \code{TRUE}, then R's random number seed for the ith chain is set to be \code{i}, at the onset of each MCMC chain, and if \code{FALSE}, the random number seed is never set or modified.  The case of providing a single numeric value for this argument is not supported, except in the case when \code{nchains = 1}.  Default value is \code{FALSE}.
 #'
 #' @param progressBar Logical argument.  If \code{TRUE}, an MCMC progress bar is displayed during execution of each MCMC chain.  Default value is defined by the nimble package option MCMCprogressBar.
 #'
@@ -126,11 +126,9 @@ runMCMC <- function(mcmc,
     ##samplerExecutionOrderToUse <- if(!missing(samplerExecutionOrder)) samplerExecutionOrder else mcmc$samplerExecutionOrderFromConfPlusTwoZeros[mcmc$samplerExecutionOrderFromConfPlusTwoZeros>0]
     for(i in 1:nchains) {
         messageIfVerbose('running chain ', i, '...')
-        ##if(setSeed) set.seed(i)
         if(is.numeric(setSeed)) {
-            if(length(setSeed) == 1) {
-                set.seed(setSeed)
-            } else { if(length(setSeed) == nchains) set.seed(setSeed[i]) else stop('setSeed argument has different length from nchains.') }
+            if(length(setSeed) != nchains) stop('setSeed argument has different length from nchains.')
+            set.seed(setSeed[i])
         } else if(setSeed) set.seed(i)
         if(!missing(inits)) {
             if(is.function(inits)) {


### PR DESCRIPTION
The title says it all.

Fixes #1494