### PR TITLE
Don't do unnecessary code post-processing if there are no macros

### DIFF
--- a/packages/nimble/R/BUGS_macros.R
+++ b/packages/nimble/R/BUGS_macros.R
@@ -379,6 +379,11 @@ processMacrosInternal <- function(code,
       curPars <- modelInfo$parameters
       expandedInfo$modelInfo$parameters <- c(curPars, newPars)
 
+      # Just in case nMacros is missing, set to 0
+      if(is.null(expandedInfo$modelInfo$nMacros)) expandedInfo$modelInfo$nMacros <- 0
+      # Increment number of macros run
+      expandedInfo$modelInfo$nMacros <- expandedInfo$modelInfo$nMacros + 1
+
       ## Return object is a list so we can possibly extract other
       ## content in the future.  We recurse on the returned code
       ## to expand macros that it might contain.
@@ -407,18 +412,27 @@ codeProcessModelMacros <- function(code, modelInfo, env){
   modelInfo$indexCreator <- macroIndexCreator
   # No macro generated parameters before any macros run, so parameters = empty list
   modelInfo$parameters <- list()
+  # Initialize number of macros that ran to 0
+  modelInfo$nMacros <- 0
   # Recursively step through the code expanding macros
   # and adding information to modelInfo such as updated constants and
   # parameter names
   macroOutput <- processMacrosInternal(code=code, modelInfo=modelInfo, env=env)
-  # Clean up extra brackets in output code
-  macroOutput$code <- removeExtraBrackets(macroOutput$code)
-  # Convert factors in constants to numeric
-  macroOutput$modelInfo$constants <- convertFactorConstantsToNumeric(macroOutput$modelInfo$constants)  
-  # Remove intermediate parameters from list of generated parameters
-  # and check for duplicates
-  macroOutput$modelInfo$parameters <- checkMacroPars(macroOutput$modelInfo$parameters,
-                                                     code, macroOutput$code)
+
+  # Do post-processing on code if at least one macro was run
+  if(macroOutput$modelInfo$nMacros > 0){
+    # Clean up extra brackets in output code
+    macroOutput$code <- removeExtraBrackets(macroOutput$code)
+    # Convert factors in constants to numeric
+    macroOutput$modelInfo$constants <- convertFactorConstantsToNumeric(macroOutput$modelInfo$constants)  
+    # Remove intermediate parameters from list of generated parameters
+    # and check for duplicates
+    macroOutput$modelInfo$parameters <- checkMacroPars(macroOutput$modelInfo$parameters,
+                                                       code, macroOutput$code)
+  }
+  # Remove nMacros from modelInfo just in case (not sure this is necessary)
+  macroOutput$modelInfo$nMacros <- NULL
+
   list(code = macroOutput$code, modelInfo = macroOutput$modelInfo)
 }
 

--- a/packages/nimble/tests/testthat/test-macros.R
+++ b/packages/nimble/tests/testthat/test-macros.R
@@ -26,10 +26,15 @@ test_that('Macro expansion 1',
     )
  #   temporarilyAssignInGlobalEnv(testMacro)
     
-    expect_identical(
-        nimble:::processMacrosInternal(
+    process_macro <- nimble:::processMacrosInternal(
             quote(x[1] ~ testMacro(y[1])),
-        modelInfo = list())$code,
+        modelInfo = list(nMacros=0))
+
+    # Check that nMacros incremented
+    expect_equal(process_macro$modelInfo$nMacros, 1)
+
+    expect_identical(
+        process_macro$code,
         quote(x[1] ~ dnorm(y[1], 1))
     )
     
@@ -636,9 +641,20 @@ test_that("macros can add constants", {
 test_that("codeProcessModelMacros converts factors to numeric", {
   inp_constants <- list(y = rnorm(3), x = factor(c("a","b","c")))
 
+  testMacro <- list(process = function(code, modelInfo, .env){
+      code[[3]] <- quote(dnorm(0, sd = 1))
+      modelInfo$constants$b <- 2
+      list(code = code, modelInfo=modelInfo)
+    }
+  )
+  class(testMacro) <- "model_macro"
+
+  # needed since this test creates macro manually
+  temporarilyAssignInGlobalEnv(testMacro)
+
   code <- nimbleCode({
     for (i in 1:3){
-      y[i] ~ dnorm(x[i], sd = 1)
+      y[i] ~ testMacro()
     }
   })
   
@@ -649,6 +665,20 @@ test_that("codeProcessModelMacros converts factors to numeric", {
     as.numeric(inp_constants$x)
   )
 
+  # In this case there is no macro in the code, so the constants should not
+  # be automatically converted from factor to numeric
+  code <- nimbleCode({
+    for (i in 1:3){
+      y[i] ~ dnorm(x[i], sd = 1)
+    }
+  })
+  
+  mod <- nimble:::codeProcessModelMacros(code, modelInfo=list(constants=inp_constants), env=parent.frame())
+
+  expect_equal(
+    mod$modelInfo$constants$x,
+    inp_constants$x
+  )
 })
 
 test_that("convertFactorConstantsToNumeric converts factors to numeric", {
@@ -977,6 +1007,74 @@ test_that("removeExtraBrackets cleans up output from processMacrosInternal",{
     }
     })
   )
+
+  # Check that removeExtraBrackets is applied correctly by codeProcessModelMacros
+  testMacro <- list(process = function(code, modelInfo, .env){
+      code[[3]] <- quote(dnorm(0, sd = 1))
+      modelInfo$constants$b <- 2
+      list(code = code, modelInfo=modelInfo)
+    }
+  )
+  class(testMacro) <- "model_macro"
+
+  # needed since this test creates macro manually
+  temporarilyAssignInGlobalEnv(testMacro)
+
+  code <- nimbleCode({
+  {
+    alpha <- 1
+    for (i in 1:n){
+      {
+        for (j in 1:k){
+          z <- testMacro()
+          {
+          y <- 1
+          }
+        }
+      }
+    }
+  }
+  })
+
+  minfo <- list()
+  
+  expect_equal(
+    nimble:::codeProcessModelMacros(code, minfo, env=environment())$code,
+    quote({
+      alpha <- 1
+      for (i in 1:n){
+        for (j in 1:k){
+          z <- dnorm(0, sd = 1)
+          y <- 1
+        }
+      }
+    })
+  )
+
+  # Now make sure removeExtraBrackets is NOT applied when there is no
+  # macro in the code
+  code <- nimbleCode({
+  {
+    alpha <- 1
+    for (i in 1:n){
+      {
+        for (j in 1:k){
+          z <- 1
+          {
+          y <- 1
+          }
+        }
+      }
+    }
+  }
+  })
+
+  minfo <- list()
+  
+  expect_equal(
+    nimble:::codeProcessModelMacros(code, minfo, env=environment())$code,
+    code)
+
 })
 
 test_that("comments are added to macro output if enableMacroComments = TRUE",{


### PR DESCRIPTION
Currently, certain macro-related code and constants processing steps are done regardless if there are any macros in the code. This PR runs these steps only if there are macros in the code and skips them otherwise. This should mean that if there are future bugs in this post-processing code, they would only affect code with macros and not nimble models more generally.

This is implemented by adding an element to the `modelInfo` list representing the number of macros that have run (initialized at 0). Then, each time a macro is detected (in `processMacrosInternal`), this number is incremented by 1. After all macros (if any) are expanded, `codeProcessModelMacros` checks if this total number is >0, and only runs the post-processing steps if it is. The count of macros is then deleted from `modelInfo` just to be safe.

@paciorek @perrydv 

Fixes #1506 