### PR TITLE
Fix scoping for nimbleMCMC

### DIFF
--- a/UserManual/src/chapter_MCMC.Rmd
+++ b/UserManual/src/chapter_MCMC.Rmd
@@ -1228,9 +1228,9 @@ samplesList <- runMCMC(Cmcmc_CL, niter=1000, nchains=3)
 lapply(samplesList, dim)
 ```
 
-## Comparing different MCMCs with *MCMCsuite* and *compareMCMCs* {#mcmc-suite-compare-mcmcs}
+## Comparing different MCMCs with *compareMCMCs* {#mcmc-suite-compare-mcmcs}
 
-Please see the `compareMCMCs` package for the features previously provided by `MCMCsuite` and `compareMCMCs` in NIMBLE (until version 0.8.0).  The `compareMCMCs` package provides tools to automatically run MCMC in nimble (including multiple sampler configurations), WinBUGS, OpenBUGS, JAGS, Stan, or any other engine for which you provide a simple common interface.  The package makes it easy to manage comparison metrics and generate html pages with comparison figures.
+Please see the `compareMCMCs` package for the features previously provided by the `compareMCMCs` function (and `MCMCsuite` function) in NIMBLE (until version 0.8.0).  The `compareMCMCs` package provides tools to automatically run MCMC in nimble (including multiple sampler configurations), WinBUGS, OpenBUGS, JAGS, Stan, or any other engine for which you provide a simple common interface.  The package makes it easy to manage comparison metrics and generate html pages with comparison figures.
 
 ## Running MCMC chains in parallel
 

--- a/UserManual/src/chapter_MCMC.Rmd
+++ b/UserManual/src/chapter_MCMC.Rmd
@@ -35,7 +35,6 @@ The lengthier and more customizable approach to invoking the MCMC engine on a pa
   1. Run the MCMC and extract the samples (Sections \@ref(sec:runMCMC), \@ref(sec:executing-the-mcmc-algorithm) and \@ref(sec:extracting-samples)).
   1. Optionally, calculate the WAIC (Section \@ref(sec:WAIC)).
 
-Prior to version 0.8.0, NIMBLE provided two additional functions, `MCMCsuite` and `compareMCMCs`, to facilitate comparison of multiple MCMC algorithms, either internal or external to NIMBLE.  Those capabilities have been redesigned and moved into a separate package called `compareMCMCs`.
 
 End-to-end examples of MCMC in NIMBLE can be found in Sections \@ref(sec:creating-mcmc)-\@ref(sec:customizing-mcmc) and Section \@ref(sec:mcmc-example-litters).
 <!---  ### Creating an MCMC algorithm -->

--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -502,7 +502,7 @@ modelDefClass$methods(checkADsupportForDistribution = function(dist) {
   if(!supported)
       if(getNimbleOption('doADerrorTraps'))
           messageIfVerbose("  [Note] It is fine to have a distribution without derivatives as long as no\n",
-                           "         algorithm requests derivatives from it.",
+                           "         algorithm requests derivatives from it.\n",
                            "         For a user-defined distribution, set `buildDerivs = TRUE` (or to a list)\n",
                            "         in its nimbleFunction to turn on derivative support.\n",
                            "         Set `nimbleOptions(doADerrorTraps=FALSE)` to disable this check.")

--- a/packages/nimble/R/MCMC_build.R
+++ b/packages/nimble/R/MCMC_build.R
@@ -31,7 +31,7 @@
 #' \code{initializeModel}: Boolean specifying whether to run the initializeModel routine on the underlying model object, prior to beginning MCMC sampling (default = TRUE).
 #' 
 #' \code{chain}: Integer specifying the MCMC chain number.  The chain number is passed to each MCMC sampler's before_chain and after_chain methods.  The value for this argument is specified automatically from invocation via runMCMC, and genernally need not be supplied when calling mcmc$run (default = 1).
-
+#'
 #' \code{time}: Boolean specifying whether to record runtimes of the individual internal MCMC samplers.  When \code{time = TRUE}, a vector of runtimes (measured in seconds) can be extracted from the MCMC using the method \code{mcmc$getTimes()} (default = FALSE).
 #'
 #' \code{progressBar}: Boolean specifying whether to display a progress bar during MCMC execution (default = TRUE).  The progress bar can be permanently disabled by setting the system option \code{nimbleOptions(MCMCprogressBar = FALSE)}.

--- a/packages/nimble/R/MCMC_run.R
+++ b/packages/nimble/R/MCMC_run.R
@@ -313,7 +313,8 @@ nimbleMCMC <- function(code,
                        samples = TRUE,
                        samplesAsCodaMCMC = FALSE,
                        summary = FALSE,
-                       WAIC = FALSE) {
+                       WAIC = FALSE,
+                       userEnv = parent.frame()) {
     #### process 'code' argument, to accept a filename, or a function
     ##if(is.character(code) || is.function(code)) {
     ##    if(is.function(code)) modelText <- mergeMultiLineStatements(deparse(body(code)))
@@ -327,7 +328,7 @@ nimbleMCMC <- function(code,
     if(missing(code) && missing(model)) stop('must provide either code or model argument')
     if(!samples && !summary && !WAIC) stop('no output specified, use samples = TRUE, summary = TRUE, or WAIC = TRUE')
     if(!missing(code) && inherits(code, 'modelBaseClass')) model <- code   ## let's handle it, if model object is provided as un-named first argument to nimbleMCMC
-    Rmodel <- mcmc_createModelObject(model, inits, nchains, setSeed, code, constants, data, dimensions, check)
+    Rmodel <- mcmc_createModelObject(model, inits, nchains, setSeed, code, constants, data, dimensions, check, userEnv = userEnv)
     conf <- configureMCMC(Rmodel, monitors = monitors, thin = thin, enableWAIC = WAIC, print = FALSE)
     Rmcmc <- buildMCMC(conf)
     compiledList <- compileNimble(Rmodel, Rmcmc)    ## only one compileNimble() call

--- a/packages/nimble/R/MCMC_utils.R
+++ b/packages/nimble/R/MCMC_utils.R
@@ -422,7 +422,7 @@ mcmc_checkWAICmonitors <- function(model, monitors, dataNodes) {
 }
 
 
-mcmc_createModelObject <- function(model, inits, nchains, setSeed, code, constants, data, dimensions, check, buildDerivs = FALSE) {
+mcmc_createModelObject <- function(model, inits, nchains, setSeed, code, constants, data, dimensions, check, buildDerivs = FALSE, userEnv) {
     ## create the Rmodel object using arguments provided to nimbleMCMC
     if(missing(model)) {  ## model object not provided
         if(!missing(inits)) {
@@ -434,8 +434,8 @@ mcmc_createModelObject <- function(model, inits, nchains, setSeed, code, constan
             } else if(is.list(inits) && (length(inits) > 0) && is.list(inits[[1]])) {
                 theseInits <- inits[[1]]
             } else theseInits <- inits
-            Rmodel    <- nimbleModel(code, constants, data, theseInits, dimensions = dimensions, check = check, buildDerivs = buildDerivs)    ## inits provided
-        } else Rmodel <- nimbleModel(code, constants, data,             dimensions = dimensions, check = check, buildDerivs = buildDerivs)    ## inits not provided
+            Rmodel    <- nimbleModel(code, constants, data, theseInits, dimensions = dimensions, check = check, buildDerivs = buildDerivs, userEnv = userEnv)    ## inits provided
+        } else Rmodel <- nimbleModel(code, constants, data,             dimensions = dimensions, check = check, buildDerivs = buildDerivs, userEnv = userEnv)    ## inits not provided
     } else {              ## model object provided
         if(!is.model(model)) stop('model argument must be a NIMBLE model object')
         Rmodel <- if(is.Rmodel(model)) model else model$Rmodel


### PR DESCRIPTION
This fixes issue #1545 by adding a `userEnv` arg to `nimbleMCMC`, functioning in the same fashion as that arg for `nimbleModel`.