### PR TITLE
Add `glueNimbleCode()`

### DIFF
--- a/packages/nimble/R/BUGS_readBUGS.R
+++ b/packages/nimble/R/BUGS_readBUGS.R
@@ -149,6 +149,40 @@ nimbleCode <- function(code) {
 
 BUGScode <- nimbleCode
 
+#' Combine outputs of two or more calls to 'nimbleCode()'
+#'
+#' Combines the outputs of two or more \code{\link{nimbleCode}} calls into one, which can then be used by \code{\link{nimbleModel}}.
+#'
+#' @param ... Two or more outputs from \code{\link{nimbleCode}.
+#' @author Adam B. Smith
+#' @returns Concatenated `nimbleCode()` objects.
+#' @examples
+#' a <- nimbleCode({ x1 <- 23; x2 <- 13 })
+#' b <- nimbleCode({ x1 + x2 })
+#' c <- glueNimbleCode(a, b)
+#' c
+#' eval(c) # executes a and b together
+#' @export
+glueNimbleCode <- function(...) {
+    
+    x <- list(...)
+    
+    # extract expressions from each nimbleCode object
+    allExpress <- unlist(
+        lapply(x, function(expr) {
+            if (is.call(expr) && identical(expr[[1]], as.name('{'))) {
+                as.list(expr[-1])
+            } else {
+                list(expr)
+            }
+        }),
+        recursive = FALSE
+    )
+    
+    as.call(c(list(as.name('{')), allExpress))
+
+}
+
 processVarBlock <- function(lines) {
   # processes a var block from a BUGS file, determining variable names, dimensions, and sizes
   # at this point, sizes may have unevaluated variables in them


### PR DESCRIPTION
`glueNimbleCode()` combines output from different calls to `nimbleCode()` so it can be processed by `nimbleModel()`.

Useful for cases where we have the same basic `nimble` code, but want to tack on different blocks depending on the workflow. Obviates having a different script for every small difference between models. A very simple example:
```
code_start <- nimbleCode({
   sigma ~ dunif(0, 100)
   for (i in 1:n) {
      y[i] ~ dnorm(mu, sd = sigma)
   }
})

broad_prior <- nimbleCode({ mu ~ dnorm(0, sd = 100) })
reg_prior_prior <- nimbleCode({ mu ~ ddexp(rate = 1) })

if (dataset == 'a') {
   model_code <- glueNimbleCode(code_start, broad_prior)
} else if (dataset == 'b') {
   model_code <- glueNimbleCode(code_start, reg_prior)
}

model <- nimbleModel(model_code, ...) # etc
```