### PR TITLE
Candidate fix to #1564 (but in getConditionallyIndependentSets)

### DIFF
--- a/packages/nimble/inst/CppCode/nimbleGraph.cpp
+++ b/packages/nimble/inst/CppCode/nimbleGraph.cpp
@@ -856,7 +856,8 @@ void nimbleGraph::exploreUp(vector<int> &deps,
         exploreDown(deps, thisParentCgraphID,
                     isGivenVec, isLatentVec, unknownsAsGiven, recursionDepth + 1);
     }
-    thisParentNode->touched = true; // Touch it now in case it was deterministic and hence not touched above
+    // Experimental: Commenting out this line to try fixing Issue #1564
+    // thisParentNode->touched = true; // Touch it now in case it was deterministic and hence not touched above
   }
   // myindent(recursionDepth);
   // std::cout<<"Exiting exploreUp from "<<thisGraphNode->name<<std::endl;
@@ -904,7 +905,9 @@ void nimbleGraph::exploreDown(vector<int> &deps,
     if(!isGiven) {
       exploreDown(deps, thisChildCgraphID,
                   isGivenVec, isLatentVec, unknownsAsGiven, recursionDepth + 1);
-      thisChildNode->touched = true;
+      // Experimental: Commenting out this line to try fixing Issue #1564
+      // Note that this touch setting would only impact !isGiven && !isStoch (because above !isGiven && isStoch is handled)
+      // thisChildNode->touched = true;
     }
   }
   // myindent(recursionDepth);

--- a/packages/nimble/tests/testthat/test-setupMargNodes.R
+++ b/packages/nimble/tests/testthat/test-setupMargNodes.R
@@ -439,3 +439,28 @@ test_that("setupMargNodes finds correct randomEffectsNodes based on calcNodes in
   expect_identical(SMN$randomEffectsNodes, c("r[1]","r[2]"))
   expect_identical(SMN$paramNodes, c("p[1]","p[2]"))
 })
+
+test_that("regression tests that `getConditionallyIndependentSets` works with traversal of determ nodes", {
+    code <- nimbleCode({
+        for(i in 1:5) {
+            y[i] ~ dnorm(b1*x[i] + mu[i], sd = exp(b2*x[i]+ mu2[i]))
+            mu[i] ~ dnorm(0, tau)
+            mu2[i] ~ dnorm(0, tau2)
+        }
+        b1~dflat()
+        b2 ~dflat()
+        tau ~ dhalfflat()
+        tau2~dhalfflat()
+    })
+    m <- nimbleModel(code, data = list(y = rnorm(5)))
+    given <- c('tau','tau2',paste0('y[', 1:5, ']'))
+    
+    ## Correct
+    latents <- c('b1','b2',paste0('mu[', 1:5, ']'),paste0('mu2[', 1:5, ']'))
+    expect_length(m$getConditionallyIndependentSets(nodes = latents, givenNodes = given, unknownAsGiven = TRUE), 1)
+    
+    ## In issue 1564, incorrect with different order for the latents: `mu2[1]` split out into its own set
+    latents <- c(paste0('mu[', 1:5, ']'),paste0('mu2[', 1:5, ']'),'b1','b2')
+    expect_length(m$getConditionallyIndependentSets(nodes = latents, givenNodes = given, unknownAsGiven = TRUE), 1)
+})
+


### PR DESCRIPTION
I am throwing this up as a candidate fix. It fixes Issue #1564 and it passes test-setupMargNodes.R. 

We should probably tests in (at least) nimbleQuad (in development at this time) and nimbleSMC,

If this seems to work, I will document more about the change and add a regression test.

The basic idea is: don't mark deteministic nodes as touched during getConditionallyIndependent sets traversals of the graph. The reason is that as we are iterating over a set of parent (or presumably in some cases child) nodes, the recursions could pass through a deterministic node that then needs to be passed through by a later parent (or child) node of the original iterations. But if it has been "touched" (tagged as done), then it blocks activity. But in the case of a deterministic node, this is not really correct. So it takes a particular setup of nodes to trigger the issue. I think it is actually correct to never  tag deterministic nodes, since the algorithm is fundamentally about stochastic nodes.