### PR TITLE
Avoid memcpy of size 0

### DIFF
--- a/packages/nimble/inst/include/nimble/nimbleEigenNimArr.h
+++ b/packages/nimble/inst/include/nimble/nimbleEigenNimArr.h
@@ -215,6 +215,7 @@ template<typename NimArrOutput, typename NimArrInput>
 template<typename NimArrOutput, typename NimArrInput>
   void copyNimArrToNimArrInternal(NimArrOutput &output, NimArrInput &input, int totSize, bool fillZeros, bool recycle) {
   int sizeToCopy;
+  if((totSize == 0) || input.size() == 0) return;
   if(input.size() < totSize) {
     //     _nimble_global_output << "Warning from C++: not enough initialization values.\n"; nimble_print_to_R( _nimble_global_output);
       sizeToCopy = input.size();


### PR DESCRIPTION
Fixes #1524 I *think*.

Reproducing 1524 is a hassle because it happens only on Windows and only under SAN checking.

The problem is a memcpy where C++ run-time SAN checking says both pointers (input and output) are passed as null. This was in a user's code, specifically in their package vignette (is that why it was run with SAN checking by CRAN?).

From studying the situation, I think the "problem" (i.e. not a problem) could occur from a memcpy of size 0 (which is harmless anyway). I can't see a way that our generated code would pass uninitialized NimArr objects in a real (not size 0) situation. If that was happening we'd be seeing crashes. But in a corner case it could pass size 0 objects, and I guess they could be uninitialized but it wouldn't matter, and memcpy would not do anything, but the C++ type expectation is still that the input pointers must not be void (according to what I just read about this). So my change here is to quickly exit if the copying size involved is 0. I'd prefer not to try to check if this actually removes the SAN checking error (because it is harmless and not evident in our own tests or CRAN check results) and just make this change (because it is harmless) and see if it ever comes up again.

