### PR TITLE
Allow nimbleCode to combine multiple code chunks

### DIFF
--- a/packages/nimble/R/BUGS_readBUGS.R
+++ b/packages/nimble/R/BUGS_readBUGS.R
@@ -157,41 +157,46 @@ nimbleModel <- function(code,
 #'     mu ~ dnorm(0, sd = prior_sd)
 #' })
 #'
+#' code_new <- nimbleCode({
+#'     prior_sd ~ dhalfflat()
+#' })
+#'
 #' # Combine multiple previously saved code objects
-#' code2 <- nimbleCode(code, code)
+#' code2 <- nimbleCode(code, code_new)
 #'
 #' # Combine code and previously saved code objects
 #' code3 <- nimbleCode({
 #'    y ~ dnorm(mu, sd = 1)
-#' }, code, code2)
+#' }, code, code_new)
+#' 
 nimbleCode <- function(...){
   # Doing this substitution first is necessary to keep R from evaluating directly 
-  # provided code chunks, which will usually result in an error
+  # provided code chunks, which will usually result in an error.
   code <- substitute(list(...))
   if(length(code) == 1){
     stop("Must provide at least one argument")
   }
-  code <- code[2:length(code)] # drop list prefix
+  code <- code[2:length(code)] # Drop list prefix.
 
-  # Iterate through each code element and extract the code from it
+  # Iterate through each code element and extract the code from it.
   out <- lapply(1:length(code), function(i){
     # If element i is a call (a directly provided code chunk)
     if(is.call(code[[i]])){
       # Check it is in brackets
       if(code[[i]][[1]] == "{"){
-        # If it is, return the code unchanged
+        # If it is, return the code unchanged.
         return(code[[i]])
       } else {
-        # Error if not in brackets
+        # Error if not in brackets.
         stop("Call ", safeDeparse(code[[i]])," must be wrapped in brackets { }",
              call.=FALSE)
       }
     } else {
-      # If not a call, we assume element i must be an object containing code
+      # If not a call, we assume element i must be an object containing code.
       # We need to extract element i from the ...
-      # Can do this by evaluating ..i
+      # Can do this by evaluating `..i`.
       out <- eval(str2lang(paste0("..", i)))
-      # Check that the evaluated result is code and error if it isn't
+      # Check that the evaluated result is code and error if it isn't.
       if(is.call(out)){
         if(out[[1]] != "{"){
           stop("Call ", safeDeparse(code[[i]])," must be wrapped in brackets { }",
@@ -205,9 +210,9 @@ nimbleCode <- function(...){
     }
   })
 
-  # Combine all the code chunks if more than one
+  # Combine all the code chunks if more than one.
   # This could be done regardless of number of chunks, but possibly better
-  # not to run this code unless absolutely necessary
+  # not to run this code unless absolutely necessary.
   if(length(code) > 1){
     out <- embedListInRbracket(out)
     out <- removeExtraBrackets(out)

--- a/packages/nimble/R/BUGS_readBUGS.R
+++ b/packages/nimble/R/BUGS_readBUGS.R
@@ -130,20 +130,81 @@ nimbleModel <- function(code,
 
 #' Turn BUGS model code into an object for use in \code{nimbleModel} or \code{readBUGSmodel}
 #'
-#' Simply keeps model code as an R call object, the form needed by \code{\link{nimbleModel}} and optionally usable by \code{\link{readBUGSmodel}}.
+#' Takes one or more R expressions or code objects, combines them if necessary, and returns the 
+#' resulting code as an R call object in the form needed by \code{\link{nimbleModel}}
+#' and optionally usable by \code{\link{readBUGSmodel}}.
 #'
-#' @param code expression providing the code for the model
-#' @author Daniel Turek
+#' @param ... One or more R code expressions or objects containing R code, providing the code for the model. See details.
+#' @author Daniel Turek and Ken Kellner
 #' @export
-#' @details It is equivalent to use the R function \code{\link{quote}}.  \code{nimbleCode} is simply provided as a more readable alternative for NIMBLE users not familiar with \code{quote}.
+#' @details
+#' You may provide code to \code{nimbleCode} in two ways. The first way
+#' is to provide the code as an argument directly, wrapped in curly brackets (\{\}).
+#' The second is to create an object containing code with either \code{nimbleCode} or \code{quote},
+#' and pass that object to \code{nimbleCode}. You may mix and match these two approaches.
+#' Note that code provided directly but not wrapped in \{\} will be rejected.
+#' When multiple pieces of code are provided as arguments, they will be combined into
+#' a single code object by \code{nimbleCode} and unnecessary curly brackets will be
+#' automatically removed.
+#'
+#' When providing a single block of code directly, the result from \code{nimbleCode}
+#' is equivalent to using the R function \code{\link{quote}}.  \code{nimbleCode} is 
+#' simply provided as a more readable alternative for NIMBLE users not familiar with \code{quote}.
 #' @examples
+#' # Provide a single block of code directly
 #' code <- nimbleCode({
 #'     x ~ dnorm(mu, sd = 1)
 #'     mu ~ dnorm(0, sd = prior_sd)
 #' })
-nimbleCode <- function(code) {
-  code <- substitute(code)
-  return(code)
+#'
+#' # Combine multiple previously saved code objects
+#' code2 <- nimbleCode(code, code)
+#'
+#' # Combine code and previously saved code objects
+#' code3 <- nimbleCode({
+#'    y ~ dnorm(mu, sd = 1)
+#' }, code, code2)
+nimbleCode <- function(...){
+  # Doing this substitution first is necessary to keep R from evaluating directly 
+  # provided code chunks, which will usually result in an error
+  code <- substitute(list(...))
+  if(length(code) == 1){
+    stop("Must provide at least one argument")
+  }
+  code <- code[2:length(code)] # drop list prefix
+
+  # Iterate through each code element and extract the code from it
+  out <- lapply(1:length(code), function(i){
+    # If element i is a call (a directly provided code chunk)
+    if(is.call(code[[i]])){
+      # Check it is in brackets
+      if(code[[i]][[1]] == "{"){
+        # If it is, return the code unchanged
+        return(code[[i]])
+      } else {
+        # Error if not in brackets
+        stop("Call ", safeDeparse(code[[i]])," must be wrapped in brackets { }",
+             call.=FALSE)
+      }
+    } else {
+      # If not a call, we assume element i must be an object containing code
+      # We need to extract element i from the ...
+      # Can do this by evaluating ..i
+      out <- eval(str2lang(paste0("..", i)))
+      # Check that the evaluated result is code and error if it isn't
+      if(!is.call(out) | is.name(out) | is.expression(out)){
+        stop("Object ", safeDeparse(code[[i]]), " does not contain valid code",
+             call.=FALSE)
+      }
+      # Return the evaluated result
+      return(out)
+    }
+  })
+
+  # Combine all the code chunks
+  out <- embedListInRbracket(out)
+  # Remove extra curly brackets before returning
+  removeExtraBrackets(out)
 }
 
 

--- a/packages/nimble/R/BUGS_readBUGS.R
+++ b/packages/nimble/R/BUGS_readBUGS.R
@@ -192,19 +192,29 @@ nimbleCode <- function(...){
       # Can do this by evaluating ..i
       out <- eval(str2lang(paste0("..", i)))
       # Check that the evaluated result is code and error if it isn't
-      if(!is.call(out) | is.name(out) | is.expression(out)){
+      if(is.call(out)){
+        if(out[[1]] != "{"){
+          stop("Call ", safeDeparse(code[[i]])," must be wrapped in brackets { }",
+              call.=FALSE)
+        }
+        return(out)
+      } else {
         stop("Object ", safeDeparse(code[[i]]), " does not contain valid code",
              call.=FALSE)
       }
-      # Return the evaluated result
-      return(out)
     }
   })
 
-  # Combine all the code chunks
-  out <- embedListInRbracket(out)
-  # Remove extra curly brackets before returning
-  removeExtraBrackets(out)
+  # Combine all the code chunks if more than one
+  # This could be done regardless of number of chunks, but possibly better
+  # not to run this code unless absolutely necessary
+  if(length(code) > 1){
+    out <- embedListInRbracket(out)
+    out <- removeExtraBrackets(out)
+  } else {
+    out <- out[[1]]
+  }
+  out
 }
 
 

--- a/packages/nimble/man/nimbleCode.Rd
+++ b/packages/nimble/man/nimbleCode.Rd
@@ -4,23 +4,45 @@
 \alias{nimbleCode}
 \title{Turn BUGS model code into an object for use in \code{nimbleModel} or \code{readBUGSmodel}}
 \usage{
-nimbleCode(code)
+nimbleCode(...)
 }
 \arguments{
-\item{code}{expression providing the code for the model}
+\item{...}{One or more R code expressions or objects containing R code, providing the code for the model. See details.}
 }
 \description{
-Simply keeps model code as an R call object, the form needed by \code{\link{nimbleModel}} and optionally usable by \code{\link{readBUGSmodel}}.
+Takes one or more R expressions or code objects, combines them if necessary, and returns the 
+resulting code as an R call object in the form needed by \code{\link{nimbleModel}}
+and optionally usable by \code{\link{readBUGSmodel}}.
 }
 \details{
-It is equivalent to use the R function \code{\link{quote}}.  \code{nimbleCode} is simply provided as a more readable alternative for NIMBLE users not familiar with \code{quote}.
+You may provide code to \code{nimbleCode} in two ways. The first way
+is to provide the code as an argument directly, wrapped in curly brackets (\{\}).
+The second is to create an object containing code with either \code{nimbleCode} or \code{quote},
+and pass that object to \code{nimbleCode}. You may mix and match these two approaches.
+Note that code provided directly but not wrapped in \{\} will be rejected.
+When multiple pieces of code are provided as arguments, they will be combined into
+a single code object by \code{nimbleCode} and unnecessary curly brackets will be
+automatically removed.
+
+When providing a single block of code directly, the result from \code{nimbleCode}
+is equivalent to using the R function \code{\link{quote}}.  \code{nimbleCode} is 
+simply provided as a more readable alternative for NIMBLE users not familiar with \code{quote}.
 }
 \examples{
+# Provide a single block of code directly
 code <- nimbleCode({
     x ~ dnorm(mu, sd = 1)
     mu ~ dnorm(0, sd = prior_sd)
 })
+
+# Combine multiple previously saved code objects
+code2 <- nimbleCode(code, code)
+
+# Combine code and previously saved code objects
+code3 <- nimbleCode({
+   y ~ dnorm(mu, sd = 1)
+}, code, code2)
 }
 \author{
-Daniel Turek
+Daniel Turek and Ken Kellner
 }


### PR DESCRIPTION
This PR modifies `nimbleCode` to take an arbitrary number of arguments instead of a single argument. Each argument can be either bracketed code (how it currently works) or objects containing bracketed code. The code is then combined (#1570). For example, the following would now be possible:

```r
c1 <- nimbleCode({
  x ~ dnorm(0, sd = 1)
})

c2 <- nimbleCode({
  y ~ dunif(0, 1)
})

nimbleCode({
  z ~ dnorm(0, sd = 1)
}, c1, c2)
```

with a result of

```
{
    z ~ dnorm(0, sd = 1)
    x ~ dnorm(0, sd = 1)
    y ~ dunif(0, 1)
}
```

There is error trapping to catch un-bracked code and objects that do not actually contain code.

This requires a bit of complexity in the implementation because we need to avoid converting the arguments `...` to a list at any point, because if `...` contains code, R will try to evaluate that code and error. My solution was to immeadiatly use `substitute` on `...` to avoid this, and then detect what type of input each argument is. If it's an object containing code, we extract the code with `eval`. While not ideal to need `eval` least the current approach avoids messing with environments.

I've tried to do the minimum processing in the case when there's a single argument directly providing code, to minimize the chance of causing errors when using `nimbleCode` in the established way. Adding this functionality still makes me a bit nervous though considering the importance of `nimbleCode` in the ecosystem.