### PR TITLE
relaceSamplers does lookup in parent.frame

### DIFF
--- a/packages/nimble/R/MCMC_configuration.R
+++ b/packages/nimble/R/MCMC_configuration.R
@@ -786,7 +786,8 @@ This function also has the side effect of resetting the sampler execution orderi
             samplerConfs_save <- samplerConfs
             samplerExecutionOrder_save <- samplerExecutionOrder
             m <- match.call(definition = addSampler)
-            removeSamplers(eval(m$target), eval(m$nodes))   ## both unnamed arguments accepted as ... argument
+            env <- parent.frame()
+            removeSamplers(eval(m$target, env), eval(m$nodes, env))   ## both unnamed arguments accepted as ... argument
             e <- try(addSampler(...), silent = TRUE)   ## pass all arguments along to addSampler
             ## if an error occurred in addSampler, then restore original samplerConfs
             if(inherits(e, 'try-error')) {


### PR DESCRIPTION
Fixes #1538 

`conf$replaceSamplers` method forces lookup of `nodes` and `target` to take place in calling frame.
