### PR TITLE
Pg simple update

### DIFF
--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -3174,6 +3174,7 @@ sampler_polyagamma <- nimbleFunction(
             if(initializeX & !infiniteOkay) {
               for(j in 1:nCoef){
                 if( any(abs(X[, j]) == Inf) ){
+                  ## @CJP: Maybe we should change this to a stop? I suspect it can happen if we have uncaught zero inflation on a stochastic column...
                   cat("Warning: Infinite values constructed in the design matrix for covariate '", j, "'. Please consider scaling the covariate, providing the design matrix, or overriding this error with infiniteOkay = TRUE.\n")
                 }
               }

--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -2825,10 +2825,6 @@ sampler_polyagamma <- nimbleFunction(
         
         ## This allows user to override error trapping for unusual model structures.
         check <- extractControlElement(control, 'check', TRUE)   
-        ## If not checking, then inflation nodes need to be provided by user or set as empty
-        inflationNodes <- model$expandNodeNames(control$inflationNodes)
-        ## Check if design matrix columns are infinite and warn to scale design matrix.
-        infiniteOkay <-   extractControlElement(control, 'infiniteOkay', FALSE)
 
         ## node list generation
         target <- model$expandNodeNames(target)
@@ -2873,7 +2869,10 @@ sampler_polyagamma <- nimbleFunction(
         sizeNodes <- setdiff(probAndSizeNodes, probNodes)
 
         zeroInflated <- FALSE
-        
+        ## Zero-Inflation node detection:
+        inflationNodes <- model$getParents(probNodes, omit = c(target, nonTarget), stochOnly = TRUE)
+        if(length(inflationNodes)) inflationNodes <- setdiff(inflationNodes, nonTarget)
+
         ## Conjugacy checking, part 2.
         ## Make sure any stochastic dependencies between target and y are Bernoulli (i.e. only zero-inflation allowed)
         ## and that zero-inflation variable multiplies the baseline probability.
@@ -2881,12 +2880,10 @@ sampler_polyagamma <- nimbleFunction(
         ## First we need some processing to make sure that we can simply check inflation based only on `probNodes[1]`,
         ## to avoid costly checking.
         if(check) {
-            inflationNodes <- model$getParents(probNodes, omit = c(target, nonTarget), stochOnly = TRUE)
             if(length(inflationNodes)) {
                 ## Check that inflation probabilities are directly specified as parents of `probNodes`
                 ## to avoid having to check multiple declarations. Seemingly anything otherwise would be
                 ## an unusual zero inflation construction.
-                inflationNodes <- setdiff(inflationNodes, nonTarget)
                 test <- model$getParents(probNodes, omit = c(target, nonTarget), stochOnly = TRUE, immediateOnly = TRUE)
                 test <- setdiff(test, nonTarget)
                 if(!identical(test, inflationNodes))  # So we need to only consider a single declaration.
@@ -3171,11 +3168,10 @@ sampler_polyagamma <- nimbleFunction(
                 values(model, inflationNodesDeps) <<- inflationDepsValuesSaved
             }
             ## Check to see if covariates need to be scaled:
-            if(initializeX & !infiniteOkay) {
+            if(initializeX) {
               for(j in 1:nCoef){
                 if( any(abs(X[, j]) == Inf) ){
-                  ## @CJP: Maybe we should change this to a stop? I suspect it can happen if we have uncaught zero inflation on a stochastic column...
-                  cat("Warning: Infinite values constructed in the design matrix for covariate '", j, "'. Please consider scaling the covariate, providing the design matrix, or overriding this error with infiniteOkay = TRUE.\n")
+                  stop("Infinite values constructed in the design matrix of the polyagamma sampler. Please consider scaling the covariate or providing the design matrix.\n")
                 }
               }
             }

--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -2825,6 +2825,10 @@ sampler_polyagamma <- nimbleFunction(
         
         ## This allows user to override error trapping for unusual model structures.
         check <- extractControlElement(control, 'check', TRUE)   
+        ## If not checking, then inflation nodes need to be provided by user or set as empty
+        inflationNodes <- model$expandNodeNames(control$inflationNodes)
+        ## Check if design matrix columns are infinite and warn to scale design matrix.
+        infiniteOkay <-   extractControlElement(control, 'infiniteOkay', FALSE)
 
         ## node list generation
         target <- model$expandNodeNames(target)
@@ -3012,6 +3016,8 @@ sampler_polyagamma <- nimbleFunction(
             }
             if(all(fixedColumns)) 
                 fixed <- TRUE
+
+            initializeX <- TRUE ## Initialize Design Matrix on first run
         } else {
             X <- control$designMatrix
             if(ncol(X) != nCoef)
@@ -3020,10 +3026,10 @@ sampler_polyagamma <- nimbleFunction(
                 stop("polyagamma sampler: number of rows of design matrix, ", nrow(X), ", doesn't match number of Bernoulli observations, ", N)
             fixed <- TRUE
             fixedColumns <- rep(TRUE, nCoef)
+            initializeX <- TRUE ## Don't Initialize Design Matrix on first run
         }
 
         initializeSize <- TRUE
-        initializeX <- TRUE
         pgSampler <- samplePolyaGamma()
 
         Q <- matrix(0, nrow = nCoef, ncol = nCoef)
@@ -3163,6 +3169,14 @@ sampler_polyagamma <- nimbleFunction(
             if(initializeX & zeroInflated) {
                 values(model, inflationNodes) <<- inflationValuesSaved
                 values(model, inflationNodesDeps) <<- inflationDepsValuesSaved
+            }
+            ## Check to see if covariates need to be scaled:
+            if(initializeX & !infiniteOkay) {
+              for(j in 1:nCoef){
+                if( any(abs(X[, j]) == Inf) ){
+                  cat("Warning: Infinite values constructed in the design matrix for covariate '", j, "'. Please consider scaling the covariate, providing the design matrix, or overriding this error with infiniteOkay = TRUE.\n")
+                }
+              }
             }
             nimCopy(from = mvSaved, to = model, row = 1, nodes = target, logProb = FALSE)
             nimCopy(from = mvSaved, to = model, row = 1, nodes = copyNodesDeterm, logProb = FALSE)

--- a/packages/nimble/R/MCMC_samplers.R
+++ b/packages/nimble/R/MCMC_samplers.R
@@ -3026,7 +3026,7 @@ sampler_polyagamma <- nimbleFunction(
                 stop("polyagamma sampler: number of rows of design matrix, ", nrow(X), ", doesn't match number of Bernoulli observations, ", N)
             fixed <- TRUE
             fixedColumns <- rep(TRUE, nCoef)
-            initializeX <- TRUE ## Don't Initialize Design Matrix on first run
+            initializeX <- FALSE ## Don't Initialize Design Matrix on first run
         }
 
         initializeSize <- TRUE


### PR DESCRIPTION
Three changes:
1) Initiate `inflationNodes` to avoid a small error when `check = FALSE`.
2) Ensure `initializeX=FALSE` if a design matrix is passed
3) Add a warning if infinite values are found in the design matrix. Suggests to scale the design matrix in advance.

@paciorek Should we put a full stop if infinite values are detected in the design matrix instead of a warning?
Does it make sense to allow the user to override this warning? Currently `infiniteOkay` is a list input. Better name? I need to add it documentation still.