### PR TITLE
added system option doRStudioHangingFix

### DIFF
--- a/packages/nimble/R/BUGS_modelDef.R
+++ b/packages/nimble/R/BUGS_modelDef.R
@@ -2932,7 +2932,7 @@ modelDefClass$methods(buildSymbolTable = function() {
 })
 
 
-modelDefClass$methods(newModel = function(data = list(), inits = list(), where = globalenv(), modelName = character(), check = getNimbleOption('checkModel'), calculate = TRUE, debug = FALSE) {
+modelDefClass$methods(newModel = function(data = list(), inits = list(), where = globalenv(), modelName = character(), check = getNimbleOption('checkModel'), calculate = TRUE, debug = FALSE, rstudioFix = getNimbleOption('doRStudioHangingFix')) {
     if(debug) browser()
     if(inherits(modelClass, 'uninitializedField')) {
         vars <- lapply(varInfo, `[[`, 'maxs')
@@ -3006,7 +3006,7 @@ modelDefClass$methods(newModel = function(data = list(), inits = list(), where =
         if(getNimbleOption('verbose')) message("Checking model calculations")
         model$check()
     }
-    fixRStudioHanging(model)
+    if(rstudioFix)   fixRStudioHanging(model)
     return(model)
 })
 

--- a/packages/nimble/R/options.R
+++ b/packages/nimble/R/options.R
@@ -189,6 +189,7 @@ nimOptimMethod("bobyqa",
         compileOnly = FALSE,
         buildInterfacesForCompiledNestedNimbleFunctions = FALSE,   ## provides interfaces, i.e. named access in R, to all variables in nested compiled nimbleFunctions
         clearNimbleFunctionsAfterCompiling = FALSE,
+        doRStudioHangingFix = FALSE,      ## causes implementation of the str method for all dynamically generated classes, to prevent hanging in RStudio
         checkModel = FALSE,
         checkNimbleFunction = TRUE,
         checkDuplicateNodeDefinitions = TRUE,


### PR DESCRIPTION
Fixes #1604 

This PR adds a new system option `doRStudioHangingFix`, with default value `FALSE`.

When `doRStudioHangingFix = TRUE`, the `str` method is overloaded for all dynamically generated class definitions.  At least back in 2015, this was needed to prevent hanging in RStudio.