### PR TITLE
Make nf name conflict more efficient

### DIFF
--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -185,7 +185,7 @@ scalarOutputTypes <- list(decide = 'logical',
 expressionSymbolTypeReplacements <- c('symbolNimbleListGenerator', 'symbolNimbleList', 'symbolNimbleFunction', 'symbolMemberFunction')
 
 checkNameConflict <- function(nm) {
-    if(!exists(nm, nimbleUserNamespace$.checkedNames)) {
+    if(!exists(nm, nimbleUserNamespace$.checkedNames, inherits = FALSE)) {
       nimbleUserNamespace$.checkedNames[[nm]] <- 1
       ## Handle replacements such as `gamma` -> `gammafn`.  
       if(nm %in% specificCallReplacements) {

--- a/packages/nimble/R/genCpp_sizeProcessing.R
+++ b/packages/nimble/R/genCpp_sizeProcessing.R
@@ -184,6 +184,24 @@ scalarOutputTypes <- list(decide = 'logical',
 ## and it will set the size expressions for A and for itself to 1.
 expressionSymbolTypeReplacements <- c('symbolNimbleListGenerator', 'symbolNimbleList', 'symbolNimbleFunction', 'symbolMemberFunction')
 
+checkNameConflict <- function(nm) {
+    if(!exists(nm, nimbleUserNamespace$.checkedNames)) {
+      nimbleUserNamespace$.checkedNames[[nm]] <- 1
+      ## Handle replacements such as `gamma` -> `gammafn`.  
+      if(nm %in% specificCallReplacements) {
+          nm <- names(specificCallReplacements)[which(nm == specificCallReplacements)]
+      } else if(nm %in% nimKeyWords)
+          nm <- names(nimKeyWords)[which(nm == nimKeyWords)]
+      for(i in seq_along(nm)) { # `lgammafn` will give back two items, not one.
+          objs <- sapply(nm[i], function(x) getAnywhere(x)$objs)
+          if(any(sapply(objs, is.rcf))) 
+              stop("The name of the nimbleFunction `", nm[i], "` conflicts with a function in the NIMBLE language (DSL); please use a different name")
+      }
+    }
+}
+
+
+
 exprClasses_setSizes <- function(code, symTab, typeEnv) { ## input code is exprClass
   ## name:
   if(code$isName) {
@@ -263,17 +281,7 @@ exprClasses_setSizes <- function(code, symTab, typeEnv) { ## input code is exprC
     }
     sizeCall <- sizeCalls[[code$name]]
     if(!is.null(sizeCall)) {
-      nm <- code$name
-      ## Handle replacements such as `gamma` -> `gammafn`.  
-      if(nm %in% specificCallReplacements) {
-          nm <- names(specificCallReplacements)[which(nm == specificCallReplacements)]
-      } else if(nm %in% nimKeyWords)
-          nm <- names(nimKeyWords)[which(nm == nimKeyWords)]
-      for(i in seq_along(nm)) { # `lgammafn` will give back two items, not one.
-          objs <- sapply(nm[i], function(x) getAnywhere(x)$objs)
-          if(any(sapply(objs, is.rcf))) 
-              stop("The name of the nimbleFunction `", nm[i], "` conflicts with a function in the NIMBLE language (DSL); please use a different name")
-      }
+      checkNameConflict(code$name) 
       if(.nimbleOptions$debugSizeProcessing) {
         browser()
         eval(

--- a/packages/nimble/R/nimbleProject.R
+++ b/packages/nimble/R/nimbleProject.R
@@ -1160,7 +1160,8 @@ compileNimble <- function(..., project, dirName = NULL, projectName = '',
     for(i in names(controlDefaults)) {
         if(!i %in% names(control)) control[[i]] <- controlDefaults[[i]]
     }
-    
+
+    nimbleUserNamespace$.checkedNames <- new.env()  # Memoization for checking nf name conflicts in `checkNameConflict()`.
 
     ## Units should be either Rmodel, nimbleFunction, or RCfunction (now coming from nimbleFunction with no setup)
     if(!showCompilerOutput) {


### PR DESCRIPTION
This memoizes the check within each `compileNimble` call to avoid repeated scoping lookups for the same function. 

Fixes #1542 .

I believe this brings the timing of `compileNimble` back to be similar with before 1.3.0, but I'm having a surprisingly-difficult time getting consistent timing numbers.